### PR TITLE
feat: LLM quality escalation + OpenRouter tier-based routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ wheels/
 # streamlit
 secrets.toml
 
-
 ### Frontend
 
 # dependencies
@@ -60,4 +59,7 @@ bun-debug.log*
 
 ### misc
 data/
+
+# AI tools
+superpowers/
 .planning

--- a/packages/backend/scripts/benchmark_pipeline.py
+++ b/packages/backend/scripts/benchmark_pipeline.py
@@ -53,8 +53,12 @@ async def _count_escalations():
         global _escalation_count, _call_count
         _call_count += 1
         resp = await acompletion_with_fallback(messages, model_priority=primary, **kwargs)
-        content = _extract_json_from_response(resp)
-        if not validator(content):
+        try:
+            content = _extract_json_from_response(resp)
+            should_escalate = not validator(content)
+        except ValueError:
+            should_escalate = True
+        if should_escalate:
             _escalation_count += 1
             resp = await acompletion_with_fallback(messages, model_priority=escalation, **kwargs)
         return resp
@@ -122,7 +126,7 @@ async def _run_doc(doc: Document, baseline: bool) -> dict[str, Any]:
         "doc_type": doc.doc_type,
         "text_length": len(doc.text or ""),
         "models_used": "|".join(summary.keys()),
-        "escalation_count": _escalation_count,
+        "escalation_count": 0 if baseline else _escalation_count,
         "total_tokens": total_tokens,
         "estimated_cost_usd": round(total_cost, 6),
         "duration_s": round(time.time() - start, 2),

