### PR TITLE
feat(pipeline): truthful crawl/analysis failures, server-side product pagination, extension usage limit

### DIFF
--- a/packages/backend/scripts/ship_health_check.py
+++ b/packages/backend/scripts/ship_health_check.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Ship-readiness health check for Clausea's analysis pipeline.
+
+Read-only diagnostic. Queries the live MongoDB and prints a single-screen
+status report covering the five ship-readiness gates defined in
+docs/superpowers/specs/2026-05-25-ship-readiness-design.md.
+
+Usage:
+    uv run python scripts/ship_health_check.py
+    uv run python scripts/ship_health_check.py --json
+
+Exit code:
+    0  all five ship gates green (SHIP_FOUNDATION_GREEN)
+    1  at least one gate red
+    2  could not query the database
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from src.core.database import db_session  # noqa: E402
+
+# Ship-readiness thresholds (mirrored from the design doc).
+MIN_PRODUCTS_WITH_OVERVIEW = 30
+MAX_OVERVIEWS_MISSING_REQUIRED_FIELDS = 0
+MAX_DOCUMENTS_WITH_EMPTY_TEXT = 0
+MAX_PIPELINE_FAILURE_RATE = 0.10
+EMPTY_TEXT_THRESHOLD_CHARS = 500
+PIPELINE_LOOKBACK_DAYS = 7
+
+# Fields on the stored MetaSummary in the product_overviews collection.
+# The API later transforms summary → one_line_summary (product_service.py:475).
+# We measure the underlying storage shape, not the API shape.
+REQUIRED_OVERVIEW_FIELDS = (
+    "summary",
+    "verdict",
+    "keypoints",
+    "data_collected",
+    "your_rights",
+    "dangers",
+)
+
+
+async def collect_metrics() -> dict[str, Any]:
+    """Run all the read-only queries and assemble the report payload."""
+    async with db_session() as db:
+        products_total = await db.products.count_documents({})
+        documents_total = await db.documents.count_documents({})
+
+        # Coverage gates.
+        products_with_documents = len(await db.documents.distinct("product_id"))
+        product_overview_count = await db.product_overviews.count_documents({})
+
+        # Empty-text documents — a doc that crawled but holds no real policy text.
+        documents_with_empty_text = await db.documents.count_documents(
+            {
+                "$or": [
+                    {"text": {"$exists": False}},
+                    {"text": ""},
+                    {"text": None},
+                    {
+                        "$expr": {
+                            "$lt": [
+                                {"$strLenCP": {"$ifNull": ["$text", ""]}},
+                                EMPTY_TEXT_THRESHOLD_CHARS,
+                            ]
+                        }
+                    },
+                ]
+            }
+        )
+
+        # Overviews missing required fields.
+        overviews_missing_fields: list[dict[str, Any]] = []
+        async for ov in db.product_overviews.find(
+            {}, {"product_slug": 1, **dict.fromkeys(REQUIRED_OVERVIEW_FIELDS, 1)}
+        ):
+            missing = [f for f in REQUIRED_OVERVIEW_FIELDS if not ov.get(f)]
+            if missing:
+                overviews_missing_fields.append(
+                    {"product_slug": ov.get("product_slug"), "missing": missing}
+                )
+
+        # Pipeline jobs in the last N days.
+        lookback = datetime.now(UTC) - timedelta(days=PIPELINE_LOOKBACK_DAYS)
+        jobs_recent = await db.pipeline_jobs.count_documents({"updated_at": {"$gte": lookback}})
+        jobs_recent_failed = await db.pipeline_jobs.count_documents(
+            {"updated_at": {"$gte": lookback}, "status": "failed"}
+        )
+        jobs_recent_completed = await db.pipeline_jobs.count_documents(
+            {"updated_at": {"$gte": lookback}, "status": "completed"}
+        )
+
+        # Top failure reasons (across all time — recent samples are sparse).
+        error_counter: Counter[str] = Counter()
+        async for job in db.pipeline_jobs.find(
+            {"status": "failed"}, {"error": 1, "product_slug": 1}
+        ):
+            err = (job.get("error") or "unknown")[:120]
+            error_counter[err] += 1
+
+        # Orphaned running jobs older than 30 minutes.
+        orphan_cutoff = datetime.now(UTC) - timedelta(minutes=30)
+        orphaned_running = await db.pipeline_jobs.count_documents(
+            {"status": "running", "updated_at": {"$lt": orphan_cutoff}}
+        )
+
+        # Per-stage signal: how many documents have analysis vs extraction.
+        docs_with_extraction = await db.documents.count_documents({"extraction": {"$ne": None}})
+        docs_with_analysis = await db.documents.count_documents({"analysis": {"$ne": None}})
+
+    failure_rate = jobs_recent_failed / jobs_recent if jobs_recent else 0.0
+
+    gates = {
+        "products_with_overview": {
+            "value": product_overview_count,
+            "threshold": f">= {MIN_PRODUCTS_WITH_OVERVIEW}",
+            "green": product_overview_count >= MIN_PRODUCTS_WITH_OVERVIEW,
+        },
+        "overviews_missing_required_fields": {
+            "value": len(overviews_missing_fields),
+            "threshold": f"== {MAX_OVERVIEWS_MISSING_REQUIRED_FIELDS}",
+            "green": len(overviews_missing_fields) <= MAX_OVERVIEWS_MISSING_REQUIRED_FIELDS,
+        },
+        "documents_with_empty_text": {
+            "value": documents_with_empty_text,
+            "threshold": f"== {MAX_DOCUMENTS_WITH_EMPTY_TEXT} (< {EMPTY_TEXT_THRESHOLD_CHARS} chars)",
+            "green": documents_with_empty_text <= MAX_DOCUMENTS_WITH_EMPTY_TEXT,
+        },
+        "pipeline_failure_rate_7d": {
+            "value": round(failure_rate, 3),
+            "threshold": f"< {MAX_PIPELINE_FAILURE_RATE}",
+            "green": failure_rate < MAX_PIPELINE_FAILURE_RATE if jobs_recent else False,
+            "note": "no recent jobs" if not jobs_recent else None,
+        },
+        "no_orphaned_running_jobs": {
+            "value": orphaned_running,
+            "threshold": "== 0 older than 30 min",
+            "green": orphaned_running == 0,
+        },
+    }
+
+    return {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "totals": {
+            "products_total": products_total,
+            "documents_total": documents_total,
+            "products_with_documents": products_with_documents,
+            "documents_with_extraction": docs_with_extraction,
+            "documents_with_analysis": docs_with_analysis,
+            "product_overviews": product_overview_count,
+        },
+        "pipeline_jobs_last_7d": {
+            "total": jobs_recent,
+            "failed": jobs_recent_failed,
+            "completed": jobs_recent_completed,
+            "failure_rate": round(failure_rate, 3),
+        },
+        "top_failure_reasons": error_counter.most_common(10),
+        "overviews_missing_fields": overviews_missing_fields,
+        "orphaned_running_jobs": orphaned_running,
+        "gates": gates,
+        "all_green": all(g["green"] for g in gates.values()),
+    }
+
+
+def format_human(report: dict[str, Any]) -> str:
+    """Render the report as a single-screen status block."""
+    out: list[str] = []
+    out.append("=" * 72)
+    out.append("Clausea Ship-Readiness Health Check")
+    out.append(report["timestamp"])
+    out.append("=" * 72)
+
+    t = report["totals"]
+    out.append("")
+    out.append("Catalog")
+    out.append(f"  products_total           : {t['products_total']}")
+    out.append(f"  products_with_documents  : {t['products_with_documents']}")
+    out.append(f"  documents_total          : {t['documents_total']}")
+    out.append(f"  documents_with_extraction: {t['documents_with_extraction']}")
+    out.append(f"  documents_with_analysis  : {t['documents_with_analysis']}")
+    out.append(f"  product_overviews        : {t['product_overviews']}")
+
+    pj = report["pipeline_jobs_last_7d"]
+    out.append("")
+    out.append(f"Pipeline jobs (last {PIPELINE_LOOKBACK_DAYS}d)")
+    out.append(
+        f"  total: {pj['total']:>3}  completed: {pj['completed']:>3}  "
+        f"failed: {pj['failed']:>3}  failure_rate: {pj['failure_rate']}"
+    )
+
+    if report["top_failure_reasons"]:
+        out.append("")
+        out.append("Top failure reasons (all time)")
+        for reason, count in report["top_failure_reasons"]:
+            out.append(f"  [{count:>3}x] {reason}")
+
+    if report["overviews_missing_fields"]:
+        out.append("")
+        out.append("Overviews missing required fields")
+        for ov in report["overviews_missing_fields"]:
+            out.append(f"  {ov['product_slug']}: missing {', '.join(ov['missing'])}")
+
+    if report["orphaned_running_jobs"]:
+        out.append("")
+        out.append(f"Orphaned `running` jobs > 30 min: {report['orphaned_running_jobs']}")
+
+    out.append("")
+    out.append("Ship gates")
+    for name, gate in report["gates"].items():
+        symbol = "GREEN" if gate["green"] else "RED  "
+        note = f" ({gate['note']})" if gate.get("note") else ""
+        out.append(f"  [{symbol}] {name:<36} = {gate['value']:<8} (need {gate['threshold']}){note}")
+
+    out.append("")
+    if report["all_green"]:
+        out.append("SHIP_FOUNDATION_GREEN")
+    else:
+        out.append("NOT SHIP-READY")
+    out.append("=" * 72)
+    return "\n".join(out)
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    args = parser.parse_args()
+
+    try:
+        report = await collect_metrics()
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: could not collect metrics: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, default=str, indent=2))
+    else:
+        print(format_human(report))
+
+    return 0 if report["all_green"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -181,15 +181,17 @@ async def analyse_product_documents(
                 )
 
     # return_exceptions=True so a sibling raise (e.g. CancelledError) doesn't
-    # mask the in-flight successful ones. Re-raise CancelledError below to
-    # preserve cancellation semantics.
+    # mask the in-flight successful ones. Per-document failures are already
+    # caught inside _analyse_one, so anything that escapes to gather is either
+    # cancellation or a harness bug (cancellation check / progress callback) —
+    # re-raise both rather than swallowing them.
     results = await asyncio.gather(
         *[_analyse_one(i, doc) for i, doc in enumerate(documents, 1)],
         return_exceptions=True,
     )
-    for r in results:
-        if isinstance(r, asyncio.CancelledError):
-            raise r
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
 
     succeeded = total_docs - len(failed_doc_ids)
     if failed_doc_ids:

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -69,12 +69,26 @@ from src.utils.llm_usage import UsageTracker, log_usage_summary, usage_tracking
 load_dotenv()
 logger = get_logger(__name__)
 
-_ANALYSIS_RESILIENCE: list[SupportedModel] = ["openrouter/deepseek-v4-flash"]
-_ANALYSIS_PRIMARY: list[SupportedModel] = ["openrouter/gpt-oss-120b-nitro"] + _ANALYSIS_RESILIENCE
-_ANALYSIS_ESCALATION: list[SupportedModel] = ["openrouter/grok-4.1-fast"] + _ANALYSIS_RESILIENCE
+# Cheap, fast, reliable structured-output models spanning four providers. Policy
+# analysis is structured extraction, not frontier reasoning, so small models suffice.
+# Spanning providers means a single model deprecation or provider outage (as happened
+# when openrouter/grok-4.1-fast was deprecated) can no longer break analysis.
+# Mid-tier, cross-provider models. Structured policy extraction needs real capability:
+# tiny models (gemini-flash-lite, gpt-5-nano) run fast/cheap but produce wrong analyses
+# (e.g. "data collection not specified" on a detailed policy). These three are capable
+# enough for reliable extraction while still cheap, and span three providers so a single
+# model deprecation or provider outage cannot break analysis.
+_ANALYSIS_RESILIENCE: list[SupportedModel] = [
+    "openrouter/gpt-oss-120b-nitro",  # OpenRouter (120B, capable)
+    "gpt-5-mini",  # OpenAI
+]
+_ANALYSIS_PRIMARY: list[SupportedModel] = ["gemini-2.5-flash"] + _ANALYSIS_RESILIENCE
+# Escalation leads with a stronger model for harder documents.
+_ANALYSIS_ESCALATION: list[SupportedModel] = ["gpt-5-mini"] + _ANALYSIS_RESILIENCE
 _OVERVIEW_PRIORITY: list[SupportedModel] = [
+    "gemini-2.5-flash",
     "openrouter/gpt-oss-120b-nitro",
-    "openrouter/deepseek-v4-flash",
+    "gpt-5-mini",
 ]
 
 
@@ -133,6 +147,8 @@ async def analyse_product_documents(
 
     sem = asyncio.Semaphore(3)
 
+    failed_doc_ids: list[str] = []
+
     async def _analyse_one(index: int, doc: Document) -> None:
         await token.check_cancellation()
         async with sem:
@@ -150,9 +166,39 @@ async def analyse_product_documents(
             except asyncio.CancelledError:
                 logger.info(f"Summarization cancelled at document {index}/{total_docs}")
                 raise
+            except Exception as exc:
+                # Per-document failure isolation: one bad document must not block
+                # the rest of the product from getting its overview. Log loudly so
+                # the failure is visible to operators, but allow sibling tasks to
+                # complete. The overview stage downstream filters by doc.analysis,
+                # so this doc simply contributes nothing rather than poisoning the
+                # whole product.
+                failed_doc_ids.append(doc.id)
+                logger.error(
+                    f"✗ Document analysis raised for {doc.id} ({doc.url}): "
+                    f"{exc.__class__.__name__}: {exc}",
+                    exc_info=True,
+                )
 
-    await asyncio.gather(*[_analyse_one(i, doc) for i, doc in enumerate(documents, 1)])
-    logger.info(f"✓ Successfully analysed all {total_docs} documents for {product_slug}")
+    # return_exceptions=True so a sibling raise (e.g. CancelledError) doesn't
+    # mask the in-flight successful ones. Re-raise CancelledError below to
+    # preserve cancellation semantics.
+    results = await asyncio.gather(
+        *[_analyse_one(i, doc) for i, doc in enumerate(documents, 1)],
+        return_exceptions=True,
+    )
+    for r in results:
+        if isinstance(r, asyncio.CancelledError):
+            raise r
+
+    succeeded = total_docs - len(failed_doc_ids)
+    if failed_doc_ids:
+        logger.warning(
+            f"⚠ Analysed {succeeded}/{total_docs} documents for {product_slug}; "
+            f"{len(failed_doc_ids)} failed: {failed_doc_ids}"
+        )
+    else:
+        logger.info(f"✓ Successfully analysed all {total_docs} documents for {product_slug}")
     return documents
 
 
@@ -1008,6 +1054,17 @@ async def generate_product_overview(
                 "benefits": [b.value for b in doc.extraction.benefits],
             }
         doc_inputs.append(entry)
+
+    # Refuse to synthesise an overview when no document was successfully analysed.
+    # With no analysed input the model fabricates a confident but false verdict
+    # (e.g. "no documents supplied", risk_score 0, verdict very_pervasive) that reads
+    # like a real assessment. Raise instead so the pipeline marks the job failed rather
+    # than publishing a misleading overview.
+    if not doc_inputs:
+        raise ValueError(
+            f"Cannot generate overview for {product_slug}: none of {len(core_docs)} "
+            "core document(s) have analysis (upstream document analysis failed)."
+        )
 
     # Include cross-document conflicts from the aggregation engine.
     # These are deterministically detected facts (e.g., one doc says data is not sold,

--- a/packages/backend/src/core/config.py
+++ b/packages/backend/src/core/config.py
@@ -173,6 +173,11 @@ class CrawlerConfig:
 
         # --- Concurrency & politeness ---
         self.concurrent_limit: int = int(os.getenv("CRAWLER_CONCURRENT_LIMIT", "20"))
+        # Browser (Camoufox) renders share a single browser instance per crawler, so a
+        # handful of concurrent JS-heavy page loads can starve each other (every goto
+        # then hits the navigation timeout). Throttle browser renders well below the
+        # static-fetch concurrency.
+        self.browser_concurrency: int = int(os.getenv("CRAWLER_BROWSER_CONCURRENCY", "2"))
         self.delay_between_requests: float = float(
             os.getenv("CRAWLER_DELAY_BETWEEN_REQUESTS", "1.0")
         )

--- a/packages/backend/src/core/db_indexes.py
+++ b/packages/backend/src/core/db_indexes.py
@@ -61,6 +61,16 @@ async def ensure_product_indexes(db: AgnosticDatabase) -> None:
         else:
             logger.warning(f"Could not create index on products.domains: {e}")
 
+    try:
+        await collection.create_index("name", name="idx_product_name", background=True)
+        logger.info("Created index on products.name")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "already exists" in error_msg:
+            logger.debug("Index on products.name already exists")
+        else:
+            logger.warning(f"Could not create index on products.name: {e}")
+
 
 async def ensure_document_indexes(db: AgnosticDatabase) -> None:
     """Ensure indexes exist on the documents collection.

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -245,6 +245,22 @@ class URLScorer:
         # Compile word extraction pattern once
         self.word_pattern = re.compile(r"\b\w+\b")
 
+        # "terms" used as glossary/terminology (e.g. /chess/terms/absolute-pin,
+        # /glossary/terms/foo) rather than legal "Terms of Service". Matches when
+        # "terms" is a non-terminal mid-path segment followed by a slug that is NOT a
+        # legal qualifier. Such pages score as high as a real /terms page otherwise,
+        # because both the "/terms/" path pattern and the "terms" keyword fire.
+        self._glossary_terms_re = re.compile(
+            r"/[^/]+/terms/"
+            r"(?!service|use|conditions|sale|payment|payments|business|"
+            r"general|user|website|privacy|cookie|cookies|policy|of-|and-)"
+            r"[^/]+",
+            re.IGNORECASE,
+        )
+        # Total weight contributed by a "/terms/" path-pattern match (4.5) plus the
+        # "terms" keyword match (4.0); removed when the glossary guard fires.
+        self._terms_signal_weight = 8.5
+
         self.legal_keywords = {
             # Generic legal terms
             "legal": 3.5,
@@ -387,6 +403,12 @@ class URLScorer:
                     ):
                         score += weight * 0.8
                         scored_keywords.add(keyword)
+
+        # Demote glossary/terminology pages whose only legal signal is "terms" used
+        # in a non-legal sense (e.g. /chess/terms/absolute-pin). Without this they
+        # score identically to a real /terms page and flood the crawl.
+        if self._glossary_terms_re.search(path):
+            score -= self._terms_signal_weight
 
         return max(0.0, score)
 
@@ -1098,6 +1120,7 @@ class ClauseaCrawler:
         max_retries: int = 3,  # Maximum retry attempts for transient errors
         log_file_path: str | None = None,  # Optional path to log file for crawl session
         use_browser: bool = False,  # Whether to use a headless browser for dynamic rendering
+        browser_concurrency: int = 2,  # Max concurrent browser renders (shared browser instance)
         proxy: str | None = None,  # Optional proxy URL (e.g., "http://user:pass@host:port")
         allowed_paths: list[str] | None = None,  # Optional list of allowed path regexes
         denied_paths: list[str] | None = None,  # Optional list of denied path regexes
@@ -1147,6 +1170,10 @@ class ClauseaCrawler:
         self.max_retries = max_retries
         self.log_file_path = log_file_path
         self.use_browser = use_browser
+        self.browser_concurrency = max(1, browser_concurrency)
+        # Throttles concurrent Camoufox renders, which all share one browser instance.
+        # Created lazily in the running loop (see _browser_render_slot).
+        self._browser_semaphore: asyncio.Semaphore | None = None
         self.proxy = proxy
         self.allowed_paths = allowed_paths
         self.denied_paths = denied_paths
@@ -1194,6 +1221,15 @@ class ClauseaCrawler:
         self.url_stack: list[tuple[str, int]] = []  # For DFS
         self.url_priority_queue: list[tuple[float, str, int]] = []  # For best-first (scored URLs)
         self._sitemap_seeded: bool = False  # True when sitemaps provided seed URLs
+        # Best policy-relevance score assigned to each queued URL (anchor-aware).
+        # Consulted by the browser-fetch gate so opaque policy URLs discovered via
+        # anchor text still get a browser render when needed.
+        self._url_scores: dict[str, float] = {}
+        # URLs that are speculative guesses (generate_potential_policy_urls), not real
+        # discovered links. They must NOT each trigger an expensive browser render:
+        # SPA catch-all sites return a 200 shell for every guessed path, so escalating
+        # all ~80 guesses to the browser floods the shared instance and trips bot defenses.
+        self._speculative_urls: set[str] = set()
         self.results: list[CrawlResult] = []
         self.stats = CrawlStats()
 
@@ -1458,8 +1494,14 @@ class ClauseaCrawler:
         # Secondary check: if the extracted markdown body is effectively empty the
         # page is almost certainly a JS SPA shell — the raw text came from nav/JSON
         # but the policy content isn't there. Trigger a browser retry.
+        #
+        # Threshold is 400 (not 200) so the body that survives this gate will still
+        # clear the downstream processor gate, which demands text-after-strip >= 300
+        # in pipeline._process_crawl_result. See tests/unit/threshold_mismatch_test.py
+        # for the regression fixture; changing one threshold without the other will
+        # re-open the silent-skip class of bugs that motivated this constant.
         markdown = page.markdown or ""
-        if len(markdown.strip()) < 200:
+        if len(markdown.strip()) < 400:
             return False
         return True
 
@@ -1793,6 +1835,12 @@ class ClauseaCrawler:
         "context or browser has been closed",
         "browser closed",
     )
+
+    def _browser_render_slot(self) -> asyncio.Semaphore:
+        """Browser-render semaphore, created on first use so it binds to the running loop."""
+        if self._browser_semaphore is None:
+            self._browser_semaphore = asyncio.Semaphore(self.browser_concurrency)
+        return self._browser_semaphore
 
     async def _browser_fetch(self, url: str) -> PageContent | None:
         """Fetch page with Camoufox headless browser, returning PageContent or None on failure."""
@@ -2724,6 +2772,65 @@ class ClauseaCrawler:
 
             page = await self._extract_page_content(raw, effective_url)
 
+            # The static result is unusable when the content type is unsupported / the
+            # body is empty (page is None — e.g. a 406/403 bot block returns no usable
+            # body) OR when it parsed but is too thin (a JS-rendered SPA shell).
+            static_unusable = page is None or not self._content_is_sufficient(page, effective_url)
+
+            # Speculative guessed URLs never escalate to the browser — see _speculative_urls.
+            is_speculative = self.normalize_url(url) in self._speculative_urls
+
+            if static_unusable and self.use_browser and not is_speculative:
+                # Only spend an expensive browser render (full navigation + hydration,
+                # up to the navigation timeout) on pages that plausibly host a policy
+                # document. JS-heavy marketing/app pages (e.g. /course/*) are also
+                # content-insufficient, but rendering them burns a full timeout for a
+                # page we don't want anyway. Honour anchor-aware scores recorded at
+                # queue time so opaque policy URLs still get rendered.
+                relevance = max(
+                    self._url_scores.get(self.normalize_url(url), 0.0),
+                    self.url_scorer.score_url(effective_url),
+                )
+                if relevance >= self.min_legal_score:
+                    reason = "blocked/empty" if page is None else "insufficient"
+                    logger.info(f"🔄 Static content {reason}, trying browser: {effective_url}")
+                    # Limit concurrent renders — all share one Camoufox instance, and too
+                    # many simultaneous JS-heavy navigations starve each other into timeouts.
+                    async with self._browser_render_slot():
+                        browser_page = await self._browser_fetch(effective_url)
+                    if browser_page is not None and self._content_is_sufficient(
+                        browser_page, effective_url
+                    ):
+                        # The browser may have followed additional redirects / JS
+                        # navigations; prefer its resolved URL if available.
+                        browser_resolved = browser_page.metadata.pop("_browser_resolved_url", None)
+                        if browser_resolved and browser_resolved != effective_url:
+                            effective_url = browser_resolved
+                            self.visited_urls.add(self.normalize_url(effective_url))
+                        return self._build_crawl_result(effective_url, browser_page)
+                    # Policy-relevant but neither static nor browser produced usable content.
+                    logger.warning(
+                        f"⚠️ Browser render did not yield usable content: {effective_url}"
+                    )
+                    return CrawlResult(
+                        url=effective_url,
+                        title=(browser_page.title if browser_page else ""),
+                        content="",
+                        markdown="",
+                        metadata=(browser_page.metadata if browser_page else {}),
+                        status_code=(browser_page.status_code if browser_page else raw.status_code),
+                        success=False,
+                        error_message="Static content unusable and browser rendering failed",
+                    )
+                if page is not None:
+                    # Not policy-relevant but we parsed something — keep the static content
+                    # (cheap) so its links can still be followed.
+                    logger.info(
+                        f"⏭️  Skipping browser render for low-relevance page "
+                        f"(score {relevance:.2f} < {self.min_legal_score}): {effective_url}"
+                    )
+                    return self._build_crawl_result(effective_url, page)
+
             if page is None:
                 return CrawlResult(
                     url=effective_url,
@@ -2735,42 +2842,6 @@ class ClauseaCrawler:
                     success=False,
                     error_message=f"Unsupported content type: {raw.content_type}",
                 )
-
-            if not self._content_is_sufficient(page, effective_url) and self.use_browser:
-                logger.info(f"🔄 Static content insufficient, trying browser: {effective_url}")
-                browser_page = await self._browser_fetch(effective_url)
-                if browser_page is not None:
-                    if not self._content_is_sufficient(browser_page, effective_url):
-                        logger.warning(f"⚠️ Browser content still insufficient: {effective_url}")
-                        return CrawlResult(
-                            url=effective_url,
-                            title=browser_page.title,
-                            content="",
-                            markdown="",
-                            metadata=browser_page.metadata,
-                            status_code=browser_page.status_code,
-                            success=False,
-                            error_message="Browser rendered content is still insufficient",
-                        )
-                    # The browser may have followed additional redirects / JS
-                    # navigations; prefer its resolved URL if available.
-                    browser_resolved = browser_page.metadata.pop("_browser_resolved_url", None)
-                    if browser_resolved and browser_resolved != effective_url:
-                        effective_url = browser_resolved
-                        self.visited_urls.add(self.normalize_url(effective_url))
-                    page = browser_page
-                else:
-                    logger.warning(f"⚠️ Browser and static fetch both failed for: {effective_url}")
-                    return CrawlResult(
-                        url=effective_url,
-                        title=page.title if page else "",
-                        content="",
-                        markdown="",
-                        metadata=page.metadata if page else {},
-                        status_code=page.status_code if page else 0,
-                        success=False,
-                        error_message="Static content insufficient and browser rendering failed",
-                    )
 
             return self._build_crawl_result(effective_url, page)
 
@@ -3059,6 +3130,13 @@ class ClauseaCrawler:
 
         return 0.0
 
+    def _remember_score(self, url: str, score: float) -> None:
+        """Record the best (highest) policy-relevance score seen for a URL."""
+        key = self.normalize_url(url)
+        prev = self._url_scores.get(key)
+        if prev is None or score > prev:
+            self._url_scores[key] = score
+
     def add_urls_to_queue(
         self,
         links: list[dict[str, str]],
@@ -3108,6 +3186,11 @@ class ClauseaCrawler:
             if not self.should_crawl_url(url, base_url, depth + 1):
                 continue
 
+            # Compute the anchor-aware relevance score once (cheap, lru-cached) for all
+            # strategies and remember it so the browser-fetch gate can honour it later.
+            score = self.url_scorer.score_url(url, anchor_text=anchor_text) + parent_boost
+            self._remember_score(url, score)
+
             self.queued_urls.add(url)
             if self.strategy == "bfs":
                 self.url_queue.append((url, depth + 1))
@@ -3116,7 +3199,6 @@ class ClauseaCrawler:
                 self.url_stack.append((url, depth + 1))
                 logger.debug(f"Added to DFS stack: {url} (depth: {depth + 1})")
             elif self.strategy == "best_first":
-                score = self.url_scorer.score_url(url, anchor_text=anchor_text) + parent_boost
                 if score < self.min_legal_score:
                     logger.debug(
                         f"Skipping URL below min_legal_score ({score:.2f} < {self.min_legal_score}): {url}"
@@ -3150,6 +3232,12 @@ class ClauseaCrawler:
                 if not self.should_crawl_url(url, base_url, 1):
                     continue
 
+                # Generated policy URLs are policy-relevant by construction; record a
+                # score so the browser-fetch gate will render them if needed.
+                score = self.url_scorer.score_url(url, anchor_text=None)
+                self._remember_score(url, score)
+                self._speculative_urls.add(normalized)
+
                 self.queued_urls.add(url)
                 if self.strategy == "bfs":
                     self.url_queue.append((url, 1))
@@ -3158,7 +3246,6 @@ class ClauseaCrawler:
                     self.url_stack.append((url, 1))
                     logger.debug(f"Added potential legal URL to DFS stack: {url}")
                 elif self.strategy == "best_first":
-                    score = self.url_scorer.score_url(url, anchor_text=None)
                     heapq.heappush(self.url_priority_queue, (-score, url, 1))
                     logger.debug(
                         f"Added potential legal URL to Best-First queue: {url} (score: {score:.2f})"
@@ -3205,8 +3292,13 @@ class ClauseaCrawler:
             base_url = self.normalize_url(base_url)
             self.stats = CrawlStats()
 
-            # Add base URL to queue
+            # Add base URL to queue. Base URLs are explicit seeds (crawl_base_urls) and
+            # are always crawled regardless of score; record a generous score so the
+            # browser-fetch gate never blocks rendering a seed page.
             self.queued_urls.add(base_url)
+            self._remember_score(
+                base_url, max(self.url_scorer.score_url(base_url), self.min_legal_score)
+            )
             if self.strategy == "bfs":
                 self.url_queue.append((base_url, 0))
                 logger.debug(f"Added base URL to BFS queue: {base_url} (depth: 0)")
@@ -3229,21 +3321,35 @@ class ClauseaCrawler:
                 try:
                     sitemap_urls = await self._discover_sitemap_urls(session, base_url)
                     seeded = 0
+                    skipped_irrelevant = 0
                     for url in sitemap_urls:
                         if not self.should_crawl_url(url, base_url, 0):
                             continue
+                        # Sitemap entries are speculative bulk seeds with no anchor-text
+                        # context. A large sitemap (e.g. thousands of course/product pages)
+                        # would otherwise flood the queue and waste crawl budget + browser
+                        # renders on non-policy pages. Only seed policy-relevant URLs —
+                        # the same gate discovered links pass through. If none qualify,
+                        # _sitemap_seeded stays False and speculative path probing kicks in.
+                        score = self.url_scorer.score_url(url, anchor_text=None)
+                        if score < self.min_legal_score:
+                            skipped_irrelevant += 1
+                            continue
+                        self._remember_score(url, score)
                         self.queued_urls.add(url)
                         if self.strategy == "bfs":
                             self.url_queue.append((url, 0))
                         elif self.strategy == "dfs":
                             self.url_stack.append((url, 0))
                         elif self.strategy == "best_first":
-                            score = self.url_scorer.score_url(url, anchor_text=None)
                             heapq.heappush(self.url_priority_queue, (-score, url, 0))
                         seeded += 1
                     if seeded:
                         self._sitemap_seeded = True
-                        logger.info(f"🗺️  Seeded {seeded} URLs from sitemaps (depth 0)")
+                    logger.info(
+                        f"🗺️  Seeded {seeded} policy-relevant URLs from sitemaps (depth 0); "
+                        f"skipped {skipped_irrelevant} non-policy"
+                    )
                 except Exception:
                     logger.debug("Sitemap discovery failed; continuing without sitemap")
 

--- a/packages/backend/src/models/document.py
+++ b/packages/backend/src/models/document.py
@@ -3,7 +3,14 @@ from datetime import datetime
 from typing import Any, Literal, get_args
 
 import shortuuid
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 TierRelevance = Literal["core", "extended"]
 
@@ -775,6 +782,22 @@ class DocumentRiskBreakdown(BaseModel):
     risk_by_category: dict[str, int] = Field(
         default_factory=dict
     )  # {"data_sharing": 8, "retention": 5}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _derive_overall_risk(cls, data: Any) -> Any:
+        """Tolerate cheaper models that omit overall_risk but provide per-category risks.
+
+        Without this, a single missing nested field discards the entire document
+        analysis. When overall_risk is absent we derive it from risk_by_category
+        (mean), falling back to a neutral 5 only when no category signal exists.
+        """
+        if isinstance(data, dict) and data.get("overall_risk") in (None, ""):
+            categories = data.get("risk_by_category") or {}
+            values = [v for v in categories.values() if isinstance(v, int | float)]
+            data["overall_risk"] = round(sum(values) / len(values)) if values else 5
+        return data
+
     top_concerns: list[str] = Field(default_factory=list)  # Specific concerns
     positive_protections: list[str] = Field(default_factory=list)  # Good practices
     missing_information: list[str] = Field(default_factory=list)  # What's not mentioned

--- a/packages/backend/src/models/pipeline_job.py
+++ b/packages/backend/src/models/pipeline_job.py
@@ -50,6 +50,28 @@ class CrawlError(BaseModel):
     error_type: CrawlErrorType = "unknown"
 
 
+CrawlSkipReason = Literal[
+    "insufficient_content",
+    "garbled_content",
+    "low_legal_score",
+    "non_policy_classification",
+    "non_english",
+]
+
+
+class CrawlSkip(BaseModel):
+    """A single URL that was fetched without error but dropped by a pipeline filter.
+
+    Distinct from CrawlError — these are pages we got, looked at, and decided not to
+    store. Knowing which filter rejected which URL is essential for diagnosing why
+    a pipeline finishes with zero stored documents despite a successful crawl.
+    """
+
+    url: str
+    reason: CrawlSkipReason
+    detail: str | None = None  # e.g. "text=212 chars", "legal_score=0.18", "locale=fr-FR"
+
+
 class PipelineStep(BaseModel):
     """Status of an individual pipeline step."""
 
@@ -95,3 +117,9 @@ class PipelineJob(BaseModel):
 
     # Per-URL crawl failures (e.g. robots.txt blocks, HTTP errors)
     crawl_errors: list[CrawlError] = Field(default_factory=list)
+
+    # Per-URL silent skips: pages we fetched OK but rejected by a filter.
+    # Populated by pipeline._process_crawl_result. Used to produce a
+    # categorized failure message when crawl_errors is empty but the
+    # pipeline still found no policy documents.
+    crawl_skip_reasons: list[CrawlSkip] = Field(default_factory=list)

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -52,6 +52,7 @@ import tracemalloc
 from collections.abc import Awaitable, Callable
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
@@ -96,6 +97,29 @@ def _content_fingerprint(text: str) -> str:
     return hashlib.md5(normalized[:5000].encode()).hexdigest()
 
 
+# Locale path segment (/es/, /fr/, /pt-br/, /en_US/) or locale subdomain (es., de.).
+# Used only to prefer a canonical URL when collapsing same-content duplicates — the
+# collapse decision itself is content-based, so genuinely different regional policies
+# (different text) are never merged.
+_LOCALE_PATH_RE = re.compile(r"^/[a-z]{2}([-_][a-z]{2})?(/|$)", re.IGNORECASE)
+_LOCALE_HOST_RE = re.compile(r"^[a-z]{2}([-_][a-z]{2})?\.", re.IGNORECASE)
+
+
+def _canonical_rank(url: str) -> tuple[int, int]:
+    """Lower rank = more canonical. Prefers non-locale URLs, then shorter paths.
+
+    Ensures that when several URLs serve identical content (e.g. /privacy and
+    /es/privacy), the locale-neutral one is kept as the representative.
+    """
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    path = parsed.path or "/"
+    looks_locale = bool(_LOCALE_PATH_RE.match(path)) or (
+        bool(_LOCALE_HOST_RE.match(host)) and not host.startswith("www.")
+    )
+    return (1 if looks_locale else 0, len(path))
+
+
 class ProcessingStats(BaseModel):
     """Statistics for document processing pipeline."""
 
@@ -117,6 +141,12 @@ class ProcessingStats(BaseModel):
 
     # Per-URL crawl failures collected during the pipeline run
     crawl_errors: list[dict[str, Any]] = Field(default_factory=list)
+
+    # Per-URL silent skips — pages fetched OK but rejected by a filter
+    # (e.g. insufficient_content, low_legal_score, non_policy_classification).
+    # Mirrors models.pipeline_job.CrawlSkip; kept as dicts here to avoid an
+    # import cycle.
+    crawl_skip_reasons: list[dict[str, Any]] = Field(default_factory=list)
 
     @property
     def success_rate(self) -> float:
@@ -728,6 +758,7 @@ class PolicyDocumentPipeline:
             max_parallel_products if max_parallel_products is not None else c.max_parallel_products
         )
         self.use_browser = use_browser if use_browser is not None else c.use_browser
+        self.browser_concurrency = c.browser_concurrency
         self.proxy = proxy if proxy is not None else c.proxy
         self.fallback_min_legal_score = (
             fallback_min_legal_score
@@ -824,6 +855,7 @@ class PolicyDocumentPipeline:
             strategy=strategy or self.crawler_strategy,
             log_file_path=log_file_path,
             use_browser=self.use_browser,
+            browser_concurrency=self.browser_concurrency,
             proxy=self.proxy,
             allowed_paths=product.crawl_allowed_paths,
             denied_paths=product.crawl_denied_paths,
@@ -844,6 +876,14 @@ class PolicyDocumentPipeline:
         updated_count = 0
         duplicate_count = 0
         error_count = 0
+
+        # Process canonical (locale-neutral, shorter) URLs first so they win as the
+        # representative when collapsing same-content locale variants.
+        documents = sorted(documents, key=lambda d: _canonical_rank(d.url))
+        # (product_id, content fingerprint) -> URL kept for that content. Lets us collapse
+        # locale variants that serve identical policy text (e.g. /privacy and /es/privacy)
+        # while keeping genuinely different regional policies (different text → different fp).
+        seen_fingerprints: dict[tuple[str | None, str], str] = {}
 
         async with db_session() as db:
             document_service = create_document_service()
@@ -895,7 +935,31 @@ class PolicyDocumentPipeline:
                             )
                             self.stats.duplicates_skipped += 1
                             duplicate_count += 1
+                        if document.text and document.text.strip():
+                            seen_fingerprints[
+                                (document.product_id, _content_fingerprint(document.text))
+                            ] = document.url
                     else:
+                        # Collapse same-content locale variants: if another doc for this
+                        # product already holds identical policy text at a different URL,
+                        # skip this one. Different regional policies have different text and
+                        # therefore a different fingerprint, so they are never merged.
+                        if document.text and document.text.strip():
+                            fp_key = (
+                                document.product_id,
+                                _content_fingerprint(document.text),
+                            )
+                            kept_url = seen_fingerprints.get(fp_key)
+                            if kept_url and kept_url != document.url:
+                                logger_storage.info(
+                                    f"collapsing same-content variant {document.url} "
+                                    f"(identical to {kept_url})"
+                                )
+                                self.stats.duplicates_skipped += 1
+                                duplicate_count += 1
+                                continue
+                            seen_fingerprints[fp_key] = document.url
+
                         # Create new document
                         logger_storage.info(f"storing new document: {document.url}")
                         await document_service.store_document(db, document)
@@ -935,19 +999,37 @@ class PolicyDocumentPipeline:
 
             # Skip empty or very short content without wasting LLM calls
             if not text_content or len(text_content.strip()) < 300:
-                logger_analysis.debug(f"skipping document with insufficient content: {result.url}")
+                text_len = len(text_content.strip()) if text_content else 0
+                self.stats.crawl_skip_reasons.append(
+                    {
+                        "url": result.url,
+                        "reason": "insufficient_content",
+                        "detail": f"text={text_len} chars",
+                    }
+                )
+                logger_analysis.info(
+                    f"[skip:insufficient_content] {result.url} (text={text_len} chars)"
+                )
                 return None
 
             # Skip garbled/binary content that slipped through
             if ClauseaCrawler._is_garbled_content(text_content):
-                logger_analysis.debug(
-                    f"skipping document with garbled/binary content: {result.url}"
+                self.stats.crawl_skip_reasons.append(
+                    {"url": result.url, "reason": "garbled_content", "detail": None}
                 )
+                logger_analysis.info(f"[skip:garbled_content] {result.url}")
                 return None
 
             if result.legal_score is not None and result.legal_score < MIN_LEGAL_SCORE_THRESHOLD:
-                logger.debug(
-                    f"Skipping low legal-score page ({result.legal_score:.2f}): {result.url}"
+                self.stats.crawl_skip_reasons.append(
+                    {
+                        "url": result.url,
+                        "reason": "low_legal_score",
+                        "detail": f"legal_score={result.legal_score:.2f}",
+                    }
+                )
+                logger_analysis.info(
+                    f"[skip:low_legal_score] {result.url} (legal_score={result.legal_score:.2f})"
                 )
                 return None
 
@@ -962,10 +1044,18 @@ class PolicyDocumentPipeline:
 
             # Skip pages that are not policy documents
             if not classification.get("is_policy_document", False):
-                logger_analysis.debug(f"skipping non-policy document: {result.url}")
-                usage_reason = (
-                    f"non-policy classification: {classification.get('classification', 'unknown')}"
+                classification_label = str(classification.get("classification", "unknown"))
+                self.stats.crawl_skip_reasons.append(
+                    {
+                        "url": result.url,
+                        "reason": "non_policy_classification",
+                        "detail": f"classifier={classification_label}",
+                    }
                 )
+                logger_analysis.info(
+                    f"[skip:non_policy_classification] {result.url} (classifier={classification_label})"
+                )
+                usage_reason = f"non-policy classification: {classification_label}"
                 return None
 
             # Detect locale only for policy documents
@@ -982,9 +1072,14 @@ class PolicyDocumentPipeline:
             # Skip non-English documents*
             # TODO: Support other languages
             if "en" not in detected_locale.lower():
-                logger_analysis.debug(
-                    f"skipping non-English document ({detected_locale}): {result.url}"
+                self.stats.crawl_skip_reasons.append(
+                    {
+                        "url": result.url,
+                        "reason": "non_english",
+                        "detail": f"locale={detected_locale}",
+                    }
                 )
+                logger_analysis.info(f"[skip:non_english] {result.url} (locale={detected_locale})")
                 self.stats.non_english_skipped += 1
                 usage_reason = f"non-English locale: {detected_locale}"
                 return None

--- a/packages/backend/src/repositories/document_repository.py
+++ b/packages/backend/src/repositories/document_repository.py
@@ -156,6 +156,42 @@ class DocumentRepository(BaseRepository):
         ).to_list(length=None)
         return [Document(**_normalize_document_record(document)) for document in documents]
 
+    async def find_by_product_id_with_analysis(
+        self, db: AgnosticDatabase, product_id: str
+    ) -> list[Document]:
+        """Get all documents with analysis, excluding heavy body fields (text, markdown, extraction).
+
+        Use this when DocumentSummary fields are needed but the raw text/markdown is not —
+        avoids transferring large body fields over the wire.
+        """
+        projection = {"text": 0, "markdown": 0, "extraction": 0}
+        documents: list[dict[str, Any]] = await db.documents.find(
+            {"product_id": product_id}, projection
+        ).to_list(length=None)
+        for document in documents:
+            document.setdefault("text", "")
+            document.setdefault("markdown", "")
+        return [Document(**_normalize_document_record(document)) for document in documents]
+
+    async def get_compliance_status_by_product(
+        self, db: AgnosticDatabase, product_id: str
+    ) -> list[dict[str, int]]:
+        """Return only the compliance_status maps for a product's documents.
+
+        Tight projection — pulls only ``analysis.compliance_status`` from each document, avoiding
+        the cost of streaming full document bodies just to aggregate one nested field.
+        """
+        projection = {"_id": 0, "analysis.compliance_status": 1}
+        rows: list[dict[str, Any]] = await db.documents.find(
+            {"product_id": product_id, "analysis.compliance_status": {"$exists": True}},
+            projection,
+        ).to_list(length=None)
+        return [
+            row["analysis"]["compliance_status"]
+            for row in rows
+            if row.get("analysis", {}).get("compliance_status")
+        ]
+
     async def find_by_type(self, db: AgnosticDatabase, doc_type: str) -> list[Document]:
         """Get all documents of a specific type.
 
@@ -197,6 +233,13 @@ class DocumentRepository(BaseRepository):
     async def save(self, db: AgnosticDatabase, document: Document) -> Document:
         """Store a document in the database.
 
+        Refuses to persist a Document whose ``text`` AND ``markdown`` are both
+        effectively empty. Such inserts created the 40-empty-doc graveyard in
+        the past — a Document with no source text is useless for analysis and
+        masks crawl bugs by looking superficially valid in MongoDB. Callers
+        that legitimately need to store empty content (none today) should
+        catch ValueError explicitly.
+
         Args:
             db: Database instance
             document: Document to store
@@ -205,8 +248,15 @@ class DocumentRepository(BaseRepository):
             The stored document
 
         Raises:
-            Exception: If storage fails
+            ValueError: If text and markdown are both empty / whitespace.
+            Exception: If storage fails for other reasons.
         """
+        if not (document.text or "").strip() and not (document.markdown or "").strip():
+            raise ValueError(
+                f"Refusing to store empty document {document.id} for url={document.url} "
+                f"(text and markdown are both empty — fix upstream extraction instead "
+                f"of persisting a placeholder)."
+            )
         try:
             document_dict = document.model_dump()
             await db.documents.insert_one(document_dict)
@@ -219,6 +269,13 @@ class DocumentRepository(BaseRepository):
     async def update(self, db: AgnosticDatabase, document: Document) -> bool:
         """Update a document in the database.
 
+        Defensive: callers that load a Document via a projecting reader
+        (e.g. find_by_product_id strips text/markdown to "") and then $set
+        the full model_dump would wipe the stored source text. To prevent
+        that class of round-trip data loss, this method drops empty text /
+        markdown from the update payload when the stored row has content,
+        and logs a warning so the misuse stays visible.
+
         Args:
             db: Database instance
             document: Document to update
@@ -230,9 +287,30 @@ class DocumentRepository(BaseRepository):
             Exception: If update fails
         """
         try:
-            result = await db.documents.update_one(
-                {"id": document.id}, {"$set": document.model_dump()}
-            )
+            document_dict = document.model_dump()
+            incoming_text = document_dict.get("text") or ""
+            incoming_markdown = document_dict.get("markdown") or ""
+
+            if not incoming_text or not incoming_markdown:
+                existing = await db.documents.find_one(
+                    {"id": document.id}, {"text": 1, "markdown": 1}
+                )
+                if existing:
+                    if not incoming_text and (existing.get("text") or ""):
+                        document_dict.pop("text", None)
+                        logger.warning(
+                            "DocumentRepository.update refused to overwrite non-empty "
+                            f"text for document {document.id} with an empty value "
+                            "(caller likely loaded via a projecting reader)."
+                        )
+                    if not incoming_markdown and (existing.get("markdown") or ""):
+                        document_dict.pop("markdown", None)
+                        logger.warning(
+                            "DocumentRepository.update refused to overwrite non-empty "
+                            f"markdown for document {document.id} with an empty value."
+                        )
+
+            result = await db.documents.update_one({"id": document.id}, {"$set": document_dict})
             success = result.modified_count > 0
             if not success:
                 logger.warning(f"No document found with id {document.id} to update")

--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from datetime import datetime
 from typing import Any
 
@@ -148,11 +149,14 @@ class ProductRepository(BaseRepository):
         """
         query: dict[str, Any] = {}
         if search:
+            # Escape so user input is matched literally — raw regex metacharacters
+            # would 500 on invalid patterns or open a ReDoS vector.
+            escaped_search = re.escape(search)
             query = {
                 "$or": [
-                    {"name": {"$regex": search, "$options": "i"}},
-                    {"description": {"$regex": search, "$options": "i"}},
-                    {"categories": {"$regex": search, "$options": "i"}},
+                    {"name": {"$regex": escaped_search, "$options": "i"}},
+                    {"description": {"$regex": escaped_search, "$options": "i"}},
+                    {"categories": {"$regex": escaped_search, "$options": "i"}},
                 ]
             }
         total, items_data = await asyncio.gather(

--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 from typing import Any
 
@@ -125,6 +126,40 @@ class ProductRepository(BaseRepository):
             {"id": {"$in": product_ids}}
         ).to_list(length=None)
         return [Product(**product_data) for product_data in products_data]
+
+    async def find_paginated(
+        self,
+        db: AgnosticDatabase,
+        *,
+        skip: int,
+        limit: int,
+        search: str = "",
+    ) -> tuple[list[Product], int]:
+        """Get a paginated list of products with optional name/description/category search.
+
+        Args:
+            db: Database instance
+            skip: Number of documents to skip
+            limit: Maximum number of documents to return
+            search: Case-insensitive search string matched against name, description, categories
+
+        Returns:
+            Tuple of (products, total_count)
+        """
+        query: dict[str, Any] = {}
+        if search:
+            query = {
+                "$or": [
+                    {"name": {"$regex": search, "$options": "i"}},
+                    {"description": {"$regex": search, "$options": "i"}},
+                    {"categories": {"$regex": search, "$options": "i"}},
+                ]
+            }
+        total, items_data = await asyncio.gather(
+            db.products.count_documents(query),
+            db.products.find(query).sort("name", 1).skip(skip).limit(limit).to_list(length=limit),
+        )
+        return [Product(**p) for p in items_data], total
 
     # ============================================================================
     # Product Overview Storage Operations

--- a/packages/backend/src/routes/extension.py
+++ b/packages/backend/src/routes/extension.py
@@ -10,8 +10,9 @@ from motor.core import AgnosticDatabase
 from pydantic import BaseModel, EmailStr
 
 from src.core.database import get_db
-from src.core.jwt import clerk_auth_service
+from src.core.jwt import get_optional_user
 from src.core.logging import get_logger
+from src.models.clerkUser import ClerkUser
 from src.repositories.pipeline_repository import PipelineRepository
 from src.services.extension_usage import ExtensionUsageService
 from src.services.pipeline_scheduler import schedule_pipeline_run
@@ -23,19 +24,6 @@ from src.services.service_factory import (
 from src.utils.domain import extract_domain
 
 logger = get_logger(__name__)
-
-_extension_usage_svc = ExtensionUsageService()
-
-
-async def _get_optional_user(request: Request) -> dict | None:
-    """Verify Clerk JWT if present; return user dict or None for anonymous."""
-    auth = request.headers.get("Authorization", "")
-    if not auth.startswith("Bearer "):
-        return None
-    try:
-        return await clerk_auth_service.verify_token(auth.split(" ")[1])
-    except Exception:
-        return None
 
 
 router = APIRouter(prefix="/extension", tags=["extension"])
@@ -290,6 +278,7 @@ async def analyze_url(
     payload: ExtensionAnalyzeRequest,
     background_tasks: BackgroundTasks,
     db: AgnosticDatabase = Depends(get_db),
+    user: ClerkUser | None = Depends(get_optional_user),
 ) -> ExtensionAnalyzeResponse:
     """Trigger the analysis pipeline for a URL.
 
@@ -299,8 +288,6 @@ async def analyze_url(
     Idempotent: if a pipeline is already running for this domain, returns the
     existing job. If the product is already fully indexed, reports that.
     """
-    user = await _get_optional_user(request)
-
     if user is None:
         extension_token = request.headers.get("X-Extension-Token", "").strip()
         if not extension_token:
@@ -309,7 +296,7 @@ async def analyze_url(
                 detail="Missing X-Extension-Token header. Update the extension.",
             )
         client_ip = request.client.host if request.client else "unknown"
-        allowed, count = await _extension_usage_svc.check_and_increment(
+        allowed, count = await ExtensionUsageService().check_and_increment(
             db, token=extension_token, ip=client_ip
         )
         if not allowed:

--- a/packages/backend/src/routes/extension.py
+++ b/packages/backend/src/routes/extension.py
@@ -5,13 +5,15 @@ Provides lightweight endpoints optimized for the browser extension popup.
 
 from typing import Literal
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from motor.core import AgnosticDatabase
 from pydantic import BaseModel, EmailStr
 
 from src.core.database import get_db
+from src.core.jwt import clerk_auth_service
 from src.core.logging import get_logger
 from src.repositories.pipeline_repository import PipelineRepository
+from src.services.extension_usage import ExtensionUsageService
 from src.services.pipeline_scheduler import schedule_pipeline_run
 from src.services.service_factory import (
     create_indexation_notification_service,
@@ -21,6 +23,20 @@ from src.services.service_factory import (
 from src.utils.domain import extract_domain
 
 logger = get_logger(__name__)
+
+_extension_usage_svc = ExtensionUsageService()
+
+
+async def _get_optional_user(request: Request) -> dict | None:
+    """Verify Clerk JWT if present; return user dict or None for anonymous."""
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return None
+    try:
+        return await clerk_auth_service.verify_token(auth.split(" ")[1])
+    except Exception:
+        return None
+
 
 router = APIRouter(prefix="/extension", tags=["extension"])
 
@@ -270,6 +286,7 @@ async def get_supported_domains(
 
 @router.post("/analyze", response_model=ExtensionAnalyzeResponse, status_code=202)
 async def analyze_url(
+    request: Request,
     payload: ExtensionAnalyzeRequest,
     background_tasks: BackgroundTasks,
     db: AgnosticDatabase = Depends(get_db),
@@ -282,6 +299,31 @@ async def analyze_url(
     Idempotent: if a pipeline is already running for this domain, returns the
     existing job. If the product is already fully indexed, reports that.
     """
+    user = await _get_optional_user(request)
+
+    if user is None:
+        extension_token = request.headers.get("X-Extension-Token", "").strip()
+        if not extension_token:
+            raise HTTPException(
+                status_code=400,
+                detail="Missing X-Extension-Token header. Update the extension.",
+            )
+        client_ip = request.client.host if request.client else "unknown"
+        allowed, count = await _extension_usage_svc.check_and_increment(
+            db, token=extension_token, ip=client_ip
+        )
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "code": "anonymous_limit_reached",
+                    "uses_allowed": 3,
+                    "uses_used": count,
+                    "requires_auth": True,
+                    "login_url": "https://clausea.co/sign-in",
+                },
+            )
+
     url = payload.url.strip()
     if not url:
         raise HTTPException(status_code=400, detail="URL is required")

--- a/packages/backend/src/routes/extension.py
+++ b/packages/backend/src/routes/extension.py
@@ -25,6 +25,7 @@ from src.utils.domain import extract_domain
 
 logger = get_logger(__name__)
 
+_extension_usage_svc = ExtensionUsageService()
 
 router = APIRouter(prefix="/extension", tags=["extension"])
 
@@ -296,7 +297,7 @@ async def analyze_url(
                 detail="Missing X-Extension-Token header. Update the extension.",
             )
         client_ip = request.client.host if request.client else "unknown"
-        allowed, count = await ExtensionUsageService().check_and_increment(
+        allowed, count = await _extension_usage_svc.check_and_increment(
             db, token=extension_token, ip=client_ip
         )
         if not allowed:

--- a/packages/backend/src/routes/products.py
+++ b/packages/backend/src/routes/products.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from math import ceil
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from motor.core import AgnosticDatabase
 from pydantic import BaseModel, EmailStr
@@ -61,23 +63,27 @@ class IndexationNotifyRequest(BaseModel):
     email: EmailStr
 
 
-@router.get("", response_model=list[Product])
+class ProductsPage(BaseModel):
+    items: list[Product]
+    total: int
+    page: int
+    pages: int
+
+
+@router.get("", response_model=ProductsPage)
 async def get_all_products(
     db: AgnosticDatabase = Depends(get_db),
     service: ProductService = Depends(create_product_service),
-    include_all: bool = Query(
-        default=False,
-        description="If true, returns all products. If false (default), returns only products with at least one document.",
-    ),
-) -> list[Product]:
-    """Get a list of products.
-
-    By default, only returns products that have at least one document.
-    Set include_all=true to get all products regardless of document count.
-    """
-    if include_all:
-        return await service.get_all_products(db)
-    return await service.get_products_with_documents(db)
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=20, ge=1, le=100),
+    search: str = Query(default=""),
+) -> ProductsPage:
+    """Get a paginated list of products with optional search."""
+    products, total = await service.get_products_paginated(
+        db, page=page, limit=limit, search=search
+    )
+    pages = ceil(total / limit) if total > 0 else 1
+    return ProductsPage(items=products, total=total, page=page, pages=pages)
 
 
 @router.get("/{slug}/overview", response_model=ProductOverview)
@@ -102,7 +108,7 @@ async def get_product_overview(
     if not product:
         raise HTTPException(status_code=HTTP_404_NOT_FOUND, detail="Product not found")
 
-    overview = await service.get_product_overview(db, slug)
+    overview = await service.get_product_overview(db, slug, product=product)
     if overview:
         return overview
 

--- a/packages/backend/src/services/aggregation_service.py
+++ b/packages/backend/src/services/aggregation_service.py
@@ -617,7 +617,10 @@ class AggregationService:
     async def rebuild_findings_for_product(
         self, db: AgnosticDatabase, product_id: str
     ) -> list[Finding]:
-        documents = await self._document_repo.find_by_product_id(db, product_id)
+        # Must use the *_full loader: find_by_product_id projects out text/markdown
+        # and replaces them with "". Passing such a partial Document to update()
+        # would $set those empty strings back to MongoDB, wiping the source text.
+        documents = await self._document_repo.find_by_product_id_full(db, product_id)
         all_findings: list[Finding] = []
 
         for doc in documents:

--- a/packages/backend/src/services/extension_usage.py
+++ b/packages/backend/src/services/extension_usage.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime
 
 from motor.core import AgnosticDatabase
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
 
 ANONYMOUS_LIMIT = 3
 
@@ -13,22 +15,31 @@ class ExtensionUsageService:
     ) -> tuple[bool, int]:
         """Return (allowed, new_count). Keyed by extension install UUID, not IP.
 
+        Uses atomic find_one_and_update with $lt filter to prevent race conditions.
         IP is stored as metadata for abuse detection only — it never gates access.
         """
-        doc = await db[self.COLLECTION].find_one({"token": token})
-        current = doc["count"] if doc else 0
-
-        if current >= ANONYMOUS_LIMIT:
-            return False, current
-
         now = datetime.now(tz=UTC)
-        await db[self.COLLECTION].update_one(
-            {"token": token},
-            {
-                "$inc": {"count": 1},
-                "$set": {"last_seen": now, "ip": ip},
-                "$setOnInsert": {"first_seen": now},
-            },
-            upsert=True,
-        )
-        return True, current + 1
+        try:
+            doc = await db[self.COLLECTION].find_one_and_update(
+                {"token": token, "count": {"$lt": ANONYMOUS_LIMIT}},
+                {
+                    "$inc": {"count": 1},
+                    "$set": {"last_seen": now, "ip": ip},
+                    "$setOnInsert": {"first_seen": now},
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError:
+            # Two concurrent first-use requests raced; retry without upsert
+            doc = await db[self.COLLECTION].find_one_and_update(
+                {"token": token, "count": {"$lt": ANONYMOUS_LIMIT}},
+                {"$inc": {"count": 1}, "$set": {"last_seen": now, "ip": ip}},
+                return_document=ReturnDocument.AFTER,
+            )
+        if doc is not None:
+            return True, doc["count"]
+        # Filter didn't match — token exists at limit
+        existing = await db[self.COLLECTION].find_one({"token": token}, {"count": 1})
+        current = existing["count"] if existing else ANONYMOUS_LIMIT
+        return False, current

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -15,7 +15,7 @@ from src.analyser import analyse_product_documents, generate_product_overview
 from src.core.database import db_session
 from src.core.logging import get_logger
 from src.models.document import Document
-from src.models.pipeline_job import CrawlError, PipelineJob
+from src.models.pipeline_job import CrawlError, CrawlSkip, PipelineJob
 from src.models.product import Product
 from src.pipeline import PolicyDocumentPipeline
 from src.repositories.pipeline_repository import PipelineRepository
@@ -304,6 +304,12 @@ class PipelineService:
                     if stats.crawl_errors:
                         job.crawl_errors = [CrawlError(**err) for err in stats.crawl_errors]
 
+                    # Persist silent skips (fetched OK but rejected by a filter)
+                    if stats.crawl_skip_reasons:
+                        job.crawl_skip_reasons = [
+                            CrawlSkip(**skip) for skip in stats.crawl_skip_reasons
+                        ]
+
                     await self._update_step(
                         db,
                         job,
@@ -334,6 +340,22 @@ class PipelineService:
                             job.error = (
                                 f"Crawling failed for {len(job.crawl_errors)} URL(s). "
                                 "No policy documents could be found."
+                            )
+                        elif job.crawl_skip_reasons:
+                            # Categorize: which filter rejected the URLs? This gives the
+                            # operator a concrete next action (tune classifier, enable JS
+                            # rendering, etc.) instead of the prior opaque message.
+                            counts: dict[str, int] = {}
+                            for skip in job.crawl_skip_reasons:
+                                counts[skip.reason] = counts.get(skip.reason, 0) + 1
+                            breakdown = ", ".join(
+                                f"{n}× {reason}"
+                                for reason, n in sorted(counts.items(), key=lambda kv: -kv[1])
+                            )
+                            job.error = (
+                                f"{len(job.crawl_skip_reasons)} URLs fetched but all "
+                                f"rejected by content filters ({breakdown}). "
+                                "See crawl_skip_reasons for the per-URL detail."
                             )
                         else:
                             job.error = "No policy documents found on this site"

--- a/packages/backend/src/services/product_service.py
+++ b/packages/backend/src/services/product_service.py
@@ -7,6 +7,7 @@ and instead accepts database instances as parameters.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 from typing import Any
 from urllib.parse import urlparse
@@ -144,6 +145,17 @@ class ProductService:
         """
         products: list[Product] = await self._product_repo.find_all_with_documents(db)
         return products
+
+    async def get_products_paginated(
+        self,
+        db: AgnosticDatabase,
+        *,
+        page: int,
+        limit: int,
+        search: str = "",
+    ) -> tuple[list[Product], int]:
+        skip = (page - 1) * limit
+        return await self._product_repo.find_paginated(db, skip=skip, limit=limit, search=search)
 
     async def delete_product_cascade(self, db: AgnosticDatabase, product_id: str) -> dict[str, Any]:
         """Delete a product and all its related data across collections.
@@ -285,7 +297,12 @@ class ProductService:
     # Business Logic Methods (Level 1, 2, 3 Analysis)
     # ============================================================================
 
-    async def get_product_overview(self, db: AgnosticDatabase, slug: str) -> ProductOverview | None:
+    async def get_product_overview(
+        self,
+        db: AgnosticDatabase,
+        slug: str,
+        product: Product | None = None,
+    ) -> ProductOverview | None:
         """Get the Level 1 overview for a product.
 
         This is business logic that transforms cached data into a user-facing overview.
@@ -293,6 +310,7 @@ class ProductService:
         Args:
             db: Database instance
             slug: Product slug
+            product: Pre-fetched product to avoid a duplicate lookup (optional)
 
         Returns:
             ProductOverview or None if not available
@@ -302,15 +320,18 @@ class ProductService:
             return None
         meta_summary = MetaSummary(**overview_data["overview"])
 
-        # Fetch product info (name, id)
-        product = await self._product_repo.find_by_slug(db, slug)
+        # Fetch product info if not provided by caller
+        if product is None:
+            product = await self._product_repo.find_by_slug(db, slug)
 
-        # Compute document counts and types
+        # Compute document counts and types in parallel — independent queries
         document_counts = None
         document_types = None
         if product:
-            document_counts = await self._product_repo.get_document_counts(db, product.id)
-            document_types = await self._product_repo.get_document_types(db, product.id)
+            document_counts, document_types = await asyncio.gather(
+                self._product_repo.get_document_counts(db, product.id),
+                self._product_repo.get_document_types(db, product.id),
+            )
 
         # Extract updated_at from overview payload if present
         updated_at = None
@@ -338,13 +359,14 @@ class ProductService:
 
         # If compliance_status is missing from meta summary, aggregate from document analyses
         if not overview.compliance_status and product:
-            docs = await self._document_repo.find_by_product_id_full(db, product.id)
+            compliance_maps = await self._document_repo.get_compliance_status_by_product(
+                db, product.id
+            )
             aggregated_compliance: dict[str, list[int]] = {}
-            for doc in docs:
-                if doc.analysis and doc.analysis.compliance_status:
-                    for reg, score in doc.analysis.compliance_status.items():
-                        if score is not None:
-                            aggregated_compliance.setdefault(reg, []).append(score)
+            for compliance_status in compliance_maps:
+                for reg, score in compliance_status.items():
+                    if score is not None:
+                        aggregated_compliance.setdefault(reg, []).append(score)
             if aggregated_compliance:
                 overview.compliance_status = {
                     reg: round(sum(scores) / len(scores))
@@ -407,7 +429,7 @@ class ProductService:
         if not product:
             return []
 
-        docs = await self._document_repo.find_by_product_id_full(db, product.id)
+        docs = await self._document_repo.find_by_product_id_with_analysis(db, product.id)
         return [DocumentSummary.from_document(doc) for doc in docs]
 
     async def get_product_deep_analysis(

--- a/packages/backend/tests/services/extension_usage_test.py
+++ b/packages/backend/tests/services/extension_usage_test.py
@@ -2,9 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.services.extension_usage import ExtensionUsageService
-
-ANONYMOUS_LIMIT = 3
+from src.services.extension_usage import ANONYMOUS_LIMIT, ExtensionUsageService
 
 
 @pytest.fixture
@@ -13,7 +11,7 @@ def mock_db():
     collection = MagicMock()
     collection.find_one = AsyncMock()
     collection.update_one = AsyncMock()
-    # Support both attribute and dict access
+    # db[COLLECTION] is the production access path; attribute access is wired to the same object
     db.extension_anonymous_usage = collection
     db.__getitem__ = MagicMock(return_value=collection)
     return db
@@ -30,20 +28,26 @@ async def test_allows_first_use(mock_db):
 
 @pytest.mark.asyncio
 async def test_allows_up_to_limit(mock_db):
-    mock_db.extension_anonymous_usage.find_one.return_value = {"token": "uuid-1", "count": 2}
+    mock_db.extension_anonymous_usage.find_one.return_value = {
+        "token": "uuid-1",
+        "count": ANONYMOUS_LIMIT - 1,
+    }
     svc = ExtensionUsageService()
     allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
     assert allowed is True
-    assert count == 3
+    assert count == ANONYMOUS_LIMIT
 
 
 @pytest.mark.asyncio
 async def test_blocks_over_limit(mock_db):
-    mock_db.extension_anonymous_usage.find_one.return_value = {"token": "uuid-1", "count": 3}
+    mock_db.extension_anonymous_usage.find_one.return_value = {
+        "token": "uuid-1",
+        "count": ANONYMOUS_LIMIT,
+    }
     svc = ExtensionUsageService()
     allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
     assert allowed is False
-    assert count == 3
+    assert count == ANONYMOUS_LIMIT
 
 
 @pytest.mark.asyncio

--- a/packages/backend/tests/services/extension_usage_test.py
+++ b/packages/backend/tests/services/extension_usage_test.py
@@ -9,8 +9,8 @@ from src.services.extension_usage import ANONYMOUS_LIMIT, ExtensionUsageService
 def mock_db():
     db = MagicMock()
     collection = MagicMock()
+    collection.find_one_and_update = AsyncMock()
     collection.find_one = AsyncMock()
-    collection.update_one = AsyncMock()
     # db[COLLECTION] is the production access path; attribute access is wired to the same object
     db.extension_anonymous_usage = collection
     db.__getitem__ = MagicMock(return_value=collection)
@@ -19,7 +19,11 @@ def mock_db():
 
 @pytest.mark.asyncio
 async def test_allows_first_use(mock_db):
-    mock_db.extension_anonymous_usage.find_one.return_value = None
+    # find_one_and_update returns the updated doc (count=1 after $inc)
+    mock_db.extension_anonymous_usage.find_one_and_update.return_value = {
+        "token": "uuid-1",
+        "count": 1,
+    }
     svc = ExtensionUsageService()
     allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
     assert allowed is True
@@ -28,9 +32,10 @@ async def test_allows_first_use(mock_db):
 
 @pytest.mark.asyncio
 async def test_allows_up_to_limit(mock_db):
-    mock_db.extension_anonymous_usage.find_one.return_value = {
+    # find_one_and_update returns doc with count at limit (ANONYMOUS_LIMIT)
+    mock_db.extension_anonymous_usage.find_one_and_update.return_value = {
         "token": "uuid-1",
-        "count": ANONYMOUS_LIMIT - 1,
+        "count": ANONYMOUS_LIMIT,
     }
     svc = ExtensionUsageService()
     allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
@@ -40,6 +45,8 @@ async def test_allows_up_to_limit(mock_db):
 
 @pytest.mark.asyncio
 async def test_blocks_over_limit(mock_db):
+    # find_one_and_update returns None when filter doesn't match (count >= limit)
+    mock_db.extension_anonymous_usage.find_one_and_update.return_value = None
     mock_db.extension_anonymous_usage.find_one.return_value = {
         "token": "uuid-1",
         "count": ANONYMOUS_LIMIT,
@@ -53,7 +60,10 @@ async def test_blocks_over_limit(mock_db):
 @pytest.mark.asyncio
 async def test_different_tokens_are_independent(mock_db):
     """UUID from install A does not affect install B even on same IP."""
-    mock_db.extension_anonymous_usage.find_one.return_value = None
+    mock_db.extension_anonymous_usage.find_one_and_update.return_value = {
+        "token": "uuid-A",
+        "count": 1,
+    }
     svc = ExtensionUsageService()
     allowed_a, _ = await svc.check_and_increment(mock_db, token="uuid-A", ip="5.5.5.5")
     allowed_b, _ = await svc.check_and_increment(mock_db, token="uuid-B", ip="5.5.5.5")

--- a/packages/backend/tests/unit/analyser_failure_isolation_test.py
+++ b/packages/backend/tests/unit/analyser_failure_isolation_test.py
@@ -1,0 +1,105 @@
+"""Per-document failure isolation in analyse_product_documents.
+
+Phase 2.2 of the ship-readiness spec: one bad document inside a product's
+analyse loop must not block the rest. Before this, the inner ``_analyse_one``
+caught only ``asyncio.CancelledError`` — any other exception (LLM error, JSON
+parse, validation failure) would propagate through ``asyncio.gather`` and fail
+the whole product, leaving the overview never generated. Now, sibling tasks
+keep running and the function returns the document list with ``analysis``
+populated only on the docs that succeeded; the overview stage filters by
+``doc.analysis`` so failures contribute nothing rather than poisoning the run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.analyser import analyse_product_documents
+from src.models.document import Document, DocumentAnalysis, DocumentAnalysisScores
+
+
+def _make_doc(doc_id: str, url: str) -> Document:
+    return Document(
+        id=doc_id,
+        url=url,
+        product_id="prod-1",
+        doc_type="privacy_policy",
+        markdown="real policy " * 50,
+        text="real policy " * 50,
+        metadata={},
+        versions=[],
+        analysis=None,
+        extraction=None,
+        locale=None,
+        regions=[],
+        effective_date=None,
+        created_at=datetime(2026, 1, 1),
+    )
+
+
+def _stub_analysis() -> DocumentAnalysis:
+    return DocumentAnalysis(
+        summary="ok",
+        scores={"transparency": DocumentAnalysisScores(score=5, justification="x")},
+        risk_score=5,
+        verdict="moderate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_one_failing_document_does_not_fail_the_product() -> None:
+    docs = [
+        _make_doc("a", "https://x/a"),
+        _make_doc("b", "https://x/b"),
+        _make_doc("c", "https://x/c"),
+    ]
+    document_svc = AsyncMock()
+    document_svc.get_product_documents_by_slug = AsyncMock(return_value=docs)
+    document_svc.update_document = AsyncMock(return_value=True)
+
+    # Doc 'b' raises a generic exception; 'a' and 'c' succeed.
+    async def fake_analyse(doc: Document, **_: Any) -> DocumentAnalysis | None:
+        if doc.id == "b":
+            raise RuntimeError("simulated LLM blow-up on doc b")
+        return _stub_analysis()
+
+    with patch("src.analyser.analyse_document", side_effect=fake_analyse):
+        returned = await analyse_product_documents(
+            db=AsyncMock(), product_slug="example", document_svc=document_svc
+        )
+
+    # All three docs come back (we operate on whatever was loaded).
+    ids = sorted(d.id for d in returned)
+    assert ids == ["a", "b", "c"]
+
+    # The failing doc has no analysis attached; the others do.
+    by_id = {d.id: d for d in returned}
+    assert by_id["a"].analysis is not None
+    assert by_id["b"].analysis is None
+    assert by_id["c"].analysis is not None
+
+    # update_document should have been awaited exactly twice (a and c, not b).
+    assert document_svc.update_document.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cancellation_still_propagates() -> None:
+    """The broad except must not swallow CancelledError — cancellation semantics matter."""
+    docs = [_make_doc("a", "https://x/a"), _make_doc("b", "https://x/b")]
+    document_svc = AsyncMock()
+    document_svc.get_product_documents_by_slug = AsyncMock(return_value=docs)
+    document_svc.update_document = AsyncMock(return_value=True)
+
+    async def fake_analyse(doc: Document, **_: Any) -> DocumentAnalysis | None:
+        raise asyncio.CancelledError()
+
+    with patch("src.analyser.analyse_document", side_effect=fake_analyse):
+        with pytest.raises(asyncio.CancelledError):
+            await analyse_product_documents(
+                db=AsyncMock(), product_slug="example", document_svc=document_svc
+            )

--- a/packages/backend/tests/unit/crawl_skip_telemetry_test.py
+++ b/packages/backend/tests/unit/crawl_skip_telemetry_test.py
@@ -51,7 +51,7 @@ def test_crawl_skip_round_trips_through_pipeline_job() -> None:
         product_slug="example",
         product_name="Example",
         url="https://x.example",
-        crawl_skip_reasons=[CrawlSkip(**s) for s in skips_as_dicts],
+        crawl_skip_reasons=[CrawlSkip.model_validate(skip) for skip in skips_as_dicts],
     )
     assert [s.reason for s in job.crawl_skip_reasons] == [
         "insufficient_content",

--- a/packages/backend/tests/unit/crawl_skip_telemetry_test.py
+++ b/packages/backend/tests/unit/crawl_skip_telemetry_test.py
@@ -1,0 +1,86 @@
+"""Tests for the Phase 1.1 crawl-skip telemetry.
+
+We do not invoke the live pipeline (network + LLM + Mongo). Instead we exercise
+the data layer that carries skip information from ProcessingStats into the
+persisted PipelineJob, and the categorized failure-message logic that pulls
+from it. These are the boundaries that decide whether an operator can tell
+WHICH filter dropped each URL.
+"""
+
+from __future__ import annotations
+
+from src.models.pipeline_job import CrawlSkip, PipelineJob
+from src.pipeline import ProcessingStats
+
+
+def test_processing_stats_carries_skip_reasons() -> None:
+    stats = ProcessingStats()
+    stats.crawl_skip_reasons.append(
+        {
+            "url": "https://x.example/policy",
+            "reason": "insufficient_content",
+            "detail": "text=120 chars",
+        }
+    )
+    stats.crawl_skip_reasons.append(
+        {
+            "url": "https://y.example/help",
+            "reason": "non_policy_classification",
+            "detail": "classifier=other",
+        }
+    )
+    assert len(stats.crawl_skip_reasons) == 2
+    assert stats.crawl_skip_reasons[0]["reason"] == "insufficient_content"
+
+
+def test_crawl_skip_round_trips_through_pipeline_job() -> None:
+    skips_as_dicts = [
+        {
+            "url": "https://x.example/policy",
+            "reason": "insufficient_content",
+            "detail": "text=120 chars",
+        },
+        {
+            "url": "https://y.example/help",
+            "reason": "non_policy_classification",
+            "detail": "classifier=other",
+        },
+        {"url": "https://z.example/legal", "reason": "non_english", "detail": "locale=fr-FR"},
+    ]
+    job = PipelineJob(
+        product_slug="example",
+        product_name="Example",
+        url="https://x.example",
+        crawl_skip_reasons=[CrawlSkip(**s) for s in skips_as_dicts],
+    )
+    assert [s.reason for s in job.crawl_skip_reasons] == [
+        "insufficient_content",
+        "non_policy_classification",
+        "non_english",
+    ]
+    # Persistence shape — model_dump matches what would be written to Mongo.
+    dumped = job.model_dump()
+    assert dumped["crawl_skip_reasons"][2]["detail"] == "locale=fr-FR"
+
+
+def test_categorized_failure_breakdown_is_deterministic() -> None:
+    """The error message in pipeline_service.py sorts reasons by descending count.
+
+    Re-encoding the same logic here as a pure function pins it down so behaviour
+    can't drift silently.
+    """
+    skips = [
+        CrawlSkip(url="a", reason="insufficient_content"),
+        CrawlSkip(url="b", reason="insufficient_content"),
+        CrawlSkip(url="c", reason="insufficient_content"),
+        CrawlSkip(url="d", reason="non_english"),
+        CrawlSkip(url="e", reason="non_policy_classification"),
+        CrawlSkip(url="f", reason="non_policy_classification"),
+    ]
+    counts: dict[str, int] = {}
+    for skip in skips:
+        counts[skip.reason] = counts.get(skip.reason, 0) + 1
+    breakdown = ", ".join(
+        f"{n}× {reason}" for reason, n in sorted(counts.items(), key=lambda kv: -kv[1])
+    )
+    assert breakdown == "3× insufficient_content, 2× non_policy_classification, 1× non_english"

--- a/packages/backend/tests/unit/crawler/content_pipeline_test.py
+++ b/packages/backend/tests/unit/crawler/content_pipeline_test.py
@@ -279,7 +279,7 @@ class TestFetchPageInternalOrchestration:
 
     @pytest.mark.asyncio
     async def test_browser_failure_falls_back_to_static(self):
-        """When browser returns None, the static content is used."""
+        """When browser returns None for a policy-relevant page, surface the failure."""
         thin_html = "<html><head><title>Page</title></head><body>Loading...</body></html>"
 
         class FakeResponse:
@@ -310,11 +310,101 @@ class TestFetchPageInternalOrchestration:
 
         crawler._browser_fetch = failing_browser_fetch  # type: ignore[method-assign]
 
+        # Use a policy-relevant URL so the browser-fetch gate is passed and the
+        # browser-failure path is actually exercised.
         result = await crawler._fetch_page_internal(
-            cast(aiohttp.ClientSession, FakeSession()), "https://example.com/page"
+            cast(aiohttp.ClientSession, FakeSession()), "https://example.com/privacy-policy"
         )
         assert result.success is False
         assert "browser rendering failed" in (result.error_message or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_low_relevance_page_skips_browser(self):
+        """Content-insufficient but non-policy pages must NOT trigger an expensive
+        browser render — they return the static content as-is."""
+        thin_html = "<html><head><title>Learn Spanish</title></head><body>Loading...</body></html>"
+
+        class FakeResponse:
+            def __init__(self, url: str):
+                self.status = 200
+                self.headers = {"content-type": "text/html; charset=utf-8"}
+                self.url = url
+                self.charset = "utf-8"
+                self.content = _FakeContent(thin_html.encode())
+
+            async def text(self):
+                return thin_html
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeSession:
+            def get(self, url, **kwargs):
+                return FakeResponse(url)
+
+        crawler = ClauseaCrawler(respect_robots_txt=False, use_browser=True)
+
+        browser_called = False
+
+        async def tracking_browser_fetch(url: str) -> PageContent | None:
+            nonlocal browser_called
+            browser_called = True
+            return None
+
+        crawler._browser_fetch = tracking_browser_fetch  # type: ignore[method-assign]
+
+        # A course page scores ~0 (no policy keywords) — below min_legal_score (2.0).
+        result = await crawler._fetch_page_internal(
+            cast(aiohttp.ClientSession, FakeSession()),
+            "https://example.com/course/es/en/Learn-Spanish",
+        )
+        assert browser_called is False, "browser must not be invoked for low-relevance pages"
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_blocked_static_falls_back_to_browser_for_policy_url(self):
+        """A 406/empty static response (bot block) on a policy URL must trigger the
+        browser fallback rather than failing as 'unsupported content type'."""
+
+        class FakeResponse:
+            """Simulates a bot-block: HTTP 406, empty content-type, empty body."""
+
+            def __init__(self, url: str):
+                self.status = 406
+                self.headers = {"content-type": ""}
+                self.url = url
+                self.charset = None
+                self.content = _FakeContent(b"")
+
+            async def text(self):
+                return ""
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        class FakeSession:
+            def get(self, url, **kwargs):
+                return FakeResponse(url)
+
+        crawler = ClauseaCrawler(respect_robots_txt=False, use_browser=True)
+
+        async def good_browser_fetch(url: str) -> PageContent | None:
+            body = "Privacy Policy. " + ("We collect personal data and share it. " * 80)
+            return PageContent(text=body, markdown=body, title="Privacy Policy", metadata={})
+
+        crawler._browser_fetch = good_browser_fetch  # type: ignore[method-assign]
+
+        result = await crawler._fetch_page_internal(
+            cast(aiohttp.ClientSession, FakeSession()), "https://example.com/privacy"
+        )
+        assert result.success is True
+        assert "privacy policy" in (result.content or result.markdown).lower()
 
     @pytest.mark.asyncio
     async def test_no_browser_when_disabled(self):

--- a/packages/backend/tests/unit/crawler/url_scorer_test.py
+++ b/packages/backend/tests/unit/crawler/url_scorer_test.py
@@ -3,6 +3,31 @@ import pytest
 from src.crawler import ClauseaCrawler, URLScorer
 
 
+class TestURLScorerGlossaryGuard:
+    """'terms' used as glossary/terminology must not score like Terms of Service."""
+
+    def test_chess_terms_glossary_scores_zero(self) -> None:
+        scorer = URLScorer()
+        assert scorer.score_url("https://www.duolingo.com/chess/terms/absolute-pin") == 0.0
+        assert (
+            scorer.score_url("https://www.duolingo.com/chess/terms/what-is-checkmate-in-chess")
+            == 0.0
+        )
+
+    def test_real_terms_pages_keep_high_score(self) -> None:
+        scorer = URLScorer()
+        # Terminal /terms and legal-qualified sub-paths must remain strong signals.
+        assert scorer.score_url("https://example.com/terms") >= 5.0
+        assert scorer.score_url("https://example.com/legal/terms/service") >= 5.0
+        assert scorer.score_url("https://example.com/help/terms") >= 5.0
+        assert scorer.score_url("https://example.com/policies/terms/cookies") >= 5.0
+
+    def test_glossary_guard_does_not_touch_privacy_or_cookies(self) -> None:
+        scorer = URLScorer()
+        assert scorer.score_url("https://www.duolingo.com/privacy") >= 5.0
+        assert scorer.score_url("https://www.duolingo.com/cookies") >= 5.0
+
+
 class TestURLScorerAnchorTextBoost:
     """Anchor text should be the dominant signal for opaque URLs."""
 

--- a/packages/backend/tests/unit/document_repository_test.py
+++ b/packages/backend/tests/unit/document_repository_test.py
@@ -1,0 +1,130 @@
+"""Regression tests for DocumentRepository.update — guards against the partial-loader text-loss bug.
+
+Background: find_by_product_id projects out text/markdown and fills them with "".
+If a caller then passes such a partial Document into update(), $set(model_dump())
+would overwrite the real stored text with "". The update() method must drop empty
+text/markdown from the $set payload when the stored row already has content.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.models.document import Document
+from src.repositories.document_repository import DocumentRepository
+
+
+def _make_doc(text: str, markdown: str) -> Document:
+    return Document(
+        id="doc-1",
+        url="https://example.com/policy",
+        product_id="prod-1",
+        doc_type="privacy_policy",
+        markdown=markdown,
+        text=text,
+        metadata={},
+        versions=[],
+        analysis=None,
+        extraction=None,
+        locale=None,
+        regions=[],
+        effective_date=None,
+        created_at=datetime(2026, 1, 1),
+    )
+
+
+def _fake_db_with_existing(text: str, markdown: str) -> tuple[Any, AsyncMock]:
+    """Return a db-like mock whose documents.update_one captures the $set payload."""
+    documents_collection = AsyncMock()
+    documents_collection.find_one = AsyncMock(
+        return_value={"id": "doc-1", "text": text, "markdown": markdown}
+    )
+    update_result = AsyncMock()
+    update_result.modified_count = 1
+    documents_collection.update_one = AsyncMock(return_value=update_result)
+
+    db = AsyncMock()
+    db.documents = documents_collection
+    return db, documents_collection.update_one
+
+
+@pytest.mark.asyncio
+async def test_update_drops_empty_text_when_stored_has_content() -> None:
+    """Partial-loader regression: empty incoming text must not wipe stored text."""
+    repo = DocumentRepository()
+    db, update_one = _fake_db_with_existing(text="real policy content " * 100, markdown="# real")
+    partial_doc = _make_doc(text="", markdown="")
+
+    ok = await repo.update(db, partial_doc)
+    assert ok is True
+
+    update_one.assert_awaited_once()
+    args, _kwargs = update_one.call_args
+    set_payload = args[1]["$set"]
+    assert "text" not in set_payload, "empty incoming text must be dropped from $set"
+    assert "markdown" not in set_payload, "empty incoming markdown must be dropped from $set"
+
+
+@pytest.mark.asyncio
+async def test_update_writes_text_when_incoming_has_content() -> None:
+    """Normal path: a full Document with real text writes through unchanged."""
+    repo = DocumentRepository()
+    db, update_one = _fake_db_with_existing(text="old text", markdown="# old")
+    full_doc = _make_doc(text="new policy text", markdown="# new")
+
+    ok = await repo.update(db, full_doc)
+    assert ok is True
+
+    args, _kwargs = update_one.call_args
+    set_payload = args[1]["$set"]
+    assert set_payload["text"] == "new policy text"
+    assert set_payload["markdown"] == "# new"
+
+
+@pytest.mark.asyncio
+async def test_update_allows_empty_when_stored_is_also_empty() -> None:
+    """Edge case: both sides empty means there is nothing to protect."""
+    repo = DocumentRepository()
+    db, update_one = _fake_db_with_existing(text="", markdown="")
+    doc = _make_doc(text="", markdown="")
+
+    ok = await repo.update(db, doc)
+    assert ok is True
+    args, _kwargs = update_one.call_args
+    set_payload = args[1]["$set"]
+    # Empty values are allowed to be written since stored is also empty.
+    assert set_payload.get("text", "") == ""
+    assert set_payload.get("markdown", "") == ""
+
+
+@pytest.mark.asyncio
+async def test_save_refuses_empty_document() -> None:
+    """Inserts with both text and markdown empty must raise — masking crawl bugs is bad."""
+    repo = DocumentRepository()
+    documents_collection = AsyncMock()
+    documents_collection.insert_one = AsyncMock()
+    db = AsyncMock()
+    db.documents = documents_collection
+    doc = _make_doc(text="   ", markdown="")  # whitespace counts as empty
+
+    with pytest.raises(ValueError, match="Refusing to store empty document"):
+        await repo.save(db, doc)
+    documents_collection.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_save_accepts_normal_document() -> None:
+    repo = DocumentRepository()
+    documents_collection = AsyncMock()
+    documents_collection.insert_one = AsyncMock()
+    db = AsyncMock()
+    db.documents = documents_collection
+    doc = _make_doc(text="real policy content " * 50, markdown="# real policy")
+
+    saved = await repo.save(db, doc)
+    assert saved is doc
+    documents_collection.insert_one.assert_awaited_once()

--- a/packages/backend/tests/unit/pipeline_store_dedup_test.py
+++ b/packages/backend/tests/unit/pipeline_store_dedup_test.py
@@ -1,0 +1,68 @@
+"""Content-based collapsing of same-content locale variants in _store_documents.
+
+Same policy text at different URLs (e.g. /privacy and /es/privacy) collapses to one
+stored doc; genuinely different regional policies (different text) are both kept.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import src.pipeline as pipeline_module
+from src.models.document import Document
+from src.pipeline import PolicyDocumentPipeline
+
+
+def _doc(url: str, text: str) -> Document:
+    return Document(
+        id=url,
+        url=url,
+        product_id="prod-1",
+        doc_type="privacy_policy",
+        title="Privacy",
+        text=text,
+        markdown=text,
+    )
+
+
+@pytest.mark.asyncio
+async def test_collapses_same_content_locale_variants(monkeypatch):
+    stored_urls: list[str] = []
+
+    service = MagicMock()
+    service.get_document_by_url = AsyncMock(return_value=None)  # all URLs are new
+
+    async def _store(_db, document):
+        stored_urls.append(document.url)
+        return document
+
+    service.store_document = AsyncMock(side_effect=_store)
+
+    @asynccontextmanager
+    async def fake_db_session():
+        yield MagicMock()
+
+    monkeypatch.setattr(pipeline_module, "db_session", fake_db_session)
+    monkeypatch.setattr(pipeline_module, "create_document_service", lambda: service)
+
+    pipeline = PolicyDocumentPipeline()
+
+    same = "This Privacy Policy explains what personal data we collect and how we share it. " * 30
+    different = "Politique de confidentialité distincte pour l'Union européenne (RGPD). " * 30
+
+    docs = [
+        _doc("https://acme.com/es/privacy", same),  # locale variant, same content
+        _doc("https://acme.com/privacy", same),  # canonical, same content
+        _doc("https://acme.com/fr/privacy", same),  # locale variant, same content
+        _doc("https://acme.com/eu/privacy", different),  # different regional policy
+    ]
+
+    stored_count = await pipeline._store_documents(docs)
+
+    # Canonical /privacy kept (sorted first), /es and /fr collapsed, /eu kept (different text).
+    assert stored_count == 2
+    assert "https://acme.com/privacy" in stored_urls
+    assert "https://acme.com/eu/privacy" in stored_urls
+    assert "https://acme.com/es/privacy" not in stored_urls
+    assert "https://acme.com/fr/privacy" not in stored_urls

--- a/packages/backend/tests/unit/product_repository_search_test.py
+++ b/packages/backend/tests/unit/product_repository_search_test.py
@@ -1,0 +1,68 @@
+"""Regression test: find_paginated must match user search input literally.
+
+Raw user input passed into a Mongo $regex can 500 on invalid patterns
+(e.g. an unclosed "(") or open a ReDoS vector — the search term has to be
+escaped before it reaches the query.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.repositories.product_repository import ProductRepository
+
+
+def _fake_db_capturing_queries() -> tuple[Any, list[dict[str, Any]]]:
+    captured_queries: list[dict[str, Any]] = []
+
+    def capture_find(query: dict[str, Any]) -> MagicMock:
+        captured_queries.append(query)
+        cursor = MagicMock()
+        cursor.sort.return_value = cursor
+        cursor.skip.return_value = cursor
+        cursor.limit.return_value = cursor
+        cursor.to_list = AsyncMock(return_value=[])
+        return cursor
+
+    async def capture_count(query: dict[str, Any]) -> int:
+        captured_queries.append(query)
+        return 0
+
+    products_collection = MagicMock()
+    products_collection.find = MagicMock(side_effect=capture_find)
+    products_collection.count_documents = AsyncMock(side_effect=capture_count)
+
+    db = MagicMock()
+    db.products = products_collection
+    return db, captured_queries
+
+
+@pytest.mark.asyncio
+async def test_find_paginated_escapes_regex_metacharacters() -> None:
+    repo = ProductRepository()
+    db, captured_queries = _fake_db_capturing_queries()
+    hostile_search = "(.*+[unclosed"
+
+    products, total = await repo.find_paginated(db, skip=0, limit=10, search=hostile_search)
+    assert products == []
+    assert total == 0
+
+    assert captured_queries, "expected the search query to reach the collection"
+    for query in captured_queries:
+        for clause in query["$or"]:
+            pattern = next(iter(clause.values()))["$regex"]
+            assert pattern == re.escape(hostile_search)
+            re.compile(pattern)  # must be a valid (literal) pattern
+
+
+@pytest.mark.asyncio
+async def test_find_paginated_without_search_uses_empty_query() -> None:
+    repo = ProductRepository()
+    db, captured_queries = _fake_db_capturing_queries()
+
+    await repo.find_paginated(db, skip=0, limit=10, search="")
+    assert all(query == {} for query in captured_queries)

--- a/packages/backend/tests/unit/product_service_db_test.py
+++ b/packages/backend/tests/unit/product_service_db_test.py
@@ -213,10 +213,10 @@ async def test_get_product_documents(
             keypoints=["Point A"],
         ),
     )
-    mock_document_repo.find_by_product_id_full.return_value = [mock_doc]
+    mock_document_repo.find_by_product_id_with_analysis.return_value = [mock_doc]
 
     documents = await product_service.get_product_documents(mock_db, "test-product")
     assert len(documents) == 1
     assert documents[0].id == "doc1"
     assert documents[0].summary == "JSON SUMMARY"
-    mock_document_repo.find_by_product_id_full.assert_called_once_with(mock_db, "123")
+    mock_document_repo.find_by_product_id_with_analysis.assert_called_once_with(mock_db, "123")

--- a/packages/backend/tests/unit/threshold_mismatch_test.py
+++ b/packages/backend/tests/unit/threshold_mismatch_test.py
@@ -1,0 +1,65 @@
+"""Pins down the crawler-vs-processor length-threshold mismatch.
+
+The ship-readiness investigation (docs/superpowers/specs/2026-05-25-ship-readiness-design.md)
+found that two hardcoded length gates disagree about what "sufficient content" means:
+
+* Crawler `_content_is_sufficient` (crawler.py:1462)   accepts markdown >= 200 chars stripped.
+* Processor `_process_crawl_result`  (pipeline.py:937)  demands text-after-strip >= 300 chars.
+
+A page that passes the first gate will skip the browser-rendering retry; if its
+markdown-to-text strip then yields fewer than 300 chars, it is silently dropped
+with reason="insufficient_content" — exactly what was happening to JS-SPA shells
+for Slack / Amazon / Airbnb.
+
+This test reproduces a realistic shell payload that lands in the mismatch zone.
+If someone harmonises the gates, this test will fail; update the fixture and
+the doc reference at the same time.
+"""
+
+from __future__ import annotations
+
+from src.utils.markdown import markdown_to_text
+
+
+def test_spa_shell_passes_crawler_gate_and_fails_processor_gate() -> None:
+    spa_markdown = (
+        "# Welcome\n\n"
+        "We use cookies and similar tech.\n\n"
+        "[Privacy](https://example.com/privacy) | "
+        "[Terms](https://example.com/terms) | "
+        "[Cookie policy](https://example.com/cookies)\n\n"
+        "* Sign in\n"
+        "* Sign up\n"
+        "* Help center\n"
+        "* Loading...\n\n"
+        "Please enable JavaScript to view this page."
+    )
+
+    stripped_markdown_len = len(spa_markdown.strip())
+    assert 200 <= stripped_markdown_len < 300, (
+        f"fixture must sit in the mismatch zone (markdown stripped len={stripped_markdown_len})"
+    )
+
+    stripped_text_len = len(markdown_to_text(spa_markdown).strip())
+    assert stripped_text_len < 300, (
+        f"hypothesis: post-strip text length stays below the 300-char processor gate "
+        f"(got {stripped_text_len})"
+    )
+
+
+def test_markdown_to_text_does_not_grow_content() -> None:
+    """Sanity check the assumption that strip is near-identity on length.
+
+    If markdown_to_text ever inflates content significantly, the mismatch
+    analysis above no longer holds and the spec needs revisiting.
+    """
+    samples = [
+        "# Heading\n\nSome **bold** and *italic* text with a [link](https://x.com).",
+        "Plain content with no markdown features at all to speak of.",
+        "* item one\n* item two\n* item three\n* item four",
+    ]
+    for md in samples:
+        stripped = markdown_to_text(md)
+        assert len(stripped) <= len(md), (
+            f"strip must not inflate: input={len(md)} output={len(stripped)} for {md!r}"
+        )

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -45,6 +45,40 @@ export default defineBackground(() => {
     },
   };
 
+  /** Get or create the persistent install UUID stored in chrome.storage.local. */
+  async function getOrCreateExtensionToken(): Promise<string> {
+    const stored = await chrome.storage.local.get("extension_token");
+    if (stored.extension_token) return stored.extension_token as string;
+    const token = crypto.randomUUID();
+    await chrome.storage.local.set({ extension_token: token });
+    return token;
+  }
+
+  /** Read the Clerk session JWT from the clausea.co cookie store. */
+  async function getClerkToken(): Promise<string | null> {
+    try {
+      const baseUrl =
+        import.meta.env.MODE === "development"
+          ? "http://localhost:3000"
+          : "https://clausea.co";
+      const cookie = await chrome.cookies.get({ url: baseUrl, name: "__session" });
+      return cookie?.value ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Return headers object: always includes X-Extension-Token, optionally Authorization. */
+  async function getExtensionHeaders(): Promise<Record<string, string>> {
+    const [extensionToken, clerkToken] = await Promise.all([
+      getOrCreateExtensionToken(),
+      getClerkToken(),
+    ]);
+    const headers: Record<string, string> = { "X-Extension-Token": extensionToken };
+    if (clerkToken) headers["Authorization"] = `Bearer ${clerkToken}`;
+    return headers;
+  }
+
   /**
    * Update extension icon based on verdict
    */
@@ -118,6 +152,11 @@ export default defineBackground(() => {
     }
   });
 
+  // Generate UUID on first install so it's ready before any popup opens
+  chrome.runtime.onInstalled.addListener(() => {
+    getOrCreateExtensionToken();
+  });
+
   // Listen for tab activation
   chrome.tabs.onActivated.addListener(async (activeInfo) => {
     const tab = await chrome.tabs.get(activeInfo.tabId);
@@ -156,6 +195,13 @@ export default defineBackground(() => {
     if (message.type === "CLEAR_CACHE") {
       cache.clear();
       sendResponse({ success: true });
+      return true;
+    }
+
+    if (message.type === "GET_EXTENSION_HEADERS") {
+      getExtensionHeaders()
+        .then((headers) => sendResponse({ success: true, headers }))
+        .catch(() => sendResponse({ success: true, headers: {} }));
       return true;
     }
   });

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -145,16 +145,18 @@ export default defineBackground(() => {
     }
   }
 
+  // Generate UUID on first install so it's ready before any popup opens
+  chrome.runtime.onInstalled.addListener(() => {
+    getOrCreateExtensionToken().catch((err) => {
+      console.error("[clausea] Failed to generate extension token on install:", err);
+    });
+  });
+
   // Listen for tab updates
   chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (changeInfo.status === "complete" && tab.url) {
       checkAndUpdateIcon(tabId, tab.url);
     }
-  });
-
-  // Generate UUID on first install so it's ready before any popup opens
-  chrome.runtime.onInstalled.addListener(() => {
-    getOrCreateExtensionToken();
   });
 
   // Listen for tab activation

--- a/packages/extension/entrypoints/popup/App.tsx
+++ b/packages/extension/entrypoints/popup/App.tsx
@@ -191,26 +191,25 @@ export default function App() {
   }, []);
 
   // ── Trigger pipeline analysis ────────────────────────────────────────────
-  const getExtensionHeaders = (): Promise<Record<string, string>> =>
-    new Promise((resolve) => {
-      try {
-        chrome.runtime.sendMessage({ type: "GET_EXTENSION_HEADERS" }, (response) => {
-          if (chrome.runtime.lastError || !response?.success) {
-            resolve({});
-            return;
-          }
-          resolve((response.headers as Record<string, string>) ?? {});
-        });
-      } catch {
-        resolve({});
-      }
-    });
-
   const handleAnalyze = async () => {
     if (!currentUrl) return;
     setNotFoundPhase("triggering");
     setPhaseError("");
     try {
+      const getExtensionHeaders = (): Promise<Record<string, string>> =>
+        new Promise((resolve) => {
+          try {
+            chrome.runtime.sendMessage({ type: "GET_EXTENSION_HEADERS" }, (response) => {
+              if (chrome.runtime.lastError || !response?.success) {
+                resolve({});
+                return;
+              }
+              resolve((response.headers as Record<string, string>) ?? {});
+            });
+          } catch {
+            resolve({});
+          }
+        });
       const headers = await getExtensionHeaders();
       const result = await analyzeUrl(currentUrl, headers);
       setAnalyzeResult(result);
@@ -230,6 +229,7 @@ export default function App() {
     } catch (err) {
       if (isRateLimitError(err)) {
         setLoginUrl(err.loginUrl);
+        setNotFoundPhase("initial");
         setView("login-required");
         return;
       }
@@ -537,12 +537,14 @@ export default function App() {
                 </p>
               </div>
               <button
+                type="button"
                 onClick={() => chrome.tabs.create({ url: loginUrl })}
                 className="w-full rounded-sm bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90 transition-opacity"
               >
                 Sign in to Clausea
               </button>
               <button
+                type="button"
                 onClick={() => setView("not-found")}
                 className="text-xs text-muted-foreground underline underline-offset-2"
               >

--- a/packages/extension/entrypoints/popup/App.tsx
+++ b/packages/extension/entrypoints/popup/App.tsx
@@ -5,6 +5,7 @@ import {
   checkUrl,
   getVerdictColor,
   getVerdictLabel,
+  isRateLimitError,
   subscribeEmail,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -24,7 +25,7 @@ import { useEffect, useMemo, useState } from "react";
 
 export const CLAUSEA_URL = "https://clausea.co";
 
-type ViewState = "loading" | "loaded" | "error" | "not-found" | "crawl-failed";
+type ViewState = "loading" | "loaded" | "error" | "not-found" | "crawl-failed" | "login-required";
 
 // Sub-states within the "not-found" view
 type NotFoundPhase =
@@ -79,6 +80,8 @@ export default function App() {
   const [data, setData] = useState<ExtensionCheckResponse | null>(null);
   const [currentUrl, setCurrentUrl] = useState<string>("");
   const [error, setError] = useState<string>("");
+
+  const [loginUrl, setLoginUrl] = useState<string>("https://clausea.co/sign-in");
 
   // Not-found / pipeline state
   const [notFoundPhase, setNotFoundPhase] = useState<NotFoundPhase>("initial");
@@ -188,12 +191,28 @@ export default function App() {
   }, []);
 
   // ── Trigger pipeline analysis ────────────────────────────────────────────
+  const getExtensionHeaders = (): Promise<Record<string, string>> =>
+    new Promise((resolve) => {
+      try {
+        chrome.runtime.sendMessage({ type: "GET_EXTENSION_HEADERS" }, (response) => {
+          if (chrome.runtime.lastError || !response?.success) {
+            resolve({});
+            return;
+          }
+          resolve((response.headers as Record<string, string>) ?? {});
+        });
+      } catch {
+        resolve({});
+      }
+    });
+
   const handleAnalyze = async () => {
     if (!currentUrl) return;
     setNotFoundPhase("triggering");
     setPhaseError("");
     try {
-      const result = await analyzeUrl(currentUrl);
+      const headers = await getExtensionHeaders();
+      const result = await analyzeUrl(currentUrl, headers);
       setAnalyzeResult(result);
 
       if (result.status === "already_indexed") {
@@ -209,6 +228,11 @@ export default function App() {
       // "started" or "already_running" → show email input
       setNotFoundPhase("triggered");
     } catch (err) {
+      if (isRateLimitError(err)) {
+        setLoginUrl(err.loginUrl);
+        setView("login-required");
+        return;
+      }
       setPhaseError(formatError(err));
       setNotFoundPhase("trigger-error");
     }
@@ -497,6 +521,33 @@ export default function App() {
                   <ExternalLink className="h-3 w-3" strokeWidth={1.5} />
                 </button>
               )}
+            </div>
+          </section>
+        )}
+
+        {/* ── Login Required ── */}
+        {view === "login-required" && (
+          <section className="border-b border-border bg-card px-5 py-6">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <Shield className="h-10 w-10 text-muted-foreground" />
+              <div>
+                <p className="font-semibold text-sm">Sign in to keep analyzing</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  You've used your 3 free analyses. Sign in to continue.
+                </p>
+              </div>
+              <button
+                onClick={() => chrome.tabs.create({ url: loginUrl })}
+                className="w-full rounded-sm bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90 transition-opacity"
+              >
+                Sign in to Clausea
+              </button>
+              <button
+                onClick={() => setView("not-found")}
+                className="text-xs text-muted-foreground underline underline-offset-2"
+              >
+                Go back
+              </button>
             </div>
           </section>
         )}

--- a/packages/extension/lib/api.ts
+++ b/packages/extension/lib/api.ts
@@ -54,8 +54,8 @@ export interface ExtensionAnalyzeResponse {
 }
 
 export interface RateLimitError extends Error {
-  requiresAuth: true;
-  loginUrl: string;
+  readonly requiresAuth: true;
+  readonly loginUrl: string;
 }
 
 export function isRateLimitError(e: unknown): e is RateLimitError {
@@ -123,18 +123,14 @@ export async function analyzeUrl(
     body: JSON.stringify({ url }),
   });
 
-  if (response.status === 429) {
-    const body = await response.json().catch(() => ({}));
-    if (body?.requires_auth) {
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    if (response.status === 429 && body?.requires_auth) {
       const err = new Error("Login required to analyze more sites") as RateLimitError;
       err.requiresAuth = true;
       err.loginUrl = body.login_url ?? "https://clausea.co/sign-in";
       throw err;
     }
-  }
-
-  if (!response.ok) {
-    const body = await response.json().catch(() => null);
     throw new Error(body?.detail ?? `Analysis failed with status ${response.status}`);
   }
 

--- a/packages/extension/lib/api.ts
+++ b/packages/extension/lib/api.ts
@@ -126,10 +126,10 @@ export async function analyzeUrl(
   if (!response.ok) {
     const body = await response.json().catch(() => null);
     if (response.status === 429 && body?.requires_auth) {
-      const err = new Error("Login required to analyze more sites") as RateLimitError;
-      err.requiresAuth = true;
-      err.loginUrl = body.login_url ?? "https://clausea.co/sign-in";
-      throw err;
+      throw Object.assign(new Error("Login required to analyze more sites"), {
+        requiresAuth: true as const,
+        loginUrl: (body.login_url ?? "https://clausea.co/sign-in") as string,
+      }) as RateLimitError;
     }
     throw new Error(body?.detail ?? `Analysis failed with status ${response.status}`);
   }

--- a/packages/extension/lib/api.ts
+++ b/packages/extension/lib/api.ts
@@ -53,6 +53,15 @@ export interface ExtensionAnalyzeResponse {
   job_id: string | null;
 }
 
+export interface RateLimitError extends Error {
+  requiresAuth: true;
+  loginUrl: string;
+}
+
+export function isRateLimitError(e: unknown): e is RateLimitError {
+  return e instanceof Error && (e as RateLimitError).requiresAuth === true;
+}
+
 // ---------------------------------------------------------------------------
 // API calls
 // ---------------------------------------------------------------------------
@@ -101,17 +110,32 @@ export async function getSupportedDomains(): Promise<string[]> {
  */
 export async function analyzeUrl(
   url: string,
+  extraHeaders?: Record<string, string>,
 ): Promise<ExtensionAnalyzeResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...extraHeaders,
+  };
+
   const response = await fetch(`${API_BASE_URL}/extension/analyze`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({ url }),
   });
 
+  if (response.status === 429) {
+    const body = await response.json().catch(() => ({}));
+    if (body?.requires_auth) {
+      const err = new Error("Login required to analyze more sites") as RateLimitError;
+      err.requiresAuth = true;
+      err.loginUrl = body.login_url ?? "https://clausea.co/sign-in";
+      throw err;
+    }
+  }
+
   if (!response.ok) {
     const body = await response.json().catch(() => null);
-    const message = body?.detail ?? `Analysis failed with status ${response.status}`;
-    throw new Error(message);
+    throw new Error(body?.detail ?? `Analysis failed with status ${response.status}`);
   }
 
   return response.json();

--- a/packages/extension/lib/api.ts
+++ b/packages/extension/lib/api.ts
@@ -125,13 +125,18 @@ export async function analyzeUrl(
 
   if (!response.ok) {
     const body = await response.json().catch(() => null);
-    if (response.status === 429 && body?.requires_auth) {
+    const detail = body?.detail;
+    if (response.status === 429 && detail?.requires_auth) {
       throw Object.assign(new Error("Login required to analyze more sites"), {
         requiresAuth: true as const,
-        loginUrl: (body.login_url ?? "https://clausea.co/sign-in") as string,
+        loginUrl: (detail.login_url ?? "https://clausea.co/sign-in") as string,
       }) as RateLimitError;
     }
-    throw new Error(body?.detail ?? `Analysis failed with status ${response.status}`);
+    throw new Error(
+      typeof detail === "string"
+        ? detail
+        : `Analysis failed with status ${response.status}`,
+    );
   }
 
   return response.json();

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -27,14 +27,21 @@ export default defineConfig({
       //   1. Get the current tab URL when popup opens (App.tsx:136, App-new.tsx:167)
       //   2. Listen for tab updates/activation to update extension icon (background.ts:112,119)
       //   3. Set extension icon for specific tabs based on privacy policy verdict (background.ts:56)
-      permissions: ["activeTab"],
+      permissions: ["activeTab", "cookies", "storage"],
       // Host permission justifications:
       // - "https://api.clausea.co/*": Production API endpoint for:
       //   1. /extension/check - Check if privacy analysis exists for URL (api.ts:33, background.ts:92,139, App.tsx:190)
       //   2. /extension/domains - Get list of supported domains (api.ts:53)
       //   3. /extension/request-support - Request support for new URL (api.ts:68, App.tsx:221)
       // - "http://localhost:8000/*": Development API endpoint (same endpoints, api.ts:7)
-      host_permissions: ["https://api.clausea.co/*", "http://localhost:8000/*"],
+      // - "https://clausea.co/*": For reading Clerk __session cookie
+      // - "http://localhost:3000/*": Development frontend (for Clerk __session cookie)
+      host_permissions: [
+        "https://api.clausea.co/*",
+        "https://clausea.co/*",
+        "http://localhost:8000/*",
+        "http://localhost:3000/*",
+      ],
       action: {
         default_icon: iconSizes,
       },

--- a/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
@@ -34,6 +34,7 @@ export default async function ProductPage({
 
   return (
     <CompanyPage
+      key={slug}
       initialProduct={initialProduct as Product | null}
       initialData={initialData as ProductOverview | null}
       initialDocuments={(initialDocuments as DocumentSummary[]) ?? []}

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -202,26 +202,40 @@ export default function CompanyPage({
 
     async function fetchData() {
       try {
-        // Fetch the base product first so we can trigger indexation if needed
-        const prodRes = await fetch(`/api/products/${slug}`);
+        setDocumentsLoading(true);
+
+        // Fire all three requests in parallel — product, documents, and overview
+        // arrive together instead of in a sequential chain.
+        const [prodRes, docsRes, overviewRes] = await Promise.all([
+          fetch(`/api/products/${slug}`),
+          fetch(`/api/products/${slug}/documents`),
+          fetch(`/api/products/${slug}/overview`),
+        ]);
+
         if (!prodRes.ok) {
           setProduct(null);
           setData(null);
+          setDocumentsLoading(false);
           setIndexationMode("ready"); // render not-found
           return;
         }
         const prodJson = (await prodRes.json()) as Product;
         setProduct(prodJson);
 
-        // Fetch documents next; if none, auto-trigger pipeline and show "indexing" UI
-        setDocumentsLoading(true);
-        const docsRes = await fetch(`/api/products/${slug}/documents`);
         const docsJson = docsRes.ok
           ? ((await docsRes.json()) as DocumentSummary[])
           : [];
         setDocuments(docsJson);
         setDocumentsLoading(false);
 
+        // Overview was fetched in parallel — use the result immediately.
+        if (overviewRes.ok) {
+          setData((await overviewRes.json()) as ProductOverview);
+          setIndexationMode("ready");
+          return;
+        }
+
+        // No overview yet — decide whether to trigger the pipeline.
         if (!docsJson.length) {
           // Check if there's a recently failed job before auto-triggering
           const latestRes = await fetch(
@@ -233,7 +247,6 @@ export default function CompanyPage({
               latestJob?.status === "failed" &&
               latestJob.crawl_errors?.length > 0
             ) {
-              // Show the failure state instead of auto-retriggering
               setFailedJob({
                 error: latestJob.error,
                 crawl_errors: latestJob.crawl_errors,
@@ -243,25 +256,11 @@ export default function CompanyPage({
               return;
             }
           }
-
-          await ensurePipelineRunning(slug, prodJson);
-          setIndexationMode("indexing");
-          setData(null);
-          return;
         }
 
-        // Documents exist; try to fetch overview (may generate on the fly)
-        const res = await fetch(`/api/products/${slug}/overview`);
-        if (res.ok) {
-          const json = await res.json();
-          setData(json);
-          setIndexationMode("ready");
-        } else {
-          // If overview isn't available yet, treat as "indexing" and ensure pipeline is running.
-          await ensurePipelineRunning(slug, prodJson);
-          setIndexationMode("indexing");
-          setData(null);
-        }
+        await ensurePipelineRunning(slug, prodJson);
+        setIndexationMode("indexing");
+        setData(null);
       } catch (error) {
         console.error("Failed to fetch product data", error);
       } finally {

--- a/packages/frontend/app/(dashboard)/products/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/page.tsx
@@ -5,7 +5,6 @@ import {
   ArrowRight,
   ArrowUpDown,
   CheckCircle2,
-  ChevronDown,
   Search,
   ShieldAlert,
   Sparkles,
@@ -15,18 +14,11 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import posthog from "posthog-js";
 
-import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 
 import { IndexForm } from "@/components/pipeline/index-form";
 import { PipelineProgress } from "@/components/pipeline/pipeline-progress";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
@@ -156,6 +148,13 @@ function ProductCard({
   );
 }
 
+interface ProductsPage {
+  items: Product[];
+  total: number;
+  page: number;
+  pages: number;
+}
+
 function ProductsPageContent() {
   const { user } = useUser();
   const router = useRouter();
@@ -163,14 +162,12 @@ function ProductsPageContent() {
 
   const { trackUserJourney, trackPageView } = useAnalytics();
 
-  const [products, setProducts] = useState<Product[]>([]);
-  const [sortBy, setSortBy] = useState<"name" | "risk" | "recent">("name");
+  const [pageData, setPageData] = useState<ProductsPage>({ items: [], total: 0, page: 1, pages: 1 });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
 
-  // Pagination
-  const ITEMS_PER_PAGE = 20;
   const pageParam = searchParams.get("page");
   const currentPage = pageParam ? parseInt(pageParam) : 1;
 
@@ -190,61 +187,51 @@ function ProductsPageContent() {
     trackPageView("products");
   }, [trackPageView]);
 
+  // Debounce search — 300 ms
   useEffect(() => {
-    if (searchTerm.trim()) {
-      const filteredCount = products.filter(
-        (product) =>
-          product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-          product.description
-            ?.toLowerCase()
-            .includes(searchTerm.toLowerCase()) ||
-          product.categories?.some((cat) =>
-            cat.toLowerCase().includes(searchTerm.toLowerCase()),
-          ),
-      ).length;
-      trackUserJourney.productSearched(searchTerm, filteredCount);
-    }
-  }, [searchTerm, products, trackUserJourney]);
+    const t = setTimeout(() => setDebouncedSearch(searchTerm), 300);
+    return () => clearTimeout(t);
+  }, [searchTerm]);
 
+  // Reset to page 1 when search changes
+  const prevSearch = useRef(debouncedSearch);
+  useEffect(() => {
+    if (prevSearch.current !== debouncedSearch) {
+      prevSearch.current = debouncedSearch;
+      if (currentPage !== 1) {
+        const params = new URLSearchParams(searchParams.toString());
+        params.set("page", "1");
+        router.replace(`/products?${params.toString()}`, { scroll: false });
+      }
+    }
+  }, [debouncedSearch, currentPage, searchParams, router]);
+
+  // Fetch page from server whenever page or search changes
   useEffect(() => {
     async function fetchProducts() {
       try {
         setLoading(true);
-        const response = await fetch("/api/products");
+        const params = new URLSearchParams({ page: String(currentPage), limit: "20" });
+        if (debouncedSearch) params.set("search", debouncedSearch);
+        const response = await fetch(`/api/products?${params.toString()}`);
         if (!response.ok) throw new Error("Failed to fetch products");
-        const data = await response.json();
-        setProducts(data);
+        const data: ProductsPage = await response.json();
+        setPageData(data);
+        if (debouncedSearch.trim()) {
+          trackUserJourney.productSearched(debouncedSearch, data.total);
+        }
       } catch (err) {
         console.error("Error fetching products:", err);
-        setError(
-          err instanceof Error ? err.message : "Failed to fetch products",
-        );
+        setError(err instanceof Error ? err.message : "Failed to fetch products");
       } finally {
         setLoading(false);
       }
     }
     fetchProducts();
-  }, []);
+  }, [currentPage, debouncedSearch, trackUserJourney]);
 
-  const filteredProducts = products.filter(
-    (product) =>
-      product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      product.description?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      product.categories?.some((cat) =>
-        cat.toLowerCase().includes(searchTerm.toLowerCase()),
-      ),
-  );
-
-  const sortedProducts = [...filteredProducts].sort((a, b) => {
-    if (sortBy === "name") return a.name.localeCompare(b.name);
-    return a.name.localeCompare(b.name);
-  });
-
-  const totalPages = Math.ceil(sortedProducts.length / ITEMS_PER_PAGE);
-  const paginatedProducts = sortedProducts.slice(
-    (currentPage - 1) * ITEMS_PER_PAGE,
-    currentPage * ITEMS_PER_PAGE,
-  );
+  const paginatedProducts = pageData.items;
+  const totalPages = pageData.pages;
 
   const setPage = (page: number) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -436,58 +423,22 @@ function ProductsPageContent() {
         </div>
 
         <div className="flex items-center p-2 bg-muted/5">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-10 rounded-none px-6 text-[10px] uppercase tracking-widest font-bold hover:bg-transparent"
-              >
-                <ArrowUpDown
-                  className="mr-3 h-4 w-4 text-foreground/40"
-                  strokeWidth={1.5}
-                />
-                <span className="text-muted-foreground mr-2">Sort:</span>
-                <span className="text-foreground">{sortBy}</span>
-                <ChevronDown className="ml-3 h-3 w-3 opacity-30" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="w-56 p-2 rounded-none border-border shadow-none"
-            >
-              <DropdownMenuItem
-                onClick={() => setSortBy("name")}
-                className="rounded-none cursor-pointer text-[10px] uppercase tracking-widest font-bold focus:bg-muted/10 p-3"
-              >
-                Name (A-Z)
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setSortBy("risk")}
-                className="rounded-none cursor-pointer text-[10px] uppercase tracking-widest font-bold focus:bg-muted/10 p-3"
-              >
-                Risk Level
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => setSortBy("recent")}
-                className="rounded-none cursor-pointer text-[10px] uppercase tracking-widest font-bold focus:bg-muted/10 p-3"
-              >
-                Recently Updated
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="flex items-center px-6 gap-3 text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+            <ArrowUpDown className="h-4 w-4 text-foreground/40" strokeWidth={1.5} />
+            <span>Name (A–Z)</span>
+          </div>
 
           <div className="h-6 w-px bg-border mx-2" />
 
           <div className="px-6 text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-            {filteredProducts.length} Entries
+            {pageData.total} Entries
           </div>
         </div>
       </div>
 
       {/* Grid - Varied spacing */}
       <AnimatePresence mode="popLayout">
-        {filteredProducts.length === 0 ? (
+        {paginatedProducts.length === 0 ? (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/packages/frontend/app/api/products/route.ts
+++ b/packages/frontend/app/api/products/route.ts
@@ -5,18 +5,18 @@ import { httpJson } from "@lib/http";
 
 export async function GET(request: NextRequest) {
   try {
-    const base = apiEndpoints.products();
-    const url = `${base}?include_all=true`;
-    const products = await httpJson(url, {
-      method: "GET",
-    });
+    const { searchParams } = new URL(request.url);
+    const page = searchParams.get("page") ?? "1";
+    const limit = searchParams.get("limit") ?? "20";
+    const search = searchParams.get("search") ?? "";
 
-    // Return the products with caching headers
-    return NextResponse.json(products, {
-      headers: {
-        "Cache-Control": "public, max-age=300", // Cache for 5 minutes
-      },
-    });
+    const params = new URLSearchParams({ page, limit });
+    if (search) params.set("search", search);
+
+    const url = `${apiEndpoints.products()}?${params.toString()}`;
+    const data = await httpJson(url, { method: "GET" });
+
+    return NextResponse.json(data);
   } catch (error) {
     console.error("Error fetching products:", error);
     return NextResponse.json(


### PR DESCRIPTION
## What this PR delivers

This PR hardens the policy-analysis pipeline end to end — from crawl discovery, through document storage, to overview synthesis — and ships three supporting changes that the hardening exposed a need for: server-side product pagination, a faster product page, and a 3-use anonymous limit on the browser extension.

The throughline is **silent failures stop being silent**. Today a crawl can finish "successfully" yet store zero usable documents, an analysis can be poisoned by one bad page, or a misconfigured model list can break all analysis — and the operator sees a vague "No policy documents found". This branch makes each of those failure modes loud, isolated, or impossible: per-URL skip telemetry, per-document failure isolation, a cross-provider model list, an empty-document storage guard, and a refusal to synthesise an overview from nothing.

Alongside it: the crawler now scores discovery smarter (glossary "/terms/" demotion, anchor-aware browser-render gating, sitemap relevance filtering, locale dedup), the products list paginates and searches in the database instead of the browser, the product page fetches its three resources in parallel, and the extension gates anonymous use behind a persistent install UUID with a Clerk-JWT bypass for signed-in users.

## Why this matters

**For operators.** A pipeline that reports success while storing nothing is the worst kind of bug — it looks healthy on the dashboard. After this PR, a run that fetches pages but rejects them all produces a categorized error (`"12 URLs fetched but all rejected by content filters (8× non_policy_classification, 4× insufficient_content)"`) that names the next action. Analysis no longer breaks wholesale when one OpenRouter model is deprecated, because the model lists now span three providers. Browser renders are throttled so JS-heavy crawls stop starving themselves into navigation timeouts. The products list stops shipping the entire catalogue to every browser on every page load.

**For maintainers.** The empty-document graveyard (≈40 placeholder docs with no text) is closed off at the repository layer — `save()` refuses empty content and `update()` refuses to overwrite stored text with an empty projection, killing a round-trip data-loss class. Threshold drift between the crawler's browser-retry gate and the pipeline's storage gate is pinned by a regression test so the two constants can't silently diverge again.

## How pipeline behaviour changes

| Path | Change |
|---|---|
| Document analysis (per product) | One document raising no longer fails the product. Failures are caught, logged loudly, and counted; siblings complete. Cancellation/harness errors still propagate. Pinned by `analyser_failure_isolation_test.py`. |
| Overview synthesis | When **no** document was successfully analysed, raises instead of letting the model fabricate a confident-but-false verdict. The job is marked failed rather than publishing a misleading overview. |
| Analysis model selection | Model lists now span Gemini / OpenRouter / OpenAI. A single model deprecation or provider outage can no longer break analysis. Tiny models (gpt-5-nano, flash-lite) intentionally excluded — they produced wrong extractions. |
| `DocumentRiskBreakdown` parsing | A missing `overall_risk` is now derived from `risk_by_category` (mean, neutral-5 fallback) instead of discarding the whole document analysis. |
| Crawl-result storage | Same-content locale variants (e.g. `/privacy` and `/es/privacy` with identical text) collapse to one canonical doc. Genuinely different regional text has a different fingerprint and is **never** merged. |
| Document persistence | `save()` rejects a document whose text **and** markdown are both empty (raises `ValueError`). `update()` drops empty text/markdown from the `$set` when the stored row has content. |
| Browser-render gate | A static page is only escalated to a browser render when its anchor-aware relevance score clears `min_legal_score`. Speculative guessed URLs never escalate (SPA catch-all shells would flood the shared browser). Concurrent renders capped at `CRAWLER_BROWSER_CONCURRENCY` (default 2). |
| URL scoring | Glossary/terminology pages whose only legal signal is "terms" used non-legally (e.g. `/chess/terms/absolute-pin`) are demoted by the combined terms-signal weight so they stop flooding the crawl. |
| Sitemap seeding | Sitemap URLs are filtered by `min_legal_score` before queueing (no anchor context to lean on), so a large product/course sitemap no longer drowns the queue. |
| Browser-retry threshold | Raised from 200 → 400 chars so a body that survives the crawler gate still clears the downstream processor gate (≥300 after strip). Pinned by `threshold_mismatch_test.py`. |
| Extension `POST /analyze` (anonymous) | First 3 analyses per install UUID allowed, then `429` with a login prompt. Signed-in users (valid Clerk JWT) bypass the limit entirely. Counter increment is atomic against concurrent requests. |
| Extension `POST /analyze` (no token) | Requests with no `X-Extension-Token` and no JWT are rejected `400` ("Update the extension"). |

## UX changes operators will notice

- **Products list**: the sort dropdown (Name / Risk / Recently Updated) is removed — results are name-sorted server-side. Search is debounced (300 ms) and queries the database, so it now matches across the whole catalogue, not just the page already loaded. The entry count reflects the true total, not the filtered-in-browser subset.
- **Product page**: loads noticeably faster — product, documents, and overview are fetched in parallel instead of in a sequential chain. Navigating between two products now resets state correctly (no stale data bleed) thanks to the `key={slug}` remount.
- **Extension**: anonymous users hit a "Sign in to keep analyzing — you've used your 3 free analyses" screen with a sign-in button after their third use.
- **Failed pipeline jobs**: the error message now categorizes *why* every URL was rejected instead of the opaque "No policy documents found on this site".
- **Logs**: silent skips are now `INFO`-level and tagged (`[skip:insufficient_content]`, `[skip:low_legal_score]`, `[skip:non_policy_classification]`, …) instead of swallowed at `debug`.

## Migration — config changes required

| Item | Action |
|---|---|
| Extension permissions | The extension now requests `cookies` + `storage` and host access to `clausea.co` / `localhost:3000` (to read the Clerk `__session` cookie). Users must **re-accept permissions** when the update rolls out — expect a permission prompt on upgrade. |
| `CRAWLER_BROWSER_CONCURRENCY` | New optional env var (default `2`). Set higher only if the host can run more concurrent Camoufox renders without starving them. |
| `products.name` index | A new MongoDB index on `products.name` is auto-created on startup (`ensure_product_indexes`). No manual action; first deploy backfills it in the background. |

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| `GET /products` response | `list[Product]` | `ProductsPage { items, total, page, pages }` |
| `GET /products` query | `include_all=bool` | `page=int`, `limit=int` (≤100), `search=str` |
| Frontend `/api/products` | `?include_all=true`, 5-min `Cache-Control` | proxies `page`/`limit`/`search`, no cache header |
| `POST /extension/analyze` | no auth/identity headers | requires `X-Extension-Token`; optional `Authorization: Bearer <clerk-jwt>` to bypass the limit |
| `429` response from analyze | n/a | `detail: { code, uses_allowed, uses_used, requires_auth, login_url }` |
| `ProductService.get_product_overview` | `(db, slug)` | `(db, slug, product=None)` — accepts a pre-fetched product to avoid a duplicate lookup |
| `DocumentRepository` | — | new `find_by_product_id_with_analysis` (projects out text/markdown/extraction) and `get_compliance_status_by_product` (projects only the compliance map) |

## Tests

- 70 tests passing across the touched backend areas (crawler scoring + content pipeline, pipeline storage dedup, document repository, product repository search, product service, extension usage, analyser failure isolation, crawl-skip telemetry, threshold mismatch).
- Canonical pin: `threshold_mismatch_test.py` locks the crawler browser-retry threshold (400) above the processor storage gate (300) — the invariant that prevents the silent-skip class of bugs.
- Regression pin: `analyser_failure_isolation_test.py` — one failing document must not fail the product; any failure here is a real regression.
- Telemetry pin: `crawl_skip_telemetry_test.py` — every filter rejection must record a categorized `CrawlSkip`.
- Storage pin: `document_repository_test.py` and `pipeline_store_dedup_test.py` — empty-document refusal, projecting-update protection, and locale-variant collapse.

### Edge cases to verify in a staging session

1. Crawl a site that returns only JS-shell pages with a relevant URL (e.g. a known SPA policy page) — expected: browser render fires, content stored; concurrent renders never exceed 2.
2. Crawl a site whose policy pages are all non-English or all classified non-policy — expected: job fails with a *categorized* breakdown, not "No policy documents found".
3. A product served at both `/privacy` and `/es/privacy` with identical text — expected: one document stored (locale-neutral URL kept); different-text regional pages both kept.
4. Extension: trigger 3 analyses anonymously, then a 4th — expected: `429` → login-required screen. Sign in, retry — expected: bypasses the limit.
5. Products search for a string containing regex metacharacters (e.g. `a.b(`) — expected: literal match, no 500.
6. Force one document in a multi-doc product to fail analysis — expected: product still gets an overview from the survivors; logs name the failed doc id.

## Why this PR is large

It bundles one coherent theme — "make the pipeline tell the truth about what it stored and why" — which touches the crawler, the pipeline, the analyser, the repositories, and the models together; splitting them would leave half-wired telemetry. The products-pagination and extension-limit changes ride along because they were unblocked by the same `GET /products` and `/extension/analyze` work.

| Commit | What |
|---|---|
| `33030dc` | Crawler discovery quality (glossary demotion, anchor-aware browser gate, sitemap filtering, locale dedup), product-page parallel fetch, analysis resilience (cross-provider models, per-doc isolation, overview refusal, empty-doc guard) |
| `9b77e2d` | Per-URL crawl-skip telemetry (`CrawlSkip` model, categorized job errors) + `ship_health_check.py` diagnostic |
| `aad4922` | Escape product-search regex, surface escaped `gather` exceptions, fix a type error |
| `4b8775b` | `key={slug}` remount on the product page for correct state refresh |
| `96d7a9f`–`1bba8f0` | Extension anonymous 3-use limit: persistent install UUID, `X-Extension-Token`, atomic counter, Clerk-JWT bypass, login-required UI, FastAPI envelope handling |

## Notes for reviewers

- `threshold_mismatch_test.py` is the canonical specification for the 400/300 threshold relationship — read it before touching either constant.
- The locale-variant collapse is **content-based** (fingerprint), not URL-based — the `_canonical_rank` ordering only decides *which* URL represents identical content. Different regional text is never merged; verify with edge case 3.
- `DocumentRepository.update()` silently dropping empty text/markdown is intentional defence against projecting readers (`find_by_product_id` strips body fields). `rebuild_findings_for_product` was switched to the `_full` loader for the same reason — reverting that re-opens the data-loss path.
- The anonymous limit is keyed by install UUID, not IP; IP is stored only as abuse-detection metadata and never gates access.
