### PR TITLE
fix: auth middleware 401→500 bug + authenticated SSR prefetch

### DIFF
--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -2,8 +2,9 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import structlog
-from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi import FastAPI, Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
 
 from src.core.config import config
 from src.core.jwt import clerk_auth_service
@@ -57,7 +58,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         # No valid authentication found
-        raise HTTPException(status_code=401, detail="Authorization required")
+        return JSONResponse(status_code=401, content={"detail": "Authorization required"})
 
     def _is_whitelisted(self, request: Request) -> bool:
         """Check if the request path is whitelisted"""

--- a/packages/backend/tests/unit/core/middleware_test.py
+++ b/packages/backend/tests/unit/core/middleware_test.py
@@ -227,9 +227,6 @@ class TestDispatchFlow:
         mock_config.app.is_development = False
         request = _make_request(path="/products", headers={}, client_host="1.2.3.4")
 
-        from fastapi import HTTPException
-
         call_next = AsyncMock()
-        with pytest.raises(HTTPException) as exc:
-            await middleware.dispatch(request, call_next)
-        assert exc.value.status_code == 401
+        response = await middleware.dispatch(request, call_next)
+        assert response.status_code == 401

--- a/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
@@ -1,12 +1,13 @@
+import { auth } from "@clerk/nextjs/server";
+
 import { getBackendUrl } from "@lib/config";
 import type { Product } from "@/types";
 
 import CompanyPage from "./product-page-client";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function fetchPublic(url: string): Promise<any> {
+async function fetchWithAuth(url: string, headers: HeadersInit): Promise<unknown> {
   try {
-    const res = await fetch(url, { next: { revalidate: 300 } });
+    const res = await fetch(url, { headers });
     if (!res.ok) return null;
     return res.json();
   } catch {
@@ -21,17 +22,23 @@ export default async function ProductPage({
 }) {
   const { slug } = await params;
 
+  const { getToken } = await auth();
+  const token = (await getToken({ template: "default" })) ?? (await getToken());
+  const headers: HeadersInit = token ? { Authorization: `Bearer ${token}` } : {};
+
   const [initialProduct, initialData, initialDocuments] = await Promise.all([
-    fetchPublic(getBackendUrl(`/products/${slug}`)),
-    fetchPublic(getBackendUrl(`/products/${slug}/overview`)),
-    fetchPublic(getBackendUrl(`/products/${slug}/documents`)),
+    fetchWithAuth(getBackendUrl(`/products/${slug}`), headers),
+    fetchWithAuth(getBackendUrl(`/products/${slug}/overview`), headers),
+    fetchWithAuth(getBackendUrl(`/products/${slug}/documents`), headers),
   ]);
 
   return (
     <CompanyPage
       initialProduct={initialProduct as Product | null}
-      initialData={initialData}
-      initialDocuments={initialDocuments ?? []}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialData={initialData as any}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialDocuments={(initialDocuments as any[]) ?? []}
     />
   );
 }

--- a/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { getBackendUrl } from "@lib/config";
 import type { Product } from "@/types";
 
-import CompanyPage from "./product-page-client";
+import CompanyPage, { type DocumentSummary, type ProductOverview } from "./product-page-client";
 
 async function fetchWithAuth(url: string, headers: HeadersInit): Promise<unknown> {
   try {
@@ -23,7 +23,7 @@ export default async function ProductPage({
   const { slug } = await params;
 
   const { getToken } = await auth();
-  const token = (await getToken({ template: "default" })) ?? (await getToken());
+  const token = await getToken();
   const headers: HeadersInit = token ? { Authorization: `Bearer ${token}` } : {};
 
   const [initialProduct, initialData, initialDocuments] = await Promise.all([
@@ -35,10 +35,8 @@ export default async function ProductPage({
   return (
     <CompanyPage
       initialProduct={initialProduct as Product | null}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      initialData={initialData as any}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      initialDocuments={(initialDocuments as any[]) ?? []}
+      initialData={initialData as ProductOverview | null}
+      initialDocuments={(initialDocuments as DocumentSummary[]) ?? []}
     />
   );
 }

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -71,7 +71,7 @@ interface CoverageItem {
   notes?: string | null;
 }
 
-interface ProductOverview {
+export interface ProductOverview {
   product_name: string;
   product_slug: string;
   company_name?: string | null;
@@ -103,7 +103,7 @@ interface ProductOverview {
   contract_clauses?: string[] | null;
 }
 
-interface DocumentSummary {
+export interface DocumentSummary {
   id: string;
   title: string | null;
   url: string;


### PR DESCRIPTION
## Summary

- **Backend:** Replace `raise HTTPException` with `return JSONResponse` in `AuthMiddleware.dispatch` — Starlette's `BaseHTTPMiddleware` wraps exceptions in an anyio `ExceptionGroup` that FastAPI's exception handlers can't process, silently converting 401s into 500s
- **Frontend:** Update product `page.tsx` SSR to use `auth()` from Clerk to get the user's token before calling the backend — previously used `fetchPublic` with no auth headers, which always failed in production (only worked in dev via localhost bypass), meaning SSR never pre-loaded any data

## Test plan

- [ ] Unauthenticated request to a protected backend route returns 401 (not 500)
- [ ] Product page loads without a skeleton flash when authenticated (SSR pre-fetches data)
- [ ] Product page still renders correctly via client-side fallback when token is unavailable
- [ ] Backend logs no longer show ASGI `ExceptionGroup` errors for auth failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)