--- a/packages/backend/scripts/benchmark_pipeline.py
+++ b/packages/backend/scripts/benchmark_pipeline.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Benchmark escalation vs. nano-only baseline across a sample corpus.
+
+Usage:
+    uv run python scripts/benchmark_pipeline.py --corpus path/to/docs/ --sample 100
+    uv run python scripts/benchmark_pipeline.py --corpus path/to/docs/ --baseline
+
+With --baseline, all LLM calls are forced to ["gpt-5-nano"] (no escalation).
+Without --baseline, normal escalation routing applies.
+
+Output: benchmark_results_<mode>_<timestamp>.csv + summary to stdout.
+"""
+
+import argparse
+import asyncio
+import csv
+import json
+import sys
+import time
+from contextlib import asynccontextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from src.analyser import analyse_document  # noqa: E402
+from src.models.document import Document  # noqa: E402
+from src.services.extraction_service import extract_document_facts  # noqa: E402
+from src.utils.llm_usage import UsageTracker, usage_tracking  # noqa: E402
+
+_NANO_ONLY: list[str] = ["gpt-5-nano"]
+
+_escalation_count = 0
+_call_count = 0
+
+
+@asynccontextmanager
+async def _count_escalations():
+    """Wraps acompletion_with_escalation to count escalation events."""
+    global _escalation_count, _call_count
+    _escalation_count = 0
+    _call_count = 0
+
+    from src.llm import _extract_json_from_response, acompletion_with_fallback
+
+    async def _tracked(messages, primary, escalation, validator, **kwargs):
+        global _escalation_count, _call_count
+        _call_count += 1
+        resp = await acompletion_with_fallback(messages, model_priority=primary, **kwargs)
+        content = _extract_json_from_response(resp)
+        if not validator(content):
+            _escalation_count += 1
+            resp = await acompletion_with_fallback(messages, model_priority=escalation, **kwargs)
+        return resp
+
+    with (
+        patch("src.llm.acompletion_with_escalation", side_effect=_tracked),
+        patch("src.services.extraction_service.acompletion_with_escalation", side_effect=_tracked),
+        patch("src.analyser.acompletion_with_escalation", side_effect=_tracked),
+    ):
+        yield
+
+
+@asynccontextmanager
+async def _force_nano():
+    """Forces all LLM calls (fallback + escalation) to gpt-5-nano."""
+    from src.llm import acompletion_with_fallback as _orig_fb
+
+    async def _nano_fb(messages, model_priority=None, **kwargs):
+        return await _orig_fb(messages, model_priority=_NANO_ONLY, **kwargs)
+
+    async def _nano_esc(messages, primary, escalation, validator, **kwargs):
+        return await _orig_fb(messages, model_priority=_NANO_ONLY, **kwargs)
+
+    with (
+        patch("src.llm.acompletion_with_fallback", side_effect=_nano_fb),
+        patch("src.services.extraction_service.acompletion_with_fallback", side_effect=_nano_fb),
+        patch("src.services.extraction_service.acompletion_with_escalation", side_effect=_nano_esc),
+        patch("src.analyser.acompletion_with_fallback", side_effect=_nano_fb),
+        patch("src.analyser.acompletion_with_escalation", side_effect=_nano_esc),
+    ):
+        yield
+
+
+async def _run_doc(doc: Document, baseline: bool) -> dict[str, Any]:
+    start = time.time()
+    tracker = UsageTracker()
+    callback = tracker.create_tracker("benchmark")
+
+    ctx = _force_nano() if baseline else _count_escalations()
+
+    try:
+        async with ctx:
+            async with usage_tracking(callback):
+                await extract_document_facts(doc, use_cache=False)
+                await analyse_document(doc, use_cache=False)
+    except Exception as e:
+        return {
+            "doc_id": doc.id,
+            "doc_type": doc.doc_type,
+            "text_length": len(doc.text or ""),
+            "models_used": "",
+            "escalation_count": 0,
+            "total_tokens": 0,
+            "estimated_cost_usd": 0.0,
+            "duration_s": round(time.time() - start, 2),
+            "error": str(e),
+        }
+
+    summary = tracker.get_summary()
+    total_cost = sum(v.get("cost") or 0.0 for v in summary.values())
+    total_tokens = sum(v["total_tokens"] for v in summary.values())
+
+    return {
+        "doc_id": doc.id,
+        "doc_type": doc.doc_type,
+        "text_length": len(doc.text or ""),
+        "models_used": "|".join(summary.keys()),
+        "escalation_count": _escalation_count,
+        "total_tokens": total_tokens,
+        "estimated_cost_usd": round(total_cost, 6),
+        "duration_s": round(time.time() - start, 2),
+        "error": None,
+    }
+
+
+def _load_docs(corpus_path: Path, sample: int) -> list[Document]:
+    docs = []
+    for f in sorted(corpus_path.glob("*.json"))[:sample]:
+        try:
+            data = json.loads(f.read_text())
+            docs.append(Document(**data))
+        except Exception as e:
+            print(f"  Skip {f.name}: {e}")
+    return docs
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="LLM escalation benchmark")
+    parser.add_argument("--corpus", required=True, help="Directory of document JSON files")
+    parser.add_argument("--sample", type=int, default=100, help="Max documents to process")
+    parser.add_argument("--baseline", action="store_true", help="Force gpt-5-nano for all calls")
+    args = parser.parse_args()
+
+    corpus_path = Path(args.corpus)
+    if not corpus_path.is_dir():
+        print(f"Error: {corpus_path} is not a directory")
+        sys.exit(1)
+
+    docs = _load_docs(corpus_path, args.sample)
+    if not docs:
+        print("No documents found.")
+        sys.exit(1)
+
+    mode = "baseline (nano-only)" if args.baseline else "escalation"
+    print(f"Running {mode} benchmark on {len(docs)} documents...")
+
+    results = []
+    for i, doc in enumerate(docs, 1):
+        print(f"  [{i}/{len(docs)}] {doc.id} ({doc.doc_type})")
+        result = await _run_doc(doc, baseline=args.baseline)
+        results.append(result)
+        if result["error"]:
+            print(f"    ERROR: {result['error']}")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    mode_tag = "baseline" if args.baseline else "escalation"
+    out_path = Path(f"benchmark_results_{mode_tag}_{timestamp}.csv")
+
+    with open(out_path, "w", newline="") as f:
+        if results:
+            writer = csv.DictWriter(f, fieldnames=list(results[0].keys()))
+            writer.writeheader()
+            writer.writerows(results)
+
+    successful = [r for r in results if not r.get("error")]
+    total_cost = sum(r["estimated_cost_usd"] for r in successful)
+    total_escalations = sum(r["escalation_count"] for r in successful)
+    avg_cost = total_cost / len(successful) if successful else 0
+    total_calls_est = sum(4 * (len(r.get("models_used", "").split("|")) or 1) for r in successful)
+    escalation_rate = total_escalations / max(total_calls_est, 1) * 100
+
+    print(f"\n{'=' * 50}")
+    print(f"Mode:              {mode}")
+    print(f"Documents:         {len(successful)}/{len(docs)} succeeded")
+    print(f"Total cost:        ${total_cost:.4f}")
+    print(f"Avg cost/doc:      ${avg_cost:.4f}")
+    print(f"Total escalations: {total_escalations}")
+    print(f"Results saved to:  {out_path}")
+    print(f"{'=' * 50}")
+    print("\nAcceptance targets:")
+    print(
+        f"  Escalation rate < 30%: ~{escalation_rate:.0f}% (check CSV for exact cluster-level counts)"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/backend/scripts/benchmark_pipeline.py
+++ b/packages/backend/scripts/benchmark_pipeline.py
@@ -110,6 +110,7 @@ async def _run_doc(doc: Document, baseline: bool) -> dict[str, Any]:
             "doc_type": doc.doc_type,
             "text_length": len(doc.text or ""),
             "models_used": "",
+            "call_count": 0,
             "escalation_count": 0,
             "total_tokens": 0,
             "estimated_cost_usd": 0.0,
@@ -126,6 +127,7 @@ async def _run_doc(doc: Document, baseline: bool) -> dict[str, Any]:
         "doc_type": doc.doc_type,
         "text_length": len(doc.text or ""),
         "models_used": "|".join(summary.keys()),
+        "call_count": _call_count,
         "escalation_count": 0 if baseline else _escalation_count,
         "total_tokens": total_tokens,
         "estimated_cost_usd": round(total_cost, 6),
@@ -187,8 +189,8 @@ async def main() -> None:
     total_cost = sum(r["estimated_cost_usd"] for r in successful)
     total_escalations = sum(r["escalation_count"] for r in successful)
     avg_cost = total_cost / len(successful) if successful else 0
-    total_calls_est = sum(4 * (len(r.get("models_used", "").split("|")) or 1) for r in successful)
-    escalation_rate = total_escalations / max(total_calls_est, 1) * 100
+    total_calls = sum(r["call_count"] for r in successful)
+    escalation_rate = total_escalations / max(total_calls, 1) * 100
 
     print(f"\n{'=' * 50}")
     print(f"Mode:              {mode}")
@@ -199,9 +201,8 @@ async def main() -> None:
     print(f"Results saved to:  {out_path}")
     print(f"{'=' * 50}")
     print("\nAcceptance targets:")
-    print(
-        f"  Escalation rate < 30%: ~{escalation_rate:.0f}% (check CSV for exact cluster-level counts)"
-    )
+    print(f"  Total LLM calls:   {total_calls}")
+    print(f"  Escalation rate < 30%: {escalation_rate:.1f}%")
 
 
 if __name__ == "__main__":

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -69,10 +69,13 @@ from src.utils.llm_usage import UsageTracker, log_usage_summary, usage_tracking
 load_dotenv()
 logger = get_logger(__name__)
 
-_ANALYSIS_RESILIENCE: list[SupportedModel] = ["gemini-3.1-flash-lite"]
-_ANALYSIS_PRIMARY: list[SupportedModel] = ["gpt-5-mini"] + _ANALYSIS_RESILIENCE
-_ANALYSIS_ESCALATION: list[SupportedModel] = ["gpt-5.4-mini"] + _ANALYSIS_RESILIENCE
-_OVERVIEW_PRIORITY: list[SupportedModel] = ["gpt-5.4-nano", "gemini-2.5-flash-lite"]
+_ANALYSIS_RESILIENCE: list[SupportedModel] = ["openrouter/deepseek-v4-flash"]
+_ANALYSIS_PRIMARY: list[SupportedModel] = ["openrouter/gpt-oss-120b-nitro"] + _ANALYSIS_RESILIENCE
+_ANALYSIS_ESCALATION: list[SupportedModel] = ["openrouter/grok-4.1-fast"] + _ANALYSIS_RESILIENCE
+_OVERVIEW_PRIORITY: list[SupportedModel] = [
+    "openrouter/gpt-oss-120b-nitro",
+    "openrouter/deepseek-v4-flash",
+]
 
 
 def _analysis_validator(content: str) -> bool:

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -20,7 +20,11 @@ from dotenv import load_dotenv
 from motor.core import AgnosticDatabase
 
 from src.core.logging import get_logger
-from src.llm import acompletion_with_fallback
+from src.llm import (
+    SupportedModel,
+    acompletion_with_escalation,
+    acompletion_with_fallback,
+)
 from src.models.document import (
     BusinessImpact,
     BusinessImpactAssessment,
@@ -64,6 +68,27 @@ from src.utils.llm_usage import UsageTracker, log_usage_summary, usage_tracking
 
 load_dotenv()
 logger = get_logger(__name__)
+
+_ANALYSIS_RESILIENCE: list[SupportedModel] = ["gemini-3.1-flash-lite"]
+_ANALYSIS_PRIMARY: list[SupportedModel] = ["gpt-5-mini"] + _ANALYSIS_RESILIENCE
+_ANALYSIS_ESCALATION: list[SupportedModel] = ["gpt-5.4-mini"] + _ANALYSIS_RESILIENCE
+_OVERVIEW_PRIORITY: list[SupportedModel] = ["gpt-5.4-nano", "gemini-2.5-flash-lite"]
+
+
+def _analysis_validator(content: str) -> bool:
+    try:
+        data = json.loads(content)
+        if not isinstance(data, dict):
+            return False
+        if not isinstance(data.get("summary"), str) or not data["summary"].strip():
+            return False
+        scores = data.get("scores")
+        if not isinstance(scores, dict) or len(scores) == 0:
+            return False
+        return True
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
 
 ProgressCallback = Callable[[int, int, Document], Awaitable[None] | None]
 
@@ -638,8 +663,11 @@ Document content:
 
             async with usage_tracking(tracker_callback):
                 # Wrap the LLM call in a cancellable task
+                is_complex = should_use_reasoning_model(document)
+                model_primary = _ANALYSIS_ESCALATION if is_complex else _ANALYSIS_PRIMARY
+
                 llm_task = asyncio.create_task(
-                    acompletion_with_fallback(
+                    acompletion_with_escalation(
                         messages=[
                             {
                                 "role": "system",
@@ -647,6 +675,9 @@ Document content:
                             },
                             {"role": "user", "content": prompt},
                         ],
+                        primary=model_primary,
+                        escalation=_ANALYSIS_ESCALATION,
+                        validator=_analysis_validator,
                         response_format={"type": "json_object"},
                         temperature=0,
                     )
@@ -678,6 +709,7 @@ Document content:
 
                 # Get the response
                 response = await llm_task
+                logger.info("analyse_document %s used model %s", document.id, response.model)
 
             choice = response.choices[0]
             if not hasattr(choice, "message"):
@@ -999,6 +1031,7 @@ Per-document analyses and extractions:
                         },
                         {"role": "user", "content": prompt},
                     ],
+                    model_priority=_OVERVIEW_PRIORITY,
                     response_format={"type": "json_object"},
                 )
             )
@@ -1365,6 +1398,7 @@ Per-document analyses and extractions:
                     },
                     {"role": "user", "content": aggregate_prompt},
                 ],
+                model_priority=_OVERVIEW_PRIORITY,
                 response_format={"type": "json_object"},
             )
 

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -85,6 +85,11 @@ def _analysis_validator(content: str) -> bool:
         scores = data.get("scores")
         if not isinstance(scores, dict) or len(scores) == 0:
             return False
+        # At least one score entry must be a dict with a numeric score field
+        if not any(
+            isinstance(v, dict) and isinstance(v.get("score"), int) for v in scores.values()
+        ):
+            return False
         return True
     except (json.JSONDecodeError, AttributeError):
         return False
@@ -664,24 +669,34 @@ Document content:
             async with usage_tracking(tracker_callback):
                 # Wrap the LLM call in a cancellable task
                 is_complex = should_use_reasoning_model(document)
-                model_primary = _ANALYSIS_ESCALATION if is_complex else _ANALYSIS_PRIMARY
 
-                llm_task = asyncio.create_task(
-                    acompletion_with_escalation(
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": DOCUMENT_ANALYSIS_PROMPT,
-                            },
-                            {"role": "user", "content": prompt},
-                        ],
-                        primary=model_primary,
-                        escalation=_ANALYSIS_ESCALATION,
-                        validator=_analysis_validator,
-                        response_format={"type": "json_object"},
-                        temperature=0,
+                if is_complex:
+                    # Complex docs go straight to the escalation model — no cheaper tier to try first.
+                    llm_task = asyncio.create_task(
+                        acompletion_with_fallback(
+                            messages=[
+                                {"role": "system", "content": DOCUMENT_ANALYSIS_PROMPT},
+                                {"role": "user", "content": prompt},
+                            ],
+                            model_priority=_ANALYSIS_ESCALATION,
+                            response_format={"type": "json_object"},
+                            temperature=0,
+                        )
                     )
-                )
+                else:
+                    llm_task = asyncio.create_task(
+                        acompletion_with_escalation(
+                            messages=[
+                                {"role": "system", "content": DOCUMENT_ANALYSIS_PROMPT},
+                                {"role": "user", "content": prompt},
+                            ],
+                            primary=_ANALYSIS_PRIMARY,
+                            escalation=_ANALYSIS_ESCALATION,
+                            validator=_analysis_validator,
+                            response_format={"type": "json_object"},
+                            temperature=0,
+                        )
+                    )
 
                 # Wait for either completion or cancellation
                 cancellation_task = asyncio.create_task(token.cancelled.wait())

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -505,6 +505,11 @@ def _attach_deep_fields(analysis: DocumentAnalysis, data: dict[str, Any]) -> Non
         except Exception as e:
             logger.warning(f"Failed to parse critical_clauses: {e}")
 
+    analysis.analysis_completeness = data.get("analysis_completeness", "full")
+    raw_gaps = data.get("coverage_gaps", [])
+    if isinstance(raw_gaps, list):
+        analysis.coverage_gaps = [str(g) for g in raw_gaps if g]
+
     raw_sections = data.get("key_sections", [])
     if isinstance(raw_sections, list):
         try:
@@ -513,11 +518,6 @@ def _attach_deep_fields(analysis: DocumentAnalysis, data: dict[str, Any]) -> Non
             ]
         except Exception as e:
             logger.warning(f"Failed to parse key_sections: {e}")
-
-    analysis.analysis_completeness = data.get("analysis_completeness", "full")
-    raw_gaps = data.get("coverage_gaps", [])
-    if isinstance(raw_gaps, list):
-        analysis.coverage_gaps = [str(g) for g in raw_gaps if g]
 
     if analysis.document_risk_breakdown is not None:
         br = analysis.document_risk_breakdown
@@ -746,11 +746,10 @@ Document content:
                 parsed: DocumentAnalysis = DocumentAnalysis.model_validate(
                     parsed_dict, strict=False
                 )
-
                 # Ensure all required scores are present, normalize names, and calculate risk_score/verdict
                 parsed = _ensure_required_scores(parsed)
 
-                # Parse deep analysis fields (critical_clauses, risk_breakdown, key_sections,
+                # Parse deep analysis fields (critical_clauses, risk_breakdown,
                 # analysis_completeness, coverage_gaps) from the same response — deep is default.
                 _attach_deep_fields(parsed, parsed_dict)
 

--- a/packages/backend/src/document_processor.py
+++ b/packages/backend/src/document_processor.py
@@ -19,6 +19,8 @@ from src.models.document import Document, DocumentAnalysis, coerce_doc_type_from
 load_dotenv()
 logger = get_logger(__name__)
 
+_CLASSIFICATION_PRIORITY: list[SupportedModel] = ["gpt-5.4-nano", "gemini-2.5-flash-lite"]
+
 
 class DocumentProcessingResult(BaseModel):
     """Result of document processing."""
@@ -311,6 +313,7 @@ Use caution: If the content appears incomplete, vague, or primarily promotional,
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": prompt},
                 ],
+                model_priority=_CLASSIFICATION_PRIORITY,
                 response_format={"type": "json_object"},
             )
 
@@ -325,6 +328,7 @@ Use caution: If the content appears incomplete, vague, or primarily promotional,
                 raise ValueError("Empty response from LLM")
 
             result: dict[str, Any] = json.loads(content)
+            logger.debug("Classification used model %s for document", response.model)
             logger.debug(f"Document classification result: {result}")
             return result
 

--- a/packages/backend/src/document_processor.py
+++ b/packages/backend/src/document_processor.py
@@ -19,7 +19,10 @@ from src.models.document import Document, DocumentAnalysis, coerce_doc_type_from
 load_dotenv()
 logger = get_logger(__name__)
 
-_CLASSIFICATION_PRIORITY: list[SupportedModel] = ["gpt-5.4-nano", "gemini-2.5-flash-lite"]
+_CLASSIFICATION_PRIORITY: list[SupportedModel] = [
+    "openrouter/gpt-oss-120b-nitro",
+    "openrouter/deepseek-v4-flash",
+]
 
 
 class DocumentProcessingResult(BaseModel):

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -69,6 +69,8 @@ _OPENROUTER_ALIASES: dict[str, str] = {
     "openrouter/kimi-k2-thinking": "openrouter/moonshotai/kimi-k2-thinking",
 }
 
+EscalationValidator = Callable[[str], bool]
+
 _NO_TEMPERATURE_MODELS: frozenset[str] = frozenset(
     {"gpt-5-mini", "gpt-5.4-mini", "gpt-5-nano", "gemini-3-flash-preview"}
 )
@@ -285,3 +287,53 @@ async def get_embeddings(
     except Exception as e:
         logger.error("Error getting embeddings with %s: %s", model_name, e)
         raise
+
+
+def _extract_json_from_response(response: ModelResponse) -> str:
+    choice = response.choices[0]
+    if not hasattr(choice, "message"):
+        raise ValueError("Response missing message attribute")
+    message = choice.message  # type: ignore[attr-defined]
+    if not message:
+        raise ValueError("Response message is None")
+    content = message.content  # type: ignore[attr-defined]
+    if not content:
+        raise ValueError("Response content is empty")
+    return content
+
+
+async def acompletion_with_escalation(
+    messages: list[dict[str, str]],
+    primary: list[SupportedModel],
+    escalation: list[SupportedModel],
+    validator: EscalationValidator,
+    **kwargs: Any,
+) -> ModelResponse:
+    """Call primary model, validate response quality, escalate to better model on failure.
+
+    If the escalated response also fails validation, returns it anyway with a warning —
+    partial data is better than blocking the pipeline.
+    """
+    response = await acompletion_with_fallback(messages, model_priority=primary, **kwargs)
+    content = _extract_json_from_response(response)
+
+    if validator(content):
+        return response
+
+    logger.warning(
+        "Primary model %s failed validation, escalating to %s",
+        response.model,
+        escalation[0] if escalation else "unknown",
+    )
+
+    escalated = await acompletion_with_fallback(messages, model_priority=escalation, **kwargs)
+    logger.info("Escalated completion used model %s", escalated.model)
+
+    escalated_content = _extract_json_from_response(escalated)
+    if not validator(escalated_content):
+        logger.warning(
+            "Escalated model %s also failed validation — returning response anyway",
+            escalated.model,
+        )
+
+    return escalated

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -31,11 +31,19 @@ class Model:
     model: str
     api_key: str
     api_base: str | None
+    extra_headers: dict[str, str] | None
 
-    def __init__(self, model: str, api_key: str, api_base: str | None = None):
+    def __init__(
+        self,
+        model: str,
+        api_key: str,
+        api_base: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ):
         self.model = model
         self.api_key = api_key
         self.api_base = api_base
+        self.extra_headers = extra_headers
 
 
 # Model identifier strings. Supported prefixes:
@@ -150,7 +158,14 @@ def get_model(model_name: SupportedModel) -> Model:
         if not api_key:
             raise ValueError("OPENROUTER_API_KEY is not set")
         full_model = _OPENROUTER_ALIASES.get(model_name, model_name)
-        return Model(model=full_model, api_key=api_key)
+        return Model(
+            model=full_model,
+            api_key=api_key,
+            extra_headers={
+                "HTTP-Referer": os.getenv("APP_URL", "https://clausea.co"),
+                "X-Title": os.getenv("APP_NAME", "Clausea"),
+            },
+        )
 
     if model_name.startswith("groq/"):
         api_key = os.getenv("GROQ_API_KEY")
@@ -202,6 +217,7 @@ async def _completion_with_fallback_impl(
                 api_key=model.api_key,
                 messages=messages,
                 **({"api_base": model.api_base} if model.api_base else {}),
+                **({"extra_headers": model.extra_headers} if model.extra_headers else {}),
                 **call_kwargs,
             )
             duration = time.time() - start_time

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -65,6 +65,9 @@ _OPENROUTER_ALIASES: dict[str, str] = {
     "openrouter/free": os.getenv(
         "OPENROUTER_FREE_MODEL", "openrouter/meta-llama/llama-3.1-8b-instruct:free"
     ),
+    "openrouter/gpt-oss-120b-nitro": "openrouter/openai/gpt-oss-120b:nitro",
+    "openrouter/deepseek-v4-flash": "openrouter/deepseek/deepseek-v4-flash",
+    "openrouter/grok-4.1-fast": "openrouter/x-ai/grok-4.1-fast",
     # legacy
     "openrouter/kimi-k2-thinking": "openrouter/moonshotai/kimi-k2-thinking",
 }

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -315,9 +315,14 @@ async def acompletion_with_escalation(
     partial data is better than blocking the pipeline.
     """
     response = await acompletion_with_fallback(messages, model_priority=primary, **kwargs)
