### PR TITLE
fix(crawler): surface robots.txt blocks in the UI (it's the site, not us)

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -3639,6 +3639,14 @@ class ClauseaCrawler:
                             self.stats.failed_urls += 1
                             self.failed_urls.add(url)
                             logger.warning(f"❌ Failed: {url} - {result.error_message}")
+                            # Surface robots.txt blocks so the pipeline can tell the user
+                            # the SITE blocked us (not that we failed). Other failures stay
+                            # a count to avoid recording large volumes of probe 404s.
+                            if (
+                                result.error_message
+                                and "robots.txt" in result.error_message.lower()
+                            ):
+                                self.results.append(result)
 
                     # Progress update — emitted on a threshold crossing so it
                     # survives batched jumps in total_urls (see helper docstring).

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -144,6 +144,7 @@ class StaticFetchResult:
             status_code=self.status_code,
             success=False,
             error_message=self.error_message or f"HTTP {self.status_code}",
+            blocked_by_robots_txt=self.blocked_by_robots_txt,
         )
 
 
@@ -184,6 +185,9 @@ class CrawlResult(BaseModel):
     )
     discovered_links: list[dict[str, str]] = Field(
         default_factory=list, description="List of links with both URL and original anchor text"
+    )
+    blocked_by_robots_txt: bool = Field(
+        default=False, description="True if the fetch was refused by the site's robots.txt"
     )
 
 
@@ -3642,10 +3646,7 @@ class ClauseaCrawler:
                             # Surface robots.txt blocks so the pipeline can tell the user
                             # the SITE blocked us (not that we failed). Other failures stay
                             # a count to avoid recording large volumes of probe 404s.
-                            if (
-                                result.error_message
-                                and "robots.txt" in result.error_message.lower()
-                            ):
+                            if result.blocked_by_robots_txt:
                                 self.results.append(result)
 
                     # Progress update — emitted on a threshold crossing so it

--- a/packages/backend/tests/unit/crawl_robots_error_test.py
+++ b/packages/backend/tests/unit/crawl_robots_error_test.py
@@ -1,0 +1,37 @@
+"""A robots.txt block must be recorded as a robots_txt_blocked crawl error, so the
+pipeline can tell the user the SITE refused us (not that we failed). Without this, a
+robots-blocked crawl reports the generic "no documents found".
+"""
+
+import pytest
+
+from src.crawler import CrawlResult
+from src.models.product import Product
+from src.pipeline import PolicyDocumentPipeline
+
+
+def _product() -> Product:
+    return Product(
+        id="p1", name="X", slug="x", domains=["x.com"], crawl_base_urls=["https://x.com"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_robots_block_recorded_as_robots_txt_blocked_crawl_error() -> None:
+    pipeline = PolicyDocumentPipeline()
+    blocked = CrawlResult(
+        url="https://x.com/legal",
+        title="",
+        content="",
+        markdown="",
+        metadata={},
+        status_code=403,
+        success=False,
+        error_message="Blocked by robots.txt: Blocked by pattern: /",
+    )
+
+    docs = await pipeline._classify_results([blocked], _product(), set(), set())
+
+    assert docs == []
+    assert len(pipeline.stats.crawl_errors) == 1
+    assert pipeline.stats.crawl_errors[0]["error_type"] == "robots_txt_blocked"

--- a/packages/frontend/lib/pipeline-errors.ts
+++ b/packages/frontend/lib/pipeline-errors.ts
@@ -6,20 +6,20 @@ export const PIPELINE_ERROR_CODE_MESSAGES: Record<string, string> = {
   product_not_found:
     "We couldn't find this product. Please try submitting the URL again.",
   crawl_robots_blocked:
-    "This site's robots.txt blocks automated access, so we couldn't read its policy documents. That's a restriction set by the site — not an error on our end. You'll need to review their policies manually.",
+    "This site's robots.txt blocks automated access, so we couldn't read its policy documents. That's a restriction set by the site, not an error on our end. You'll need to review their policies manually.",
   crawl_failed:
     "We couldn't crawl this site successfully, so no policy documents were found. Please try again later.",
   no_documents_found:
     "We crawled this site but couldn't find any policy documents to analyze.",
   all_analysis_failed:
-    "We found documents but couldn't analyze any of them. This is usually a temporary issue — please try again.",
+    "We found documents but couldn't analyze any of them. This is usually a temporary issue. Please try again.",
   core_docs_unanalyzed:
-    "We couldn't analyze the core policy documents (privacy/terms), so we can't build a reliable overview. This is usually a temporary issue — please try again.",
+    "We couldn't analyze the core policy documents (privacy/terms), so we can't build a reliable overview. This is usually a temporary issue. Please try again.",
   overview_not_persisted:
     "We analyzed the documents but couldn't generate the overview. Please try again.",
   internal_error: "Something went wrong while analyzing this site.",
   timed_out:
-    "Analysis took too long and timed out. Please try again — large sites may need another attempt.",
+    "Analysis took too long and timed out. Please try again, as large sites may need another attempt.",
 };
 
 export function resolvePipelineErrorMessage(

--- a/packages/frontend/lib/pipeline-errors.ts
+++ b/packages/frontend/lib/pipeline-errors.ts
@@ -6,7 +6,7 @@ export const PIPELINE_ERROR_CODE_MESSAGES: Record<string, string> = {
   product_not_found:
     "We couldn't find this product. Please try submitting the URL again.",
   crawl_robots_blocked:
-    "This site blocks automated access via robots.txt, so we couldn't crawl any policy documents. You may need to review their policies manually.",
+    "This site's robots.txt blocks automated access, so we couldn't read its policy documents. That's a restriction set by the site — not an error on our end. You'll need to review their policies manually.",
   crawl_failed:
     "We couldn't crawl this site successfully, so no policy documents were found. Please try again later.",
   no_documents_found:


### PR DESCRIPTION
## What
When a site's `robots.txt` disallows crawling, the pipeline now reports `crawl_robots_blocked` and the frontend tells the user the **site** refused automated access — instead of the generic "no documents found", which looked like our failure.

## Why
Found during a live Disney+ eval: `disneyplus.com/robots.txt` disallows `/` (the whole site), so `/legal` was refused. But a robots-blocked URL was only counted in `failed_urls` and never appended to the crawl results, so `_classify_results` never recorded a `robots_txt_blocked` crawl error → the job fell through to `no_documents_found`.

## Change
- `crawler.py`: append robots-blocked failures to the results so the pipeline records them. Other failure types stay a count (avoids logging volumes of speculative-probe 404s).
- The pipeline already maps an all-robots crawl → `PipelineErrorCode.crawl_robots_blocked`; the frontend copy now states it's the site's restriction, not our error.
- Adds `crawl_robots_error_test.py` locking in the robots → `crawl_errors` wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)