### PR TITLE
fix(pipeline): accurate analysis progress in the frontend

### DIFF
--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -217,8 +217,17 @@ class PipelineService:
                     and step.progress_total > 0
                 ):
                     percent = (step.progress_current / step.progress_total) * 100
-                    step.progress_percent = min(100.0, round(percent, 2))
-                    update_data[f"steps.{i}.progress_percent"] = step.progress_percent
+                    candidate = min(100.0, round(percent, 2))
+                    # Progress must never move backwards. During crawling the
+                    # frontier grows as new links are discovered, so a raw
+                    # current/total ratio oscillates downward; the discovery and
+                    # deep-crawl passes also share this step on fresh crawler stats,
+                    # which would otherwise reset the bar mid-crawl. Clamp to a
+                    # monotonic high-water mark so the UI bar only ever advances.
+                    monotonic = max(step.progress_percent or 0.0, candidate)
+                    if monotonic != step.progress_percent:
+                        step.progress_percent = monotonic
+                        update_data[f"steps.{i}.progress_percent"] = monotonic
 
                 if message is not None:
                     step.message = message

--- a/packages/backend/tests/unit/pipeline_service_test.py
+++ b/packages/backend/tests/unit/pipeline_service_test.py
@@ -119,3 +119,35 @@ async def test_update_step_progress_does_not_overwrite_top_level_fields(
     # Check that step progress is present
     assert args["steps.0.progress_current"] == 2
     assert args["steps.0.progress_total"] == 10
+
+
+@pytest.mark.asyncio
+async def test_update_step_progress_is_monotonic(pipeline_service, mock_repo, mock_db):
+    # The crawl frontier grows as new links are discovered, so a raw
+    # current/total ratio can drop. The reported percent must never regress.
+    job = PipelineJob(
+        id="job-123",
+        product_slug="test-product",
+        product_name="Test Product",
+        url="https://test.com",
+        status="crawling",
+        steps=[PipelineStep(name="crawling", status="running")],
+    )
+
+    # First update: 5 of 10 -> 50%
+    await pipeline_service._update_step_progress(mock_db, job, "crawling", current=5, total=10)
+    assert job.steps[0].progress_percent == 50.0
+
+    # Frontier grew: 6 of 40 would be 15%, but the bar must not move backwards.
+    await pipeline_service._update_step_progress(mock_db, job, "crawling", current=6, total=40)
+    assert job.steps[0].progress_percent == 50.0
+    # The regressed percent must not be written to the DB payload either.
+    last_args = mock_repo.update_fields.call_args[0][2]
+    assert "steps.0.progress_percent" not in last_args
+    # Live counts still update so the message/count stay truthful.
+    assert last_args["steps.0.progress_current"] == 6
+    assert last_args["steps.0.progress_total"] == 40
+
+    # Genuine forward progress advances the bar.
+    await pipeline_service._update_step_progress(mock_db, job, "crawling", current=30, total=40)
+    assert job.steps[0].progress_percent == 75.0

--- a/packages/frontend/app/api/pipeline/jobs/[id]/route.ts
+++ b/packages/frontend/app/api/pipeline/jobs/[id]/route.ts
@@ -3,12 +3,36 @@ import { NextRequest, NextResponse } from "next/server";
 import { getBackendUrl } from "@lib/config";
 import { httpJson } from "@lib/http";
 
+type PipelineJobStatus =
+  | "pending"
+  | "crawling"
+  | "summarizing"
+  | "generating_overview"
+  | "completed"
+  | "failed";
+
 interface PipelineStep {
   name: string;
   status: "pending" | "running" | "completed" | "failed";
   message: string | null;
+  progress_current: number | null;
+  progress_total: number | null;
+  progress_percent: number | null;
   started_at: string | null;
   completed_at: string | null;
+}
+
+interface CrawlError {
+  url: string;
+  status_code: number;
+  error_message: string | null;
+  error_type: string;
+}
+
+interface CrawlSkip {
+  url: string;
+  reason: string;
+  detail: string | null;
 }
 
 interface PipelineJob {
@@ -16,14 +40,17 @@ interface PipelineJob {
   product_slug: string;
   product_name: string;
   url: string;
-  status: string;
+  status: PipelineJobStatus;
   steps: PipelineStep[];
   error: string | null;
   created_at: string;
   updated_at: string;
+  started_at: string | null;
   completed_at: string | null;
   documents_found: number;
   documents_stored: number;
+  crawl_errors: CrawlError[];
+  crawl_skip_reasons: CrawlSkip[];
 }
 
 export async function GET(

--- a/packages/frontend/components/pipeline/pipeline-progress.tsx
+++ b/packages/frontend/components/pipeline/pipeline-progress.tsx
@@ -42,12 +42,20 @@ interface CrawlError {
     | "unknown";
 }
 
+type PipelineJobStatus =
+  | "pending"
+  | "crawling"
+  | "summarizing"
+  | "generating_overview"
+  | "completed"
+  | "failed";
+
 interface PipelineJobData {
   id: string;
   product_slug: string;
   product_name: string;
   url: string;
-  status: string;
+  status: PipelineJobStatus;
   steps: PipelineStep[];
   error: string | null;
   documents_found: number;
@@ -387,10 +395,27 @@ export function PipelineProgress({
     );
   }
 
+  const totalSteps = job.steps.length;
   const completedSteps = job.steps.filter(
     (s) => s.status === "completed",
   ).length;
-  const progress = (completedSteps / job.steps.length) * 100;
+  // Blend whole-step completion with the running step's own progress. This
+  // matches the backend extension status endpoint so both clients report the
+  // same number. Without the running-step contribution the bar is quantized to
+  // thirds and sits at 0% for the entire crawl (typically the longest phase).
+  let progress = totalSteps > 0 ? (completedSteps / totalSteps) * 100 : 0;
+  const runningStep = job.steps.find((s) => s.status === "running");
+  if (
+    runningStep &&
+    runningStep.progress_percent !== undefined &&
+    runningStep.progress_percent !== null &&
+    totalSteps > 0
+  ) {
+    progress =
+      (completedSteps / totalSteps) * 100 +
+      Math.min(runningStep.progress_percent, 100) / totalSteps;
+  }
+  progress = Math.min(100, progress);
 
   return (
     <AnimatePresence>


### PR DESCRIPTION
## What this PR does

Fixes the analysis-in-progress UI so the progress it shows is accurate. Three real inaccuracies are addressed: the headline progress bar no longer sits at 0% for the entire crawl, the per-step crawl bar no longer moves backwards, and the pipeline-job TypeScript types now reflect the payload the backend actually returns.

## Why

While an analysis was running the frontend was misleading:

- **Headline bar pinned at 0%.** It was computed as `completedSteps / 3 * 100`, so during crawling (the longest phase, 0 completed steps) it showed 0% and looked frozen, then jumped 0 → 33 → 66 → 100. The backend's extension status endpoint already blends in the running step's own progress; the web component ignored it. Now both clients use the same blended formula (`completed/total + running_step%/total`).
- **Per-step crawl bar moved backwards.** Crawl progress was `current / total` where `total = visited + pending`, and the `pending` frontier grows as new links are discovered — so the percent oscillated downward, and reset when the discovery and deep-crawl passes (which share the `crawling` step) switched. The backend now clamps `progress_percent` to a monotonic high-water mark, so it only ever advances. Live counts and the "X/Y pages scanned" message still update truthfully. This fixes both the web app and the extension, which read the same field.
- **Lying types.** `status` was typed `string` / `pending|running|completed|failed`, but the backend emits `crawling | summarizing | generating_overview` mid-run. Replaced with the accurate `PipelineJobStatus` union and completed the jobs proxy payload type (progress fields, `crawl_errors`, `crawl_skip_reasons`, `started_at`).

## How to test

1. Trigger an analysis for a product with many pages and watch the progress card.
   - **Expected:** the headline bar climbs smoothly during crawling instead of staying at 0%, and rises continuously through summarizing.
2. Watch the per-step crawl bar during the discovery phase as the crawler finds more links.
   - **Edge case:** the bar must never tick backwards, and must not reset when it transitions from "Discovery" to "Deep Crawl".
3. Compare the percentage shown in the browser extension popup against the web app for the same running job.
   - **Expected:** they agree.
4. Backend regression: `uv run pytest tests/unit/pipeline_service_test.py` — includes `test_update_step_progress_is_monotonic`, which pins that a `6/40` update after a `5/10` update does not regress the reported percent.

## Note

`product-page-client.tsx:232-236` (the early return when an overview already exists) is intentionally left as-is — see the review comment thread. There is no re-analyze trigger in the UI today, so a job running over an existing overview isn't reachable; removing that fast-path would wrongly re-trigger the pipeline for every already-analyzed product.
