### PR TITLE
chore(backend): add pipeline eval and browser diagnostic scripts

### DIFF
--- a/packages/backend/scripts/analyze_only.py
+++ b/packages/backend/scripts/analyze_only.py
@@ -1,0 +1,51 @@
+"""Run only the LLM analysis (summarize + overview) on already-crawled docs for a slug.
+
+Lets us complete an analysis-quality evaluation without re-crawling, and in a fresh
+process (resets the in-process LLM circuit breaker).
+
+Usage:
+    uv run python scripts/analyze_only.py <slug>
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+
+from src.analyser import analyse_product_documents, generate_product_overview
+from src.core.database import db_session
+from src.core.logging import setup_logging
+from src.services.service_factory import create_document_service, create_product_service
+
+
+async def main(slug: str) -> None:
+    setup_logging()
+    async with db_session() as db:
+        product_svc = create_product_service()
+        doc_svc = create_document_service()
+
+        product = await product_svc.get_product_by_slug(db, slug)
+        if not product:
+            print(f"No product for slug={slug}")
+            return
+
+        t0 = time.perf_counter()
+        print(f"Summarizing documents for {slug} ...")
+        await analyse_product_documents(db, slug, doc_svc)
+        print(f"  summarize done in {time.perf_counter() - t0:.1f}s")
+
+        t1 = time.perf_counter()
+        print(f"Generating overview for {slug} ...")
+        await generate_product_overview(
+            db, slug, force_regenerate=True, product_svc=product_svc, document_svc=doc_svc
+        )
+        print(f"  overview done in {time.perf_counter() - t1:.1f}s")
+        print("DONE")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: analyze_only.py <slug>")
+        sys.exit(1)
+    asyncio.run(main(sys.argv[1]))

--- a/packages/backend/scripts/diag_browser.py
+++ b/packages/backend/scripts/diag_browser.py
@@ -1,0 +1,61 @@
+"""Diagnostic: probe the headless browser against a control page and Duolingo /privacy.
+
+Prints per-load-state timings so we can see WHERE navigation hangs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from camoufox import AsyncCamoufox
+
+
+async def probe(context, url: str) -> None:
+    page = await context.new_page()
+    t0 = time.perf_counter()
+    print(f"\n=== {url} ===")
+    try:
+        resp = await page.goto(url, wait_until="domcontentloaded", timeout=30000)
+        print(
+            f"  goto(domcontentloaded): {time.perf_counter() - t0:.1f}s  status={resp.status if resp else None}"
+        )
+    except Exception as e:
+        print(
+            f"  goto FAILED after {time.perf_counter() - t0:.1f}s: {type(e).__name__}: {str(e)[:120]}"
+        )
+        await page.close()
+        return
+    for state in ("load", "networkidle"):
+        ts = time.perf_counter()
+        try:
+            await page.wait_for_load_state(state, timeout=15000)
+            print(f"  {state}: +{time.perf_counter() - ts:.1f}s")
+        except Exception as e:
+            print(f"  {state}: TIMEOUT +{time.perf_counter() - ts:.1f}s ({str(e)[:60]})")
+    html = await page.content()
+    import re
+
+    text = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", html, flags=re.S | re.I)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    print(f"  rendered_html={len(html)} visible_text={len(text)}")
+    low = html.lower()
+    print(
+        f"  recaptcha={'recaptcha' in low} onetrust={'onetrust' in low or 'cookielaw' in low} "
+        f"challenge={'challenge' in low or 'captcha' in low}"
+    )
+    print(f"  text_sample: {text[:240]}")
+    await page.close()
+
+
+async def main() -> None:
+    t0 = time.perf_counter()
+    async with AsyncCamoufox(headless=True) as context:
+        print(f"browser launched in {time.perf_counter() - t0:.1f}s")
+        await probe(context, "https://example.com")
+        await probe(context, "https://www.duolingo.com/privacy")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/backend/scripts/eval_quality.py
+++ b/packages/backend/scripts/eval_quality.py
@@ -1,0 +1,130 @@
+"""Dump the analysed documents + product overview for a slug, for manual quality review.
+
+Usage:
+    uv run python scripts/eval_quality.py <slug>
+"""
+
+from __future__ import annotations
+
+import sys
+
+from src.core.database import db_session
+from src.core.logging import setup_logging
+from src.services.service_factory import create_document_service, create_product_service
+
+
+def _line(char: str = "-", n: int = 80) -> None:
+    print(char * n)
+
+
+async def main(slug: str) -> None:
+    setup_logging()
+    product_svc = create_product_service()
+    doc_svc = create_document_service()
+
+    async with db_session() as db:
+        product = await product_svc.get_product_by_slug(db, slug)
+        if not product:
+            print(f"No product for slug={slug}")
+            return
+
+        _line("=")
+        print(f"PRODUCT: {product.name}  (slug={product.slug}, id={product.id})")
+        print(f"domains: {product.domains}")
+        _line("=")
+
+        docs = await doc_svc.get_product_documents(db, product.id)
+        print(f"\nDOCUMENTS: {len(docs)}\n")
+        for d in docs:
+            a = d.analysis
+            print(f"### [{d.doc_type}] {d.title or '(no title)'}")
+            print(f"    url: {d.url}")
+            print(f"    locale={d.locale} regions={d.regions} effective_date={d.effective_date}")
+            print(f"    text_len={len(d.text or '')} markdown_len={len(d.markdown or '')}")
+            if a:
+                print(f"    verdict={a.verdict} risk_score={a.risk_score}")
+                if a.scores:
+                    sc = ", ".join(f"{k}={v.score}" for k, v in a.scores.items())
+                    print(f"    scores: {sc}")
+                print(f"    summary: {(a.summary or '')[:400]}")
+                if a.keypoints:
+                    print("    keypoints:")
+                    for kp in a.keypoints[:6]:
+                        print(f"      - {kp}")
+                if a.compliance_status:
+                    print(f"    compliance: {a.compliance_status}")
+                if a.critical_clauses:
+                    print(f"    critical_clauses: {len(a.critical_clauses)}")
+                    for cc in a.critical_clauses[:3]:
+                        title = getattr(cc, "title", None) or getattr(cc, "clause", "")
+                        print(f"      - {str(title)[:120]}")
+            else:
+                print("    (no analysis)")
+            print()
+
+        _line("=")
+        print("PRODUCT OVERVIEW")
+        _line("=")
+        overview = await product_svc.get_product_overview(db, slug, product=product)
+        if not overview:
+            print("(no overview generated)")
+            return
+
+        o = overview
+        print(f"product_name : {o.product_name}")
+        print(f"verdict      : {o.verdict}")
+        print(f"risk_score   : {o.risk_score}")
+        print(f"one_line     : {o.one_line_summary}")
+        if o.detailed_scores:
+            print("detailed_scores:")
+            ds_dict = (
+                o.detailed_scores
+                if isinstance(o.detailed_scores, dict)
+                else o.detailed_scores.model_dump()
+            )
+            for dim, ds in ds_dict.items():
+                score = ds.get("score") if isinstance(ds, dict) else ds
+                print(f"  {dim}: {score}")
+        print(f"\nkeypoints ({len(o.keypoints or [])}):")
+        for kp in (o.keypoints or [])[:10]:
+            print(f"  - {kp}")
+        print(f"\ndata_collected ({len(o.data_collected or [])}): {o.data_collected}")
+        print(f"\ndata_collection_details ({len(o.data_collection_details or [])}):")
+        for dl in (o.data_collection_details or [])[:10]:
+            print(f"  - {dl.data_type}: {dl.purposes}")
+        print(f"\nthird_party_details ({len(o.third_party_details or [])}):")
+        for tp in (o.third_party_details or [])[:10]:
+            print(
+                f"  - {tp.recipient} [{tp.risk_level}] shares={tp.data_shared} purpose={tp.purpose}"
+            )
+        print(f"\ndangers ({len(o.dangers or [])}):")
+        for dg in (o.dangers or [])[:8]:
+            print(f"  - {dg}")
+        print(f"\nyour_rights ({len(o.your_rights or [])}):")
+        for r in (o.your_rights or [])[:8]:
+            print(f"  - {r}")
+        if o.privacy_signals:
+            ps = o.privacy_signals
+            print("\nprivacy_signals:")
+            print(f"  sells_data={ps.sells_data} cross_site_tracking={ps.cross_site_tracking}")
+            print(f"  account_deletion={ps.account_deletion} consent_model={ps.consent_model}")
+            print(f"  data_retention_summary={ps.data_retention_summary}")
+        if o.compliance_status:
+            print(f"\ncompliance_status: {o.compliance_status}")
+        if o.coverage:
+            print(f"\ncoverage ({len(o.coverage)}):")
+            for c in o.coverage:
+                print(f"  - {c.category}: {c.status}")
+        if o.contract_clauses:
+            print(f"\ncontract_clauses ({len(o.contract_clauses)}):")
+            for cc in o.contract_clauses[:6]:
+                print(f"  - {cc[:160]}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: eval_quality.py <slug>")
+        sys.exit(1)
+    import asyncio
+
+    asyncio.run(main(sys.argv[1]))