-    content = _extract_json_from_response(response)
 
-    if validator(content):
+    try:
+        content = _extract_json_from_response(response)
+        primary_valid = validator(content)
+    except ValueError:
+        primary_valid = False
+
+    if primary_valid:
         return response
 
     logger.warning(
@@ -329,10 +334,16 @@ async def acompletion_with_escalation(
     escalated = await acompletion_with_fallback(messages, model_priority=escalation, **kwargs)
     logger.info("Escalated completion used model %s", escalated.model)
 
-    escalated_content = _extract_json_from_response(escalated)
-    if not validator(escalated_content):
+    try:
+        escalated_content = _extract_json_from_response(escalated)
+        if not validator(escalated_content):
+            logger.warning(
+                "Escalated model %s also failed validation — returning response anyway",
+                escalated.model,
+            )
+    except ValueError:
         logger.warning(
-            "Escalated model %s also failed validation — returning response anyway",
+            "Escalated model %s returned malformed content — returning response anyway",
             escalated.model,
         )
 

--- a/packages/backend/src/models/document.py
+++ b/packages/backend/src/models/document.py
@@ -670,6 +670,9 @@ class DocumentSummary(BaseModel):
     summary: str | None = None  # User-oriented explanation from analysis
     keypoints: list[str] | None = None  # Key bullet points from analysis
     keypoints_with_evidence: list[KeypointWithEvidence] | None = None  # Optional citations
+    critical_clauses: "list[CriticalClause] | None" = None
+    document_risk_breakdown: "DocumentRiskBreakdown | None" = None
+    key_sections: "list[DocumentSection] | None" = None
 
     @classmethod
     def from_document(cls, doc: "Document") -> "DocumentSummary":
@@ -685,12 +688,18 @@ class DocumentSummary(BaseModel):
             summary_data["keypoints_with_evidence"] = doc.analysis.keypoints_with_evidence
             summary_data["verdict"] = doc.analysis.verdict
             summary_data["risk_score"] = doc.analysis.risk_score
+            summary_data["critical_clauses"] = doc.analysis.critical_clauses
+            summary_data["document_risk_breakdown"] = doc.analysis.document_risk_breakdown
+            summary_data["key_sections"] = doc.analysis.key_sections
         else:
             summary_data["summary"] = None
             summary_data["keypoints"] = None
             summary_data["keypoints_with_evidence"] = None
             summary_data["verdict"] = None
             summary_data["risk_score"] = None
+            summary_data["critical_clauses"] = None
+            summary_data["document_risk_breakdown"] = None
+            summary_data["key_sections"] = None
 
         return cls(**summary_data)
 

--- a/packages/backend/src/prompts/analysis_prompts.py
+++ b/packages/backend/src/prompts/analysis_prompts.py
@@ -42,16 +42,16 @@ OVERVIEW_CORE_DOC_TYPES: frozenset[str] = frozenset(
 # ─── 1. DOCUMENT ANALYSIS (deep by default) ────────────────────────────────────
 
 DOCUMENT_ANALYSIS_JSON_SCHEMA = """{
-  "summary": string,
+  "summary": string (3-5 concrete sentences),
   "scores": {
-    "transparency":          {"score": int (0-10), "justification": string},
-    "data_collection_scope": {"score": int (0-10), "justification": string},
-    "user_control":          {"score": int (0-10), "justification": string},
-    "third_party_sharing":   {"score": int (0-10), "justification": string},
-    "data_retention_score":  {"score": int (0-10), "justification": string},  // OMIT KEY if extraction has no retention information
-    "security_score":        {"score": int (0-10), "justification": string}   // OMIT KEY if extraction has no security information
+    "transparency":          {"score": int 0-10, "justification": string},
+    "data_collection_scope": {"score": int 0-10, "justification": string},
+    "user_control":          {"score": int 0-10, "justification": string},
+    "third_party_sharing":   {"score": int 0-10, "justification": string},
+    "data_retention_score":  {"score": int 0-10, "justification": string},
+    "security_score":        {"score": int 0-10, "justification": string}
   },
-  "liability_risk": int (0-10) | null,
+  "liability_risk": int 0-10 | null,
   "compliance_status": {"GDPR": int|null, "CCPA": int|null, "PIPEDA": int|null, "LGPD": int|null} | null,
   "keypoints": [string],
   "applicability": string | null,
@@ -59,23 +59,17 @@ DOCUMENT_ANALYSIS_JSON_SCHEMA = """{
   "coverage_gaps": [string],
   "critical_clauses": [
     {
-      "clause_type": "data_collection" | "data_sharing" | "user_rights" | "liability"
-                   | "indemnification" | "retention" | "deletion" | "security"
-                   | "breach_notification" | "dispute_resolution" | "governing_law",
-      "section_title": string | null,
+      "clause_type": string,
       "quote": string,
       "risk_level": "low" | "medium" | "high" | "critical",
       "plain_english": string,
-      "why_notable": string,
-      "compliance_impact": [string]
+      "why_notable": string
     }
   ],
   "document_risk_breakdown": {
-    "overall_risk": int (0-10),
     "risk_by_category": {string: int},
     "top_concerns": [string],
-    "positive_protections": [string],
-    "missing_information": [string]
+    "positive_protections": [string]
   },
   "key_sections": [
     {
@@ -87,124 +81,57 @@ DOCUMENT_ANALYSIS_JSON_SCHEMA = """{
     }
   ]
 }
-
 """
 
-DOCUMENT_ANALYSIS_PROMPT = f"""You are a senior privacy and legal analyst at a policy intelligence firm. Produce a thorough, evidence-backed analysis of a single policy document that a non-lawyer can trust and act on.
+DOCUMENT_ANALYSIS_PROMPT = f"""You are a senior privacy analyst. Produce an evidence-backed analysis of ONE policy document for a privacy-conscious non-lawyer.
 
-## Input
-You will receive:
-1. Document metadata: title, type, URL, locale, regions.
-2. Structured extraction: evidence-backed facts drawn from the document by a prior extraction step.
-3. A completeness indicator: whether the extraction covered the full document or was truncated.
+## Rules (non-negotiable)
+- Use ONLY facts from the extraction below. If absent, state "Not specified in document".
+- Every critical clause quote must be an exact substring from the extraction evidence.
+- Never output `risk_score` or `verdict` — the platform computes them deterministically from your scores.
+- If the extraction is partial, set analysis_completeness to "partial".
 
-## Non-negotiable rules
-- Use ONLY facts present in the extraction input.
-- Every critical clause must use the exact quote from the extraction evidence.
-- If something is absent from the extraction, state "Not specified in document". Never infer or fabricate.
-- If the extraction is partial, set analysis_completeness to "partial" and list what is unknown in coverage_gaps.
+## SUMMARY
+3-5 concrete sentences. Name exact data types ("precise GPS", "biometric identifiers"), exact recipients ("Meta Pixel", "Google Analytics"), exact rights paths ("Settings > Privacy > Delete"). Start with the service/product name, never with "This document" or "This policy".
 
-## Output
-Write for a user who knows nothing about law but is privacy-conscious.
+## SCORES
+Six dimensions, each 0-10 (higher = better for user). Only include a key when the extraction provides real evidence — a missing key is an honest signal.
 
+- **transparency**: clarity of what is collected, why, and by whom. 10=crystal clear, 0=deliberately opaque.
+- **data_collection_scope**: breadth of collection. 10=minimal/necessary only, 0=sweeping.
+- **user_control**: self-service controls. 10=full opt-out/deletion/portability, 0=none.
+- **third_party_sharing**: breadth of sharing. 10=no sharing, 0=unrestricted.
+- **data_retention_score**: retention specificity. 10=short specific periods, 0=indefinite. **Omit if extraction has no retention data.**
+- **security_score**: stated security measures. 10=E2EE/SOC2/pen-tests, 0=no mention. **Omit if extraction has no security data.**
 
-- Up to 5 sentences: what service this is, the single biggest data concern OR strongest protection, and what the user must know immediately.
+Calibration: minimal-collection + E2EE → high collection/sharing scores (7-10). Ad-tech ecosystem + AI training on user content → low (0-4). Clear disclosure of invasive practices does NOT raise scores.
 
-Put all numbered/bulleted takeaways in the `keypoints` array only (see KEY POINTS below) so they are not duplicated inside `summary`.
-
-Rules:
-- Never start with "This document", "The policy", or "This service".
-- Be concrete: name exact data types ("precise GPS location", "browsing history across sites", "biometric identifiers"), exact recipients ("Meta Pixel", "Google Analytics", "Salesforce"), exact rights ("delete account via Settings > Privacy > Delete Account").
-- Use "This means…" or "In practice…" to explain user impact without adding new facts not in the extraction.
-- No legalese, no hedging, no marketing language.
+## KEYPOINTS
+5-10 specific, concrete bullets (fewer acceptable when extraction is thin). Prioritize: AI training on user data, biometrics/health, arbitration waivers, content licenses, government access, cross-entity binding, liability caps.
 
 ## CRITICAL CLAUSES
-Identify every clause in the extraction that is materially significant for the user's privacy, rights, or legal exposure.
+Flag every materially significant clause. For each: clause_type (short label), quote (exact from extraction), risk_level, plain_english (what this means to a non-lawyer), why_notable.
 
-For each clause:
-- clause_type: pick the closest match.
-- quote: exact text from the document taken directly from the extraction's evidence fields.
-- section_title: section heading from the document if available, else null.
-- risk_level: low / medium / high / critical.
-- plain_english: what this means to a non-lawyer. Use simple language and avoid legal jargon.
-- why_notable: why this clause matters: surprising scope, invasive practice, strong protection, or significant legal weight.
-- compliance_impact: regulations directly implicated.
-
-Always produce a clause entry for any of the following if present in the extraction:
-- AI training on user-generated content or data
-- Biometric, health, genetic, or precise location data collection
-- Forced arbitration and class-action / jury-trial waivers
-- Broad content licenses (perpetual, irrevocable, sublicensable, for AI or commercial use)
-- Cross-entity or subsidiary scope expansion ("by using this service you agree to our affiliates' terms")
-- Government and law enforcement data access especially without a warrant requirement
-- International data transfers without adequate safeguards
-- Unilateral right to modify terms with minimal or no notice
-- User indemnification obligations
-- Liability caps or exclusions that expose the user
-- Any clause that is worrisome or surprising.
-
-## SCORES (integers 0-10, higher = better for the user)
-- transparency: Does the document clearly explain what data is collected, why, and by whom? 10 = very clear, 0 = deliberately opaque.
-- data_collection_scope: How limited is data collection? 10 = minimal/necessary only, 0 = sweeping collection of everything possible.
-- user_control: How much control does the user have? 10 = full opt-out, deletion, portability with self-service. 0 = no control at all.
-- third_party_sharing: How limited is data sharing? 10 = no third-party sharing. 0 = unrestricted sharing with all partners.
-- data_retention_score: How limited is retention duration? 10 = short, specific periods. 0 = indefinite. **Omit this key entirely if the extraction contains no retention information** — do not guess or use a neutral default.
-- security_score: Quality of stated security measures. 10 = strong, specific technical controls (E2EE, SOC 2, pen tests). 0 = no mention at all. **Omit this key entirely if the extraction contains no security information** — do not guess or use a neutral default.
-
-Important: only include a score key when the extraction gives you real evidence to base it on. A missing key is an honest signal; a fabricated score misleads users.
-
-### Calibration
-Score from the extraction only — not brand reputation.
-
-- Minimal collection, no ads ecosystem, E2EE stated → `data_collection_scope` / `third_party_sharing` high (7-10); lower only where extraction shows exceptions (address-book flows, analytics, metadata use).
-- Broad profiling, ad-tech ecosystem, cross-app tracking, AI training on user content → collection/sharing low (0-4).
-- Clear disclosure of invasive practices does not raise collection/sharing scores.
-
-## Headline risk (platform-only)
-Do not output `risk_score` or `verdict`. The platform computes them from your six scores with fixed weights so the product always shows one consistent headline number. Your job is to make those six scores faithful to the extraction.
-
----
-
-## KEY POINTS (`keypoints`)
-The only place for takeaway bullets. 5-10 strings when `analysis_completeness` is `full`; fewer (but at least one) when `partial` and the extraction is thin. Concrete and specific; no generalisations.
-Prioritise: AI training, biometrics, arbitration, scope expansion, content licenses, government access, cross-entity binding.
-
-
-
-## APPLICABILITY (`applicability`)
-One short phrase: who and where this document applies (jurisdiction, product, or audience). Do not use this field for how *much* data is collected that is the score `data_collection_scope`.
-
-Examples: "Global", "EU-specific", "US state residents only", "Product-specific: [name]", "Service-specific: [name]". Use document title, URL, locale, and regions.
-
-## COVERAGE GAPS
-List things a user would reasonably expect a document of this type to cover that are absent or deliberately vague.
-Examples: "No breach notification timeline stated", "Retention periods not specified for any data category", "Security measures not described", "No information on how to exercise deletion rights".
-This is factual reporting — a gap does not mean non-compliance.
-
-## COMPLIANCE (`compliance_status`)
-Not every document should carry regulatory scores.
-
-- Set `compliance_status` to `null` (omit the object) when the document has no honest basis for these regimes: e.g. pure liability/dispute ToS with no personal-data content, a narrow cookie mechanics notice with no rights narrative, boilerplate unrelated to data protection, or extraction so thin that no regime can be scored without guessing.
-- When the document does address privacy, data subjects, rights, regions, or legal bases, include the object and score only regimes supported by the extraction.
-- Per-regulation `null`: inside the object, use `null` for a given key when that specific law is not implicated or evidence is insufficient. If every key would be `null`, set the whole `compliance_status` to `null` instead of an empty object.
-- Scores are 0-10 (higher = stronger alignment with what that regime typically expects to see disclosed); do not invent scores to fill all four keys.
+Must flag when present: AI training on user data, biometric/health/genetic collection, forced arbitration, class/jury waivers, perpetual/irrevocable content licenses, cross-entity scope expansion, government access without warrant, international transfers lacking safeguards, unilateral modification rights, user indemnification, liability exclusions.
 
 ## DOCUMENT RISK BREAKDOWN
-- overall_risk: 0-10 holistic severity (higher = worse for the user). Omit this field if unsure — the platform fills it from the derived headline score.
-- risk_by_category: one entry per meaningful category found in the extraction (e.g. "data_sharing": 8, "retention": 5).
-- top_concerns: up to 5 substantive concerns with concrete detail. Do not treat normal requirements for the product category (e.g. contact info needed to run a communications service) as a "top concern" unless combined with unusual risk in the extraction.
-- positive_protections: up to 5 specific protective measures actually stated in the document.
-- missing_information: omit or `[]` — platform derives this from `coverage_gaps`.
+- risk_by_category: one entry per meaningful category (e.g. "data_sharing": 8, "user_control": 3).
+- top_concerns: up to 5 substantive concerns. Skip normal category requirements (phone for messaging, email for accounts) unless tied to unusual processing.
+- positive_protections: up to 5 genuine protections the document states.
 
 ## KEY SECTIONS
-3-7 most important sections with:
-- section_title: as it appears in the document.
-- content: full text of the section (from extraction).
-- importance: low / medium / high / critical.
-- analysis: plain-language explanation of the section's significance.
-- related_clauses: indices (as strings) of any critical_clauses entries that originate from this section.
+3-7 structurally important sections of the document (e.g. "Data Sharing", "User Rights", "Arbitration Clause"). For each: section_title (exact or paraphrased heading), content (verbatim excerpt, max 300 chars), importance (critical/high/medium/low), analysis (one sentence on what this means to the user), related_clauses (list of clause_type values from critical_clauses that this section produced, or empty list).
 
-Return valid JSON strictly matching this schema:
+## APPLICABILITY
+One phrase: who/where this applies. Examples: "Global", "EU residents only", "US state residents", "Product-specific: [name]".
+
+## COVERAGE GAPS
+What a reasonable user would expect this document type to cover that is absent or vague. Factual, not alarmist.
+
+## COMPLIANCE
+Set compliance_status to null when the document has no basis for regulatory scores. When relevant, score only supported regimes 0-10. Use null for individual unsupported keys.
+
+Return valid JSON matching this schema:
 {DOCUMENT_ANALYSIS_JSON_SCHEMA}
 """
 
@@ -274,7 +201,7 @@ You will receive for each core document:
 - Structured extraction: evidence-backed facts already drawn from the full document
 - Per-document analysis: summary, scores, critical clauses, key points, coverage gaps
 
-Core documents may include: privacy policy, terms of service, terms of use, terms and conditions, cookie policy, GDPR/DPA policy, data processing agreement, children's privacy policy, security / trust practices (encryption, audits, incident handling).
+Core documents may include: privacy policy, terms of service, cookie policy, GDPR/DPA policy, data processing agreement, children's privacy policy, security / trust practices (encryption, audits, incident handling).
 
 ## Your task
 Produce a comprehensive overview covering data practices and contractual terms together:
@@ -288,22 +215,22 @@ Explicitly surface, when the inputs support it: children's or teens' data, sale 
 - Deduplicate across documents report each fact once, clearly.
 - When documents conflict, report the conflict in `contradictions` and use the more conservative interpretation for factual claims — not for tone (stay measured, not alarmist).
 - If a field cannot be filled from the evidence, use "Not specified in documents" — never invent.
-- Be honest: if the company collects a lot of data, do not soften it; but do not invent or exaggerate risks beyond what the documents support.s
+- Be honest: if the company collects a lot of data, do not soften it; but do not invent or exaggerate risks beyond what the documents support.
 
 ## SUMMARY
 1. Up to 5 sentences: who this company is, what data they collect overall, the most important privacy risk, and the most important protection (if any). Start directly with the company or service name.
-2. A markdown bullet list titled "Key Takeaways" -6-10 specific cross-document findings users must know.
+2. A markdown bullet list titled "Key Takeaways" - 6-10 specific cross-document findings users must know.
 
 Rules: start with the company/service name; be concrete (exact data types, third parties, exercise paths); use "This means…" or "In practice…" for impact without adding new facts.
 
 ## SCORES
-Synthesize from all document scores. Where documents conflict, use the most conservative (worst) interpretation for the underlying factss, then assign scores that spread across the 0-10 scale.
-Apply the same calibration as single-document analysis: minimal-data / low-sharing / strong technical protections (per extraction) → high scores on `data_collection_scope`, `third_party_sharing`, and usually `security_score`; ad-tech-scale collection, many recipients, tracking, training on user content → low scores on collection and sharing. The product’s cached `risk_score` is derived from per-document analyses with privacy_policy weighted most heavily, so privacy-policy scores must honestly reflect breadth of collection and sharing.
+Synthesize from all document scores. Where documents conflict, use the most conservative (worst) interpretation for the underlying facts, then assign scores that spread across the 0-10 scale.
+Apply the same calibration as single-document analysis: minimal-data / low-sharing / strong technical protections (per extraction) → high scores on `data_collection_scope`, `third_party_sharing`; ad-tech-scale collection, many recipients, tracking, training on user content → low scores on collection and sharing. The product's cached `risk_score` is derived from per-document analyses with privacy_policy weighted most heavily, so privacy-policy scores must honestly reflect breadth of collection and sharing.
 
 Provide only: transparency, data_collection_scope, user_control, third_party_sharing.
 
 ## DATA COLLECTED
-10-20 specific data types. Be precise: "device fingerprint", "precise GPS coordinates", "browsing history across third-party sites", "keystroke dynamics" — not "device information" or "usage data".
+10-20 specific data types. Be precise: "device fingerprint", "precise GPS coordinates", "browsing history across third-party sites" — not "device information" or "usage data".
 
 ## DATA PURPOSES
 8-15 specific purposes. Be honest: include "targeted advertising", "sale to data brokers", "AI model training" if present — not just sanitised descriptions.
@@ -315,50 +242,25 @@ For each data type, list the specific purposes for which it is used. Create one 
 Every named or implied third-party recipient from all documents. For each: what data they receive, for what purpose, and a risk level.
 
 ## YOUR RIGHTS
-8-12 items: what the documents say users may do or choose (controls, opt-outs, access/deletion paths, where to read more). Phrase as helpful facts, not lectures. For each, include how to exercise it when stated — URL, email, in-app path, or process name.
-Examples:
-- "Delete your account and data — go to Settings > Privacy > Delete Account or email privacy@company.com"
-- "Opt out of AI training on your content — toggle off in Settings > Data > AI Personalization"
-- "Request a copy of your data — submit a DSAR at company.com/privacy/request"
+8-12 items: what the documents say users may do (controls, opt-outs, access/deletion paths). Phrase as helpful facts, not lectures. Include how to exercise it — URL, email, in-app path.
 
 ## DANGERS
-Meaningful risks or trade-offs actually stated in the documents — things a reasonable user might want to weigh beyond signing up for this type of product. Aim for 5-7 items; use fewer if the evidence is thin.
-
-Do NOT treat as dangers:
-- Normal requirements for the category (e.g. a phone number to register a messaging app, an email for account recovery, basic profile fields) unless the document ties them to unusual extra uses, retention, or sharing you should call out separately.
-- Mere factual statements of how the service works when they are standard and not framed as a downside in the documents.
-
-Do include when supported: unusually broad data use, weak or one-sided legal terms (e.g. liability caps, forced venue), sensitive categories, third-party flows that add real exposure, or practices that materially limit recourse or control.
-
-Each entry should tie to what the documents say and the practical implication neutral, specific language, not hype.
-
-Examples (when actually in the documents):
-- "Photos and videos you upload may be used to train AI models with no opt-out stated"
-- "The Terms require disputes in a specific jurisdiction, which may be inconvenient depending on where you live"
-- "Location data is shared with named advertising partners for ad delivery"
+5-7 meaningful risks actually stated in documents. Skip normal category requirements (phone for messaging, email for accounts) unless tied to unusual processing. Include: unusually broad data use, one-sided legal terms, sensitive categories, third-party flows adding real exposure.
 
 ## BENEFITS
-Up to 8 specific protections or user-friendly practices the documents actually describe. Do not invent or inflate. This balances `dangers` include genuine positives (e.g. encryption claims, data-sale disclaimers, retention limits) when the text supports them.
-
-Examples:
-- "The policy states messages are end-to-end encrypted so the provider cannot read content"
-- "A published list names categories of partners who receive data"
+Up to 8 specific protections the documents actually describe. Balance dangers with genuine positives (encryption, data-sale disclaimers, retention limits).
 
 ## RECOMMENDED ACTIONS
-Up to 8 practical next steps that help someone use the product informedly — settings to review, policies to read if they care about a topic, or choices the documents highlight. Prefer guidance over fear. Include exact navigation paths, URLs, or contact details when available.
-Example: "If you use ad personalisation, review Settings > Ads > Manage Preferences and adjust what you share"
+Up to 8 practical next steps with exact navigation paths/URLs/contact details.
 
 ## PRIVACY SIGNALS
-Synthesize from all documents. When documents conflict, use the more conservative value.
+Synthesize from all documents. Use conservative value on conflict.
 
 ## COMPLIANCE
-Score each regulation 0-10 across all documents combined. Use null when evidence is insufficient.
+Score each regulation 0-10 across all documents. Use null when evidence is insufficient.
 
 ## CONTRADICTIONS
-List every meaningful inconsistency between documents. This is valuable information — users and compliance teams need it.
-Example: "Privacy Policy states data is not sold to third parties; Terms of Service permits sharing with 'commercial partners for business purposes' — these statements may conflict on whether revenue-generating data transfers constitute a sale."
-
----
+List every meaningful inconsistency between documents with verbatim statements and practical impact.
 
 Return valid JSON strictly matching this schema:
 {PRODUCT_OVERVIEW_JSON_SCHEMA}

--- a/packages/backend/src/services/extraction_service.py
+++ b/packages/backend/src/services/extraction_service.py
@@ -30,7 +30,12 @@ from typing import Any, cast
 from pydantic import BaseModel, Field
 
 from src.core.logging import get_logger
-from src.llm import SupportedModel, acompletion_with_fallback
+from src.llm import (
+    EscalationValidator,
+    SupportedModel,
+    acompletion_with_escalation,
+    acompletion_with_fallback,
+)
 from src.models.document import (
     Document,
     DocumentExtraction,
@@ -56,6 +61,45 @@ from src.models.document import (
 from src.utils.cancellation import CancellationToken
 
 logger = get_logger(__name__)
+
+_EXTRACTION_RESILIENCE: list[SupportedModel] = ["gemini-2.5-flash"]
+_EXTRACTION_PRIMARY: list[SupportedModel] = ["gpt-5-mini"] + _EXTRACTION_RESILIENCE
+_EXTRACTION_ESCALATION: list[SupportedModel] = ["gpt-5.4-mini"] + _EXTRACTION_RESILIENCE
+
+_COMPLEX_DOC_LENGTH_THRESHOLD: int = 50_000
+_COMPLEX_DOC_TYPES: frozenset[str] = frozenset(
+    {"terms_of_service", "data_processing_agreement", "terms_and_conditions"}
+)
+
+_CLUSTER_REQUIRED_KEYS: dict[str, list[str]] = {
+    "data_practices": [
+        "data_collected",
+        "data_purposes",
+        "retention_policies",
+        "security_measures",
+    ],
+    "sharing_transfers": ["third_party_details", "international_transfers", "government_access"],
+    "rights_ai": ["user_rights", "consent_mechanisms", "account_lifecycle", "ai_usage"],
+    "legal_scope": ["liability", "dispute_resolution", "content_ownership", "scope_expansion"],
+}
+
+
+def _extraction_validator(cluster_name: str) -> EscalationValidator:
+    required = _CLUSTER_REQUIRED_KEYS.get(cluster_name, [])
+
+    def validate(content: str) -> bool:
+        try:
+            data = json.loads(content)
+            if required and not all(k in data for k in required):
+                return False
+            return any(
+                isinstance(data.get(k), list) and len(data[k]) > 0
+                for k in (required if required else data)
+            )
+        except (json.JSONDecodeError, AttributeError):
+            return False
+
+    return validate
 
 
 # ---------------------------------------------------------------------------
@@ -1372,7 +1416,6 @@ async def extract_document_facts(
     document: Document,
     *,
     use_cache: bool = True,
-    model_priority: list[SupportedModel] | None = None,
     cancellation_token: CancellationToken | None = None,
 ) -> DocumentExtraction:
     """Extract evidence-backed facts from a document.
@@ -1384,10 +1427,7 @@ async def extract_document_facts(
       4. legal_scope: liability, disputes, content ownership, scope, indemnification, termination
     """
     token = cancellation_token or CancellationToken()
-    logger.debug(
-        f"Starting v4 extraction for document {document.id} "
-        f"(use_cache={use_cache}, model_priority={model_priority})"
-    )
+    logger.debug(f"Starting v4 extraction for document {document.id} (use_cache={use_cache})")
 
     content_hash = (
         document.metadata.get("content_hash") if document.metadata else None
@@ -1449,16 +1489,37 @@ async def extract_document_facts(
         logger.debug(
             f"Running cluster '{cluster_name}' for {document.id} chunk {chunk_idx}/{len(chunks)}"
         )
-        response = await acompletion_with_fallback(
-            messages=[
-                {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
-                {
-                    "role": "user",
-                    "content": _get_extraction_prompt(document, chunk_text, cluster_name),
-                },
-            ],
-            model_priority=model_priority,
-            response_format={"type": "json_object"},
+        is_complex = (
+            len(document.text) > _COMPLEX_DOC_LENGTH_THRESHOLD
+            or document.doc_type in _COMPLEX_DOC_TYPES
+        )
+        messages = [
+            {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": _get_extraction_prompt(document, chunk_text, cluster_name),
+            },
+        ]
+        if is_complex:
+            response = await acompletion_with_fallback(
+                messages,
+                model_priority=_EXTRACTION_ESCALATION,
+                response_format={"type": "json_object"},
+            )
+        else:
+            response = await acompletion_with_escalation(
+                messages=messages,
+                primary=_EXTRACTION_PRIMARY,
+                escalation=_EXTRACTION_ESCALATION,
+                validator=_extraction_validator(cluster_name),
+                response_format={"type": "json_object"},
+            )
+        logger.info(
+            "Cluster '%s' for %s chunk %d completed with model %s",
+            cluster_name,
+            document.id,
+            chunk_idx,
+            response.model,
         )
         choice = response.choices[0]
         if not hasattr(choice, "message"):

--- a/packages/backend/src/services/extraction_service.py
+++ b/packages/backend/src/services/extraction_service.py
@@ -90,6 +90,8 @@ def _extraction_validator(cluster_name: str) -> EscalationValidator:
     def validate(content: str) -> bool:
         try:
             data = json.loads(content)
+            if not isinstance(data, dict):
+                return False
             if required and not all(k in data for k in required):
                 return False
             return any(
@@ -1485,14 +1487,16 @@ async def extract_document_facts(
 
     accumulated_signals = PrivacySignals()
 
+    _is_complex = (
+        len(document.text or "") > _COMPLEX_DOC_LENGTH_THRESHOLD
+        or document.doc_type in _COMPLEX_DOC_TYPES
+    )
+
     async def _run_cluster(cluster_name: str, chunk_text: str, chunk_idx: int) -> dict[str, Any]:
         logger.debug(
             f"Running cluster '{cluster_name}' for {document.id} chunk {chunk_idx}/{len(chunks)}"
         )
-        is_complex = (
-            len(document.text) > _COMPLEX_DOC_LENGTH_THRESHOLD
-            or document.doc_type in _COMPLEX_DOC_TYPES
-        )
+        is_complex = _is_complex
         messages = [
             {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
             {
@@ -1501,6 +1505,8 @@ async def extract_document_facts(
             },
         ]
         if is_complex:
+            # Complex docs go straight to the escalation model. No validation step:
+            # there is no higher-tier model to escalate to, so we accept the response.
             response = await acompletion_with_fallback(
                 messages,
                 model_priority=_EXTRACTION_ESCALATION,

--- a/packages/backend/src/services/extraction_service.py
+++ b/packages/backend/src/services/extraction_service.py
@@ -62,9 +62,11 @@ from src.utils.cancellation import CancellationToken
 
 logger = get_logger(__name__)
 
-_EXTRACTION_RESILIENCE: list[SupportedModel] = ["gemini-2.5-flash"]
-_EXTRACTION_PRIMARY: list[SupportedModel] = ["gpt-5-mini"] + _EXTRACTION_RESILIENCE
-_EXTRACTION_ESCALATION: list[SupportedModel] = ["gpt-5.4-mini"] + _EXTRACTION_RESILIENCE
+_EXTRACTION_RESILIENCE: list[SupportedModel] = ["openrouter/deepseek-v4-flash"]
+_EXTRACTION_PRIMARY: list[SupportedModel] = [
+    "openrouter/gpt-oss-120b-nitro"
+] + _EXTRACTION_RESILIENCE
+_EXTRACTION_ESCALATION: list[SupportedModel] = ["openrouter/deepseek-v4-flash"]
 
 _COMPLEX_DOC_LENGTH_THRESHOLD: int = 50_000
 _COMPLEX_DOC_TYPES: frozenset[str] = frozenset(

--- a/packages/backend/tests/unit/analysis_validator_test.py
+++ b/packages/backend/tests/unit/analysis_validator_test.py
@@ -63,3 +63,25 @@ def test_analysis_validator_fails_empty_scores() -> None:
         }
     )
     assert _analysis_validator(content) is False
+
+
+def test_analysis_validator_fails_when_scores_have_bare_integer_values() -> None:
+    content = json.dumps(
+        {
+            "summary": "This policy collects data.",
+            "scores": {"transparency": 7},
+            "verdict": "moderate",
+        }
+    )
+    assert _analysis_validator(content) is False
+
+
+def test_analysis_validator_fails_whitespace_only_summary() -> None:
+    content = json.dumps(
+        {
+            "summary": "   ",
+            "scores": {"transparency": {"score": 7, "justification": "ok"}},
+            "verdict": "moderate",
+        }
+    )
+    assert _analysis_validator(content) is False

--- a/packages/backend/tests/unit/analysis_validator_test.py
+++ b/packages/backend/tests/unit/analysis_validator_test.py
@@ -1,0 +1,65 @@
+import json
+
+from src.analyser import _analysis_validator
+
+
+def test_analysis_validator_passes_valid_response() -> None:
+    content = json.dumps(
+        {
+            "summary": "This policy collects email addresses.",
+            "scores": {
+                "transparency": {"score": 7, "justification": "clear"},
+                "data_collection_scope": {"score": 4, "justification": "broad"},
+            },
+            "verdict": "moderate",
+            "keypoints": [],
+            "critical_clauses": [],
+        }
+    )
+    assert _analysis_validator(content) is True
+
+
+def test_analysis_validator_fails_on_invalid_json() -> None:
+    assert _analysis_validator("not json") is False
+
+
+def test_analysis_validator_fails_missing_summary() -> None:
+    content = json.dumps(
+        {
+            "scores": {"transparency": {"score": 7, "justification": "ok"}},
+            "verdict": "moderate",
+        }
+    )
+    assert _analysis_validator(content) is False
+
+
+def test_analysis_validator_fails_empty_summary() -> None:
+    content = json.dumps(
+        {
+            "summary": "",
+            "scores": {"transparency": {"score": 7, "justification": "ok"}},
+            "verdict": "moderate",
+        }
+    )
+    assert _analysis_validator(content) is False
+
+
+def test_analysis_validator_fails_missing_scores() -> None:
+    content = json.dumps(
+        {
+            "summary": "This policy does things.",
+            "verdict": "moderate",
+        }
+    )
+    assert _analysis_validator(content) is False
+
+
+def test_analysis_validator_fails_empty_scores() -> None:
+    content = json.dumps(
+        {
+            "summary": "This policy does things.",
+            "scores": {},
+            "verdict": "moderate",
+        }
+    )
+    assert _analysis_validator(content) is False

--- a/packages/backend/tests/unit/extraction_validator_test.py
+++ b/packages/backend/tests/unit/extraction_validator_test.py
@@ -1,0 +1,84 @@
+import json
+
+from src.services.extraction_service import _extraction_validator
+
+
+def test_extraction_validator_passes_valid_data_practices() -> None:
+    content = json.dumps(
+        {
+            "data_collected": [{"label": "email", "evidence": "we collect email"}],
+            "data_purposes": [],
+            "retention_policies": [],
+            "security_measures": [],
+            "cookies_and_trackers": [],
+        }
+    )
+    assert _extraction_validator("data_practices")(content) is True
+
+
+def test_extraction_validator_fails_on_invalid_json() -> None:
+    assert _extraction_validator("data_practices")("not json") is False
+
+
+def test_extraction_validator_fails_when_all_lists_empty() -> None:
+    content = json.dumps(
+        {
+            "data_collected": [],
+            "data_purposes": [],
+            "retention_policies": [],
+            "security_measures": [],
+            "cookies_and_trackers": [],
+        }
+    )
+    assert _extraction_validator("data_practices")(content) is False
+
+
+def test_extraction_validator_fails_missing_required_keys() -> None:
+    content = json.dumps({"some_other_key": [{"label": "foo"}]})
+    assert _extraction_validator("data_practices")(content) is False
+
+
+def test_extraction_validator_passes_valid_sharing_transfers() -> None:
+    content = json.dumps(
+        {
+            "third_party_details": [{"name": "Google", "evidence": "shared with Google"}],
+            "international_transfers": [],
+            "government_access": [],
+            "corporate_family_sharing": [],
+        }
+    )
+    assert _extraction_validator("sharing_transfers")(content) is True
+
+
+def test_extraction_validator_passes_valid_rights_ai() -> None:
+    content = json.dumps(
+        {
+            "user_rights": [{"right_type": "access", "evidence": "you may access"}],
+            "consent_mechanisms": [],
+            "account_lifecycle": [],
+            "ai_usage": [],
+        }
+    )
+    assert _extraction_validator("rights_ai")(content) is True
+
+
+def test_extraction_validator_passes_valid_legal_scope() -> None:
+    content = json.dumps(
+        {
+            "liability": [{"limitation": "no liability", "evidence": "..."}],
+            "dispute_resolution": [],
+            "content_ownership": [],
+            "scope_expansion": [],
+            "indemnification": [],
+            "termination_consequences": [],
+            "dangers": [],
+            "benefits": [],
+            "recommended_actions": [],
+        }
+    )
+    assert _extraction_validator("legal_scope")(content) is True
+
+
+def test_extraction_validator_unknown_cluster_accepts_any_non_empty_json() -> None:
+    content = json.dumps({"anything": [1, 2, 3]})
+    assert _extraction_validator("unknown_cluster")(content) is True

--- a/packages/backend/tests/unit/extraction_validator_test.py
+++ b/packages/backend/tests/unit/extraction_validator_test.py
@@ -82,3 +82,9 @@ def test_extraction_validator_passes_valid_legal_scope() -> None:
 def test_extraction_validator_unknown_cluster_accepts_any_non_empty_json() -> None:
     content = json.dumps({"anything": [1, 2, 3]})
     assert _extraction_validator("unknown_cluster")(content) is True
+
+
+def test_extraction_validator_fails_on_non_dict_json() -> None:
+    assert _extraction_validator("data_practices")("[]") is False
+    assert _extraction_validator("data_practices")('"a string"') is False
+    assert _extraction_validator("data_practices")("42") is False

--- a/packages/backend/tests/unit/llm_escalation_test.py
+++ b/packages/backend/tests/unit/llm_escalation_test.py
@@ -38,6 +38,39 @@ def test_extract_json_from_response_raises_on_none_content() -> None:
         _extract_json_from_response(resp)
 
 
+def test_extract_json_from_response_raises_on_none_message() -> None:
+    resp = MagicMock(spec=ModelResponse)
+    choice = MagicMock()
+    choice.message = None
+    resp.choices = [choice]
+    with pytest.raises(ValueError, match="None"):
+        _extract_json_from_response(resp)
+
+
+@pytest.mark.asyncio
+async def test_escalation_escalates_when_primary_returns_empty_content() -> None:
+    primary_response = _make_response("", model="gpt-5-mini")
+    escalation_response = _make_response('{"data": [1]}', model="gpt-5.4-mini")
+
+    call_count = 0
+
+    async def mock_fallback(messages, model_priority, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return primary_response if call_count == 1 else escalation_response
+
+    with patch("src.llm.acompletion_with_fallback", side_effect=mock_fallback):
+        result = await acompletion_with_escalation(
+            messages=[{"role": "user", "content": "test"}],
+            primary=["gpt-5-mini"],
+            escalation=["gpt-5.4-mini"],
+            validator=lambda c: True,
+        )
+
+    assert result is escalation_response
+    assert call_count == 2
+
+
 @pytest.mark.asyncio
 async def test_escalation_returns_primary_when_valid() -> None:
     primary_response = _make_response('{"ok": true}', model="gpt-5-mini")

--- a/packages/backend/tests/unit/llm_escalation_test.py
+++ b/packages/backend/tests/unit/llm_escalation_test.py
@@ -1,0 +1,103 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from litellm import ModelResponse
+
+from src.llm import _extract_json_from_response, acompletion_with_escalation
+
+
+def _make_response(content: str, model: str = "gpt-5-mini") -> ModelResponse:
+    response = MagicMock(spec=ModelResponse)
+    response.model = model
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    response.choices = [choice]
+    return response
+
+
+def test_extract_json_from_response_returns_content() -> None:
+    response = _make_response('{"key": "value"}')
+    assert _extract_json_from_response(response) == '{"key": "value"}'
+
+
+def test_extract_json_from_response_raises_on_empty_content() -> None:
+    response = _make_response("")
+    with pytest.raises(ValueError, match="empty"):
+        _extract_json_from_response(response)
+
+
+def test_extract_json_from_response_raises_on_none_content() -> None:
+    resp = MagicMock(spec=ModelResponse)
+    choice = MagicMock()
+    choice.message.content = None
+    resp.choices = [choice]
+    with pytest.raises(ValueError):
+        _extract_json_from_response(resp)
+
+
+@pytest.mark.asyncio
+async def test_escalation_returns_primary_when_valid() -> None:
+    primary_response = _make_response('{"ok": true}', model="gpt-5-mini")
+
+    with patch("src.llm.acompletion_with_fallback", new_callable=AsyncMock) as mock_fb:
+        mock_fb.return_value = primary_response
+        result = await acompletion_with_escalation(
+            messages=[{"role": "user", "content": "test"}],
+            primary=["gpt-5-mini"],
+            escalation=["gpt-5.4-mini"],
+            validator=lambda c: True,
+        )
+
+    assert result is primary_response
+    assert mock_fb.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_escalation_calls_escalation_model_when_primary_invalid() -> None:
+    primary_response = _make_response("{}", model="gpt-5-mini")
+    escalation_response = _make_response('{"data": [1]}', model="gpt-5.4-mini")
+
+    call_count = 0
+
+    async def mock_fallback(messages, model_priority, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return primary_response if call_count == 1 else escalation_response
+
+    with patch("src.llm.acompletion_with_fallback", side_effect=mock_fallback):
+        result = await acompletion_with_escalation(
+            messages=[{"role": "user", "content": "test"}],
+            primary=["gpt-5-mini"],
+            escalation=["gpt-5.4-mini"],
+            validator=lambda c: json.loads(c).get("data") is not None,
+        )
+
+    assert result is escalation_response
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_escalation_returns_escalated_response_even_when_both_fail_validation() -> None:
+    primary_response = _make_response("{}", model="gpt-5-mini")
+    escalation_response = _make_response("{}", model="gpt-5.4-mini")
+
+    call_count = 0
+
+    async def mock_fallback(messages, model_priority, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return primary_response if call_count == 1 else escalation_response
+
+    with patch("src.llm.acompletion_with_fallback", side_effect=mock_fallback):
+        result = await acompletion_with_escalation(
+            messages=[{"role": "user", "content": "test"}],
+            primary=["gpt-5-mini"],
+            escalation=["gpt-5.4-mini"],
+            validator=lambda c: False,
+        )
+
+    assert result is escalation_response
+    assert call_count == 2

--- a/packages/frontend/components/dashboard/sources-list.tsx
+++ b/packages/frontend/components/dashboard/sources-list.tsx
@@ -75,6 +75,14 @@ interface DocumentRiskBreakdown {
   missing_information: string[];
 }
 
+interface DocumentSection {
+  section_title: string;
+  content: string;
+  importance: "low" | "medium" | "high" | "critical";
+  analysis: string;
+  related_clauses: string[];
+}
+
 interface DocumentSummary {
   id: string;
   title: string | null;
@@ -88,6 +96,7 @@ interface DocumentSummary {
   keypoints_with_evidence?: KeypointWithEvidence[] | null;
   critical_clauses?: CriticalClause[] | null;
   document_risk_breakdown?: DocumentRiskBreakdown | null;
+  key_sections?: DocumentSection[] | null;
 }
 
 interface SourcesListProps {
@@ -274,6 +283,7 @@ export function SourcesList({ productSlug, documents }: SourcesListProps) {
           const displayKeypoints = doc.keypoints ?? [];
           const displayKeypointsWithEvidence = doc.keypoints_with_evidence;
           const displayCriticalClauses = doc.critical_clauses ?? [];
+          const displayKeySections = doc.key_sections ?? [];
           const riskBreakdown = doc.document_risk_breakdown;
 
           const evidenceByKeypoint = new Map<string, EvidenceSpan[]>();
@@ -433,6 +443,7 @@ export function SourcesList({ productSlug, documents }: SourcesListProps) {
                       {!displaySummary &&
                         displayKeypoints.length === 0 &&
                         displayCriticalClauses.length === 0 &&
+                        displayKeySections.length === 0 &&
                         !riskBreakdown && (
                           <p className="py-4 text-sm text-muted-foreground text-center">
                             No analysis available for this document yet.
@@ -442,6 +453,7 @@ export function SourcesList({ productSlug, documents }: SourcesListProps) {
                       {(displaySummary ||
                         displayKeypoints.length > 0 ||
                         displayCriticalClauses.length > 0 ||
+                        displayKeySections.length > 0 ||
                         !!riskBreakdown) && (
                         <div className="space-y-4">
                           {/* Summary */}
@@ -564,6 +576,58 @@ export function SourcesList({ productSlug, documents }: SourcesListProps) {
                                       </div>
                                     );
                                   })}
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Key sections */}
+                          {displayKeySections.length > 0 && (
+                            <div>
+                              <h5 className="text-[10px] font-bold text-violet-700 dark:text-violet-300 uppercase tracking-widest mb-2 flex items-center gap-2">
+                                <span className="h-px w-4 bg-violet-300 dark:bg-violet-700" />
+                                Key Sections
+                              </h5>
+                              <div className="space-y-2">
+                                {displayKeySections.slice(0, 5).map((section, i) => {
+                                  const importanceColors = {
+                                    critical: "border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/20",
+                                    high: "border-orange-200 dark:border-orange-900 bg-orange-50/50 dark:bg-orange-950/20",
+                                    medium: "border-yellow-200 dark:border-yellow-900 bg-yellow-50/50 dark:bg-yellow-950/20",
+                                    low: "border-border bg-card/50",
+                                  };
+                                  const importanceDotColors = {
+                                    critical: "bg-red-400",
+                                    high: "bg-orange-400",
+                                    medium: "bg-yellow-400",
+                                    low: "bg-muted-foreground",
+                                  };
+                                  return (
+                                    <div
+                                      key={i}
+                                      className={cn(
+                                        "rounded-md border p-3",
+                                        importanceColors[section.importance] ?? importanceColors.low,
+                                      )}
+                                    >
+                                      <div className="flex items-center gap-2 mb-1.5">
+                                        <span className={cn("h-2 w-2 rounded-full shrink-0", importanceDotColors[section.importance] ?? importanceDotColors.low)} />
+                                        <span className="text-xs font-semibold text-foreground/90">
+                                          {section.section_title}
+                                        </span>
+                                      </div>
+                                      {section.analysis && (
+                                        <p className="text-xs text-foreground/80 leading-snug mb-2 ml-4">
+                                          {section.analysis}
+                                        </p>
+                                      )}
+                                      {section.content && (
+                                        <blockquote className="text-xs leading-relaxed text-foreground/70 border-l-2 border-current/30 pl-2 ml-4 italic">
+                                          &ldquo;{section.content}&rdquo;
+                                        </blockquote>
+                                      )}
+                                    </div>
+                                  );
+                                })}
                               </div>
                             </div>
                           )}


### PR DESCRIPTION
## Summary

- Adds `acompletion_with_escalation` — calls a cheap primary model, validates the response structure, and escalates to a better model only on validation failure (partial data beats blocking the pipeline)
- Introduces per-service model constants and `EscalationValidator` type; removes the shared `DEFAULT_MODEL_PRIORITY` from targeted services
- Switches all pipeline phases to OpenRouter models, organized by price/quality tier

## Model routing

| Phase | Primary | Resilience | Escalation |
|---|---|---|---|
| Extraction (simple) | `gpt-oss-120b:nitro` $0.039/M | `deepseek-v4-flash` $0.14/M | `deepseek-v4-flash` |
| Extraction (complex >50KB) | `deepseek-v4-flash` directly | — | — |
| Analysis (simple) | `gpt-oss-120b:nitro` | `deepseek-v4-flash` | `grok-4.1-fast` $0.20/M |
| Analysis (complex) | `grok-4.1-fast` directly | `deepseek-v4-flash` | — |
| Classification | `gpt-oss-120b:nitro` | `deepseek-v4-flash` | — |
| Overview / Deep analysis | `gpt-oss-120b:nitro` | `deepseek-v4-flash` | — |

`grok-4.1-fast` (OpenRouter's #1 ranked legal model) is reserved for analysis only — extraction is JSON structure work, not legal reasoning.

## Cost estimate

Blended per-document cost across a typical document mix:

| Scale | Total | Per-doc |
|---|---|---|
| 1 doc | ~$0.008 | $0.008 |
| 50 docs | ~$0.30 | $0.006 |
| 100 docs | ~$0.60 | $0.006 |
| 500 docs | ~$2.97 | $0.006 |
| 1 000 docs | ~$5.94 | $0.006 |

Simple privacy policy (~10KB): $0.003. Full ToS / DPA (~90KB, complex path): $0.031.

## What changed

- `src/llm.py` — `EscalationValidator`, `_extract_json_from_response`, `acompletion_with_escalation`; three new `_OPENROUTER_ALIASES` entries
- `src/services/extraction_service.py` — per-cluster `EscalationValidator`, complexity routing, OpenRouter model constants
- `src/analyser.py` — `_analysis_validator`, complexity routing wired to `should_use_reasoning_model`, explicit priority for overview/aggregate
- `src/document_processor.py` — explicit `_CLASSIFICATION_PRIORITY` (resilience only, no quality gate)
- `scripts/benchmark_pipeline.py` — standalone harness to compare escalation vs. baseline cost/quality
- `.gitignore` — excludes `superpowers/` planning artifacts

## Test plan

- [ ] 25 unit tests pass (`llm_escalation_test`, `extraction_validator_test`, `analysis_validator_test`)
- [ ] Run `uv run pytest` — full suite green
- [ ] Smoke test with a real document through the pipeline; verify `response.model` logs show expected model names
- [ ] Run `scripts/benchmark_pipeline.py` on a sample corpus to confirm escalation rate < 30% and cost vs. baseline