### PR TITLE
chore: privacy and terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# Clausea 🌊
+<div align="center">
+  <img src="apps/frontend/public/static/favicons/logo.png" alt="Clausea Logo" width="200"/>
+</div>
+
+# Clausea
 
 **The definitive legal document intelligence platform** - Transform complex legal documents into clear, actionable insights with AI-powered analysis.
 
-[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Contributing](https://img.shields.io/badge/Contributing-Welcome-brightgreen.svg)](CONTRIBUTING.md)
-
-[Try now](clausea.vercel.app)
+<a href="https://clausea.co" style="display: inline-block; padding: 6px 14px; background: #0070f3; color: white; text-decoration: none; border-radius: 4px; font-weight: 500;">Try now</a>
 
 ## 🎯 Mission
 

--- a/apps/frontend/app/(site)/privacy/page.tsx
+++ b/apps/frontend/app/(site)/privacy/page.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { Header } from "@/components/clausea/Header";
+import { Footer } from "@/components/clausea/PricingAndFooter";
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground selection:bg-secondary/30 w-full overflow-hidden">
+      <Header />
+
+      <main className="pt-32 pb-24 px-4 md:px-8">
+        <div className="max-w-4xl mx-auto">
+          <div className="mb-12">
+            <h1 className="text-5xl md:text-7xl font-display font-bold text-primary mb-6">
+              Privacy Policy
+            </h1>
+            <p className="text-muted-foreground text-lg">
+              Last updated: January 2025
+            </p>
+          </div>
+
+          <div className="prose prose-lg max-w-none space-y-8 text-foreground">
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                1. Introduction
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                Clausea AI ("we," "our," or "us") is committed to protecting
+                your privacy. This Privacy Policy explains how we collect, use,
+                disclose, and safeguard your information when you use our
+                service, including our website, API, and related services
+                (collectively, the "Service").
+              </p>
+              <p className="text-muted-foreground leading-relaxed">
+                By using our Service, you agree to the collection and use of
+                information in accordance with this policy. If you do not agree
+                with our policies and practices, please do not use our Service.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                2. Information We Collect
+              </h2>
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                2.1 Information You Provide
+              </h3>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">
+                    Account Information:
+                  </strong>{" "}
+                  When you create an account, we collect your name, email
+                  address, and password.
+                </li>
+                <li>
+                  <strong className="text-foreground">Documents:</strong> We
+                  process legal documents you upload to our Service for
+                  analysis. Documents are processed securely and are not stored
+                  longer than necessary for analysis.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    Payment Information:
+                  </strong>{" "}
+                  For paid subscriptions, we collect billing information through
+                  our secure payment processor. We do not store full credit card
+                  details on our servers.
+                </li>
+                <li>
+                  <strong className="text-foreground">Communications:</strong>{" "}
+                  When you contact us, we collect the information you provide,
+                  including your name, email, and message content.
+                </li>
+              </ul>
+
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                2.2 Automatically Collected Information
+              </h3>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">Usage Data:</strong> We
+                  collect information about how you interact with our Service,
+                  including pages visited, features used, and time spent on the
+                  Service.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    Device Information:
+                  </strong>{" "}
+                  We collect information about your device, including IP
+                  address, browser type, operating system, and device
+                  identifiers.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    Cookies and Tracking:
+                  </strong>{" "}
+                  We use cookies and similar tracking technologies to enhance
+                  your experience and analyze Service usage.
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                3. How We Use Your Information
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                We use the information we collect to:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>Provide, maintain, and improve our Service</li>
+                <li>Process and analyze legal documents you upload</li>
+                <li>Authenticate your account and process payments</li>
+                <li>Send you service-related communications and updates</li>
+                <li>Respond to your inquiries and provide customer support</li>
+                <li>
+                  Monitor and analyze usage patterns to improve our Service
+                </li>
+                <li>
+                  Detect, prevent, and address technical issues and security
+                  threats
+                </li>
+                <li>
+                  Comply with legal obligations and enforce our Terms of Service
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                4. Information Sharing and Disclosure
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                We do not sell your personal information. We may share your
+                information only in the following circumstances:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">
+                    Service Providers:
+                  </strong>{" "}
+                  We may share information with third-party service providers
+                  who perform services on our behalf, such as payment
+                  processing, cloud hosting, and analytics. These providers are
+                  contractually obligated to protect your information.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    Legal Requirements:
+                  </strong>{" "}
+                  We may disclose information if required by law, court order,
+                  or government regulation, or to protect our rights and safety.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    Business Transfers:
+                  </strong>{" "}
+                  In the event of a merger, acquisition, or sale of assets, your
+                  information may be transferred to the acquiring entity.
+                </li>
+                <li>
+                  <strong className="text-foreground">
+                    With Your Consent:
+                  </strong>{" "}
+                  We may share information with your explicit consent or at your
+                  direction.
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                5. Data Security
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                We implement industry-standard security measures to protect your
+                information, including:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>Encryption of data in transit and at rest</li>
+                <li>Secure authentication and access controls</li>
+                <li>Regular security assessments and updates</li>
+                <li>
+                  Limited access to personal information on a need-to-know basis
+                </li>
+                <li>
+                  Automatic deletion of documents after analysis completion
+                </li>
+              </ul>
+              <p className="text-muted-foreground leading-relaxed mt-4">
+                However, no method of transmission over the Internet or
+                electronic storage is 100% secure. While we strive to protect
+                your information, we cannot guarantee absolute security.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                6. Your Rights and Choices
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                Depending on your location, you may have certain rights
+                regarding your personal information:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">Access:</strong> Request
+                  access to your personal information we hold
+                </li>
+                <li>
+                  <strong className="text-foreground">Correction:</strong>{" "}
+                  Request correction of inaccurate or incomplete information
+                </li>
+                <li>
+                  <strong className="text-foreground">Deletion:</strong> Request
+                  deletion of your personal information
+                </li>
+                <li>
+                  <strong className="text-foreground">Portability:</strong>{" "}
+                  Request transfer of your data to another service
+                </li>
+                <li>
+                  <strong className="text-foreground">Opt-Out:</strong> Opt out
+                  of certain data processing activities, such as marketing
+                  communications
+                </li>
+              </ul>
+              <p className="text-muted-foreground leading-relaxed mt-4">
+                To exercise these rights, please contact us at{" "}
+                <a
+                  href="mailto:privacy@clausea.ai"
+                  className="text-primary hover:underline"
+                >
+                  privacy@clausea.ai
+                </a>
+                . We will respond to your request within 30 days.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                7. Data Retention
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                We retain your personal information only for as long as
+                necessary to fulfill the purposes outlined in this Privacy
+                Policy, unless a longer retention period is required by law.
+                Specifically:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>
+                  <strong className="text-foreground">
+                    Account Information:
+                  </strong>{" "}
+                  Retained while your account is active and for a reasonable
+                  period after account closure
+                </li>
+                <li>
+                  <strong className="text-foreground">Documents:</strong>{" "}
+                  Deleted immediately after analysis completion, unless you
+                  explicitly request storage
+                </li>
+                <li>
+                  <strong className="text-foreground">Usage Data:</strong>{" "}
+                  Retained for analytics purposes for up to 2 years
+                </li>
+                <li>
+                  <strong className="text-foreground">Legal Records:</strong>{" "}
+                  May be retained longer if required by law or for legal
+                  proceedings
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                8. Children's Privacy
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                Our Service is not intended for individuals under the age of 18.
+                We do not knowingly collect personal information from children.
+                If you believe we have collected information from a child,
+                please contact us immediately, and we will delete such
+                information.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                9. International Data Transfers
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                Your information may be transferred to and processed in
+                countries other than your country of residence. These countries
+                may have different data protection laws. We ensure appropriate
+                safeguards are in place to protect your information in
+                accordance with this Privacy Policy.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                10. Changes to This Privacy Policy
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                We may update this Privacy Policy from time to time. We will
+                notify you of any material changes by posting the new Privacy
+                Policy on this page and updating the "Last updated" date. We
+                encourage you to review this Privacy Policy periodically.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                11. Contact Us
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                If you have questions or concerns about this Privacy Policy or
+                our data practices, please contact us at:
+              </p>
+              <div className="bg-muted/30 p-6 rounded-2xl border border-border mt-4">
+                <p className="text-foreground font-semibold mb-2">Clausea AI</p>
+                <p className="text-muted-foreground">
+                  Email:{" "}
+                  <a
+                    href="mailto:privacy@clausea.ai"
+                    className="text-primary hover:underline"
+                  >
+                    privacy@clausea.ai
+                  </a>
+                </p>
+                <p className="text-muted-foreground">
+                  General inquiries:{" "}
+                  <a
+                    href="mailto:hello@clausea.ai"
+                    className="text-primary hover:underline"
+                  >
+                    hello@clausea.ai
+                  </a>
+                </p>
+              </div>
+            </section>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/frontend/app/(site)/terms/page.tsx
+++ b/apps/frontend/app/(site)/terms/page.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import { Header } from "@/components/clausea/Header";
+import { Footer } from "@/components/clausea/PricingAndFooter";
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground selection:bg-secondary/30 w-full overflow-hidden">
+      <Header />
+
+      <main className="pt-32 pb-24 px-4 md:px-8">
+        <div className="max-w-4xl mx-auto">
+          <div className="mb-12">
+            <h1 className="text-5xl md:text-7xl font-display font-bold text-primary mb-6">
+              Terms of Service
+            </h1>
+            <p className="text-muted-foreground text-lg">
+              Last updated: January 2025
+            </p>
+          </div>
+
+          <div className="prose prose-lg max-w-none space-y-8 text-foreground">
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                1. Acceptance of Terms
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                By accessing or using Clausea AI ("Service"), you agree to be
+                bound by these Terms of Service ("Terms"). If you disagree with
+                any part of these Terms, you may not access or use the Service.
+              </p>
+              <p className="text-muted-foreground leading-relaxed">
+                These Terms apply to all users of the Service, including
+                individuals, businesses, and organizations. By creating an
+                account or using our Service, you represent that you are at
+                least 18 years old and have the legal capacity to enter into
+                these Terms.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                2. Description of Service
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                Clausea AI provides an AI-powered legal document analysis
+                platform that helps users understand, analyze, and compare legal
+                documents such as privacy policies, terms of service, and
+                contracts. Our Service includes:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>Document upload and processing</li>
+                <li>AI-powered summarization and analysis</li>
+                <li>Semantic search and clause comparison</li>
+                <li>Risk assessment and compliance checking</li>
+                <li>API access for developers (on applicable plans)</li>
+              </ul>
+              <p className="text-muted-foreground leading-relaxed mt-4">
+                We reserve the right to modify, suspend, or discontinue any
+                aspect of the Service at any time, with or without notice.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                3. User Accounts and Registration
+              </h2>
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                3.1 Account Creation
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                To use certain features of the Service, you must create an
+                account. You agree to:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>Provide accurate, current, and complete information</li>
+                <li>Maintain and update your account information</li>
+                <li>Maintain the security of your account credentials</li>
+                <li>
+                  Accept responsibility for all activities under your account
+                </li>
+                <li>Notify us immediately of any unauthorized access</li>
+              </ul>
+
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                3.2 Account Termination
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                You may terminate your account at any time. We reserve the right
+                to suspend or terminate your account if you violate these Terms
+                or engage in fraudulent, abusive, or illegal activity.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                4. Acceptable Use
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                You agree to use the Service only for lawful purposes and in
+                accordance with these Terms. You agree NOT to:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>
+                  Upload documents containing malicious code, viruses, or
+                  harmful software
+                </li>
+                <li>
+                  Use the Service to violate any applicable laws or regulations
+                </li>
+                <li>
+                  Attempt to reverse engineer, decompile, or extract the source
+                  code of our Service
+                </li>
+                <li>
+                  Use automated systems (bots, scrapers) to access the Service
+                  without authorization
+                </li>
+                <li>
+                  Interfere with or disrupt the Service or servers connected to
+                  the Service
+                </li>
+                <li>
+                  Upload documents that infringe on intellectual property rights
+                  or contain confidential information you do not have permission
+                  to process
+                </li>
+                <li>
+                  Use the Service to generate false or misleading legal advice
+                </li>
+                <li>
+                  Share your account credentials with others or create multiple
+                  accounts to circumvent usage limits
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                5. Intellectual Property Rights
+              </h2>
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                5.1 Our Intellectual Property
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                The Service, including all content, features, functionality,
+                algorithms, and technology, is owned by Clausea AI and protected
+                by copyright, trademark, patent, and other intellectual property
+                laws. You may not copy, modify, distribute, or create derivative
+                works without our express written permission.
+              </p>
+
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                5.2 Your Content
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                You retain ownership of documents and content you upload to the
+                Service. By uploading content, you grant us a limited,
+                non-exclusive license to:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>
+                  Process and analyze your documents to provide the Service
+                </li>
+                <li>
+                  Store your documents temporarily as necessary for analysis
+                </li>
+                <li>
+                  Generate analysis results and summaries based on your content
+                </li>
+              </ul>
+              <p className="text-muted-foreground leading-relaxed mt-4">
+                You represent and warrant that you have all necessary rights to
+                upload and process the content you submit to the Service.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                6. Subscription Plans and Payments
+              </h2>
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                6.1 Subscription Tiers
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                We offer various subscription plans with different features and
+                usage limits. Subscription fees are billed in advance on a
+                monthly or annual basis, as selected. All fees are
+                non-refundable except as required by law or as explicitly stated
+                in our refund policy.
+              </p>
+
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                6.2 Payment Terms
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                You agree to provide current, complete, and accurate payment
+                information. You authorize us to charge your payment method for
+                all fees due. If payment fails, we may suspend or terminate your
+                access to the Service.
+              </p>
+
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                6.3 Price Changes
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                We reserve the right to modify subscription prices. We will
+                provide at least 30 days' notice of any price changes. Your
+                continued use of the Service after the price change constitutes
+                acceptance of the new pricing.
+              </p>
+
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                6.4 Cancellation
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                You may cancel your subscription at any time. Cancellation takes
+                effect at the end of your current billing period. You will
+                continue to have access to paid features until the end of your
+                billing period.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                7. Service Availability and Disclaimers
+              </h2>
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                7.1 Availability
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                We strive to provide reliable service but do not guarantee
+                uninterrupted or error-free operation. The Service may be
+                unavailable due to maintenance, updates, or circumstances beyond
+                our control.
+              </p>
+
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                7.2 AI Analysis Disclaimer
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Our AI-powered analysis is provided for informational purposes
+                only and does not constitute legal advice. The Service is not a
+                substitute for professional legal counsel. You should consult
+                with qualified legal professionals for legal advice specific to
+                your situation.
+              </p>
+              <p className="text-muted-foreground leading-relaxed mt-4">
+                While we strive for accuracy, AI analysis may contain errors or
+                omissions. We do not guarantee the accuracy, completeness, or
+                reliability of any analysis provided by the Service.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                8. Limitation of Liability
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                TO THE MAXIMUM EXTENT PERMITTED BY LAW, CLAUSEA AI SHALL NOT BE
+                LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR
+                PUNITIVE DAMAGES, INCLUDING BUT NOT LIMITED TO LOSS OF PROFITS,
+                DATA, OR USE, ARISING OUT OF OR RELATING TO YOUR USE OF THE
+                SERVICE.
+              </p>
+              <p className="text-muted-foreground leading-relaxed mt-4">
+                Our total liability for any claims arising from or related to
+                the Service shall not exceed the amount you paid us in the 12
+                months preceding the claim, or $100, whichever is greater.
+              </p>
+              <p className="text-muted-foreground leading-relaxed mt-4">
+                Some jurisdictions do not allow the exclusion or limitation of
+                certain damages, so the above limitations may not apply to you.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                9. Indemnification
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                You agree to indemnify, defend, and hold harmless Clausea AI and
+                its officers, directors, employees, and agents from any claims,
+                damages, losses, liabilities, and expenses (including attorneys'
+                fees) arising out of or relating to:
+              </p>
+              <ul className="list-disc pl-6 space-y-2 text-muted-foreground">
+                <li>Your use of the Service</li>
+                <li>Your violation of these Terms</li>
+                <li>Your violation of any third-party rights</li>
+                <li>Content you upload or submit to the Service</li>
+              </ul>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                10. Privacy
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                Your use of the Service is also governed by our Privacy Policy.
+                Please review our Privacy Policy to understand how we collect,
+                use, and protect your information.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                11. Modifications to Terms
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                We reserve the right to modify these Terms at any time. We will
+                notify you of material changes by posting the updated Terms on
+                this page and updating the "Last updated" date. Your continued
+                use of the Service after such modifications constitutes
+                acceptance of the updated Terms.
+              </p>
+              <p className="text-muted-foreground leading-relaxed mt-4">
+                If you do not agree to the modified Terms, you must stop using
+                the Service and may cancel your subscription.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                12. Governing Law and Dispute Resolution
+              </h2>
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                12.1 Governing Law
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                These Terms shall be governed by and construed in accordance
+                with the laws of the State of California, United States, without
+                regard to its conflict of law provisions.
+              </p>
+
+              <h3 className="text-2xl font-display font-semibold text-foreground mt-8 mb-4">
+                12.2 Dispute Resolution
+              </h3>
+              <p className="text-muted-foreground leading-relaxed">
+                Any disputes arising out of or relating to these Terms or the
+                Service shall be resolved through binding arbitration in
+                accordance with the rules of the American Arbitration
+                Association, except where prohibited by law. The arbitration
+                shall take place in San Francisco, California.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                13. Severability
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                If any provision of these Terms is found to be unenforceable or
+                invalid, that provision shall be limited or eliminated to the
+                minimum extent necessary, and the remaining provisions shall
+                remain in full force and effect.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                14. Entire Agreement
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                These Terms, together with our Privacy Policy, constitute the
+                entire agreement between you and Clausea AI regarding the
+                Service and supersede all prior agreements and understandings.
+              </p>
+            </section>
+
+            <section className="space-y-4">
+              <h2 className="text-3xl font-display font-bold text-primary mt-12 mb-6">
+                15. Contact Information
+              </h2>
+              <p className="text-muted-foreground leading-relaxed">
+                If you have questions about these Terms, please contact us at:
+              </p>
+              <div className="bg-muted/30 p-6 rounded-2xl border border-border mt-4">
+                <p className="text-foreground font-semibold mb-2">Clausea AI</p>
+                <p className="text-muted-foreground">
+                  Email:{" "}
+                  <a
+                    href="mailto:legal@clausea.ai"
+                    className="text-primary hover:underline"
+                  >
+                    legal@clausea.ai
+                  </a>
+                </p>
+                <p className="text-muted-foreground">
+                  General inquiries:{" "}
+                  <a
+                    href="mailto:hello@clausea.ai"
+                    className="text-primary hover:underline"
+                  >
+                    hello@clausea.ai
+                  </a>
+                </p>
+              </div>
+            </section>
+          </div>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -20,9 +20,9 @@ const fraunces = Fraunces({
 });
 
 export const metadata = {
-  title: "Clausea AI - Documents weren't written for you... until now",
+  title: "Clausea AI - Legal documents were not written for you... until now",
   description:
-    "Illuminate legal complexities with AI precision. Summarize, analyze, and perform RAG on dense legal documents instantly.",
+    "Navigate legal complexities with AI precision. Summarize, analyze and ask questions to dense legal documents instantly.",
 };
 
 export default function Layout(props: { children: React.ReactNode }) {

--- a/apps/frontend/components/clausea/Header.tsx
+++ b/apps/frontend/components/clausea/Header.tsx
@@ -109,7 +109,7 @@ export function Header() {
                 </Link>
               ) : (
                 <Link href="/sign-in">
-                  <Button className="hidden sm:flex rounded-full px-6 h-10 font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-all duration-300">
+                  <Button className="hidden sm:flex rounded-full px-6 h-10 font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-all duration-300 cursor-pointer">
                     Get Started
                   </Button>
                 </Link>

--- a/apps/frontend/components/clausea/Hero.tsx
+++ b/apps/frontend/components/clausea/Hero.tsx
@@ -67,7 +67,7 @@ export default function Hero() {
           <Link href="/sign-up">
             <Button
               size="lg"
-              className="group h-14 px-8 rounded-full text-base font-medium transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg relative overflow-hidden"
+              className="group h-14 px-8 rounded-full text-base font-medium transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg relative overflow-hidden cursor-pointer"
             >
               <span className="relative z-10 flex items-center">
                 Start Exploring

--- a/apps/frontend/components/clausea/PricingAndFooter.tsx
+++ b/apps/frontend/components/clausea/PricingAndFooter.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { CheckCircle2, Github, Linkedin, Mail, Twitter } from "lucide-react";
+import { CheckCircle2, Mail } from "lucide-react";
 import { motion, useInView } from "motion/react";
 import Link from "next/link";
+import { FaGithub } from "react-icons/fa";
+import { FaTwitter } from "react-icons/fa6";
 
 import { useRef } from "react";
 
@@ -187,9 +189,8 @@ export function Footer() {
             </p>
             <div className="flex items-center gap-3">
               {[
-                { icon: Twitter, href: "#" },
-                { icon: Github, href: "#" },
-                { icon: Linkedin, href: "#" },
+                { icon: FaTwitter, href: "https://x.com/clausea_ai" },
+                { icon: FaGithub, href: "https://github.com/lvndry/clausea" },
               ].map(({ icon: Icon, href }, i) => (
                 <a
                   key={i}
@@ -226,7 +227,7 @@ export function Footer() {
                 Resources
               </h5>
               <ul className="space-y-3">
-                {["Documentation", "Security", "Support", "Blog"].map((l) => (
+                {["Security", "Support", "Blog"].map((l) => (
                   <li key={l}>
                     <Link
                       href="#"
@@ -243,21 +244,38 @@ export function Footer() {
                 Legal
               </h5>
               <ul className="space-y-3">
-                {[
-                  "Privacy Policy",
-                  "Terms of Service",
-                  "Cookie Policy",
-                  "GDPR",
-                ].map((l) => (
-                  <li key={l}>
-                    <Link
-                      href="#"
-                      className="text-sm text-muted-foreground hover:text-primary transition-colors"
-                    >
-                      {l}
-                    </Link>
-                  </li>
-                ))}
+                <li>
+                  <Link
+                    href="/privacy"
+                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                  >
+                    Privacy Policy
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/terms"
+                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                  >
+                    Terms of Service
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="#"
+                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                  >
+                    Cookie Policy
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="#"
+                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                  >
+                    GDPR
+                  </Link>
+                </li>
               </ul>
             </div>
           </div>
@@ -298,9 +316,6 @@ export function Footer() {
             </Link>
             <Link href="#" className="hover:text-primary transition-colors">
               Security
-            </Link>
-            <Link href="#" className="hover:text-primary transition-colors">
-              Accessibility
             </Link>
           </div>
         </div>


### PR DESCRIPTION
> Introduces first-class legal pages and aligns navigation/branding.
> 
> - Adds `apps/frontend/app/(site)/privacy/page.tsx` and `apps/frontend/app/(site)/terms/page.tsx` with full content and shared `Header`/`Footer`
> - Updates `Footer` links to route to `/privacy` and `/terms`; replaces social icons with `FaTwitter`/`FaGithub` and real links
> - Adjusts site metadata in `app/layout.tsx` (title/description wording)
> - Refreshes `README.md` with centered logo, updated tagline, and external “Try now” link
> - Minor UI tweaks: add `cursor-pointer` to CTA `Button`s in `Header` and `Hero`; trims "Resources" items in `PricingAndFooter.tsx` and removes "Accessibility" from bottom bar
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 081b100374dea7beb9a1ff6f0967de3d113dfcbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->