--- a/packages/backend/scripts/run_pipeline_eval.py
+++ b/packages/backend/scripts/run_pipeline_eval.py
@@ -1,0 +1,69 @@
+"""One-off driver: run the full pipeline for a single URL and report per-step results.
+
+Uses the exact production path (PipelineService.create_job_for_url + run_pipeline) so the
+output reflects real quality. Not part of the app — intended for manual quality evaluation.
+
+Usage:
+    uv run python scripts/run_pipeline_eval.py https://example.com
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+
+from src.core.database import db_session
+from src.core.logging import get_logger, setup_logging
+from src.services.service_factory import create_pipeline_service
+
+logger = get_logger(__name__)
+
+
+async def main(url: str) -> None:
+    setup_logging()
+    pipeline_svc = create_pipeline_service()
+
+    async with db_session() as db:
+        result = await pipeline_svc.create_job_for_url(db, url)
+
+    if result.get("already_indexed"):
+        print(f"ALREADY_INDEXED: {result['product_slug']} ({result['product_name']})")
+        return
+
+    job = result["job"]
+    print(f"JOB_CREATED: id={job.id} slug={job.product_slug} name={job.product_name}")
+    print(f"Running full pipeline for {url} ...")
+
+    start = time.perf_counter()
+    # run_pipeline opens its own db_session and runs crawl -> summarize -> overview
+    await pipeline_svc.run_pipeline(job.id)
+    elapsed = time.perf_counter() - start
+
+    async with db_session() as db:
+        final = await pipeline_svc.get_job(db, job.id)
+
+    print(f"\n=== PIPELINE FINISHED in {elapsed:.1f}s ===")
+    if final is None:
+        print("Job not found after run (unexpected).")
+        return
+
+    print(f"status        : {final.status}")
+    print(f"documents_found : {final.documents_found}")
+    print(f"documents_stored: {final.documents_stored}")
+    if final.error:
+        print(f"error         : {final.error}")
+    print("steps:")
+    for step in final.steps:
+        print(f"  - {step.name:22s} {step.status:10s} {step.message or ''}")
+    if final.crawl_errors:
+        print(f"crawl_errors ({len(final.crawl_errors)}):")
+        for ce in final.crawl_errors[:10]:
+            print(f"  - {ce.error_type:18s} {ce.url}  {ce.error_message or ''}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: run_pipeline_eval.py <url>")
+        sys.exit(1)
+    asyncio.run(main(sys.argv[1]))


### PR DESCRIPTION
## What this PR does

Adds four standalone backend scripts that make up the manual quality-evaluation and diagnostic harness used while building the crawler/analysis pipeline improvements (#54). None are wired into the app — they're operator/developer tools run by hand via `uv run python scripts/...`.

| Script | Purpose |
|---|---|
| `run_pipeline_eval.py` | Run the full production pipeline path (`PipelineService.create_job_for_url` + `run_pipeline`) for one URL and report per-step results. |
| `analyze_only.py` | Re-run only the LLM analysis (summarize + overview) on already-crawled docs for a slug, in a fresh process — resets the in-process LLM circuit breaker, no re-crawl. |
| `eval_quality.py` | Dump a product's analysed documents + overview for a slug for manual quality review. |
| `diag_browser.py` | Probe the headless browser (Camoufox) per-load-state timings against a control page to locate where navigation hangs — the investigation that motivated the `CRAWLER_BROWSER_CONCURRENCY` throttle. |

## Why

These were the tools driving the analysis-resilience and browser-render decisions in #54, but they never got committed. Landing them lets anyone reproduce a quality eval or a browser-hang diagnosis without rebuilding the harness from scratch.

## How to test

- `cd packages/backend && uv run python scripts/run_pipeline_eval.py https://example.com` — runs the pipeline and prints per-step results.
- `uv run python scripts/eval_quality.py <slug>` — prints the stored analysis for an already-indexed product.
- Edge case: run `analyze_only.py <slug>` for a slug with **no** crawled docs — expected: it reports no product/documents rather than erroring out.
