### PR TITLE
perf: cut idle memory (MALLOC_ARENA_MAX + lazy litellm import)

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -90,6 +90,11 @@ COPY --from=builder /opt/camoufox-cache /opt/camoufox-cache
 
 COPY . .
 
+# Cap glibc per-thread arenas. The crawler uses thread pools, and glibc otherwise
+# spins up many arenas that hoard freed memory, inflating idle RSS (and the Railway
+# memory bill). 2 arenas keeps memory returning to the OS with negligible perf cost.
+ENV MALLOC_ARENA_MAX=2
+
 EXPOSE 8000
 
 # Exec form: uvicorn runs as PID 1 so Railway's SIGTERM is delivered directly.

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -90,9 +90,7 @@ COPY --from=builder /opt/camoufox-cache /opt/camoufox-cache
 
 COPY . .
 
-# Cap glibc per-thread arenas. The crawler uses thread pools, and glibc otherwise
-# spins up many arenas that hoard freed memory, inflating idle RSS (and the Railway
-# memory bill). 2 arenas keeps memory returning to the OS with negligible perf cost.
+# Cap glibc arenas so freed memory returns to the OS instead of being hoarded per thread.
 ENV MALLOC_ARENA_MAX=2
 
 EXPOSE 8000

--- a/packages/backend/src/core/logging.py
+++ b/packages/backend/src/core/logging.py
@@ -84,11 +84,7 @@ def setup_logging() -> None:
     logging.getLogger("pymongo.server").setLevel(logging.INFO)
     logging.getLogger("httpx").setLevel(logging.INFO)
     logging.getLogger("httpcore").setLevel(logging.INFO)
-    # litellm logs every completion at INFO ("LiteLLM completion() model=..."). During an
-    # analysis burst that floods to hundreds of lines/sec (hitting Railway's 500/sec cap and
-    # dropping real errors), so keep it at WARNING. No litellm import needed: the named logger
-    # is configured here and litellm uses it when it logs.
-    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+    logging.getLogger("LiteLLM").setLevel(logging.INFO)
 
 
 def get_logger(name: str = __name__, component: str | None = None) -> Any:

--- a/packages/backend/src/core/logging.py
+++ b/packages/backend/src/core/logging.py
@@ -84,7 +84,11 @@ def setup_logging() -> None:
     logging.getLogger("pymongo.server").setLevel(logging.INFO)
     logging.getLogger("httpx").setLevel(logging.INFO)
     logging.getLogger("httpcore").setLevel(logging.INFO)
-    logging.getLogger("LiteLLM").setLevel(logging.INFO)
+    # litellm logs every completion at INFO ("LiteLLM completion() model=..."). During an
+    # analysis burst that floods to hundreds of lines/sec (hitting Railway's 500/sec cap and
+    # dropping real errors), so keep it at WARNING. No litellm import needed: the named logger
+    # is configured here and litellm uses it when it logs.
+    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
 
 
 def get_logger(name: str = __name__, component: str | None = None) -> Any:

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
 import os
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any
-
-import litellm
-from litellm import EmbeddingResponse, ModelResponse, acompletion
+from typing import TYPE_CHECKING, Any
 
 from src.core.logging import get_logger
 from src.utils.llm_usage import track_usage
+
+# litellm is heavy to import (provider SDKs, tokenizers; hundreds of MB resident). Defer it
+# to first use so a process that only serves reads never loads it. Annotations are strings
+# via `from __future__ import annotations`, so the types below are needed only for checking.
+if TYPE_CHECKING:
+    from litellm import EmbeddingResponse, ModelResponse
 
 logger = get_logger(__name__)
 
@@ -191,6 +196,8 @@ async def acompletion_with_fallback(
     if _consecutive_total_failures >= _CIRCUIT_BREAKER_THRESHOLD:
         raise CircuitBreakerError("LLM service unavailable: too many consecutive failures")
 
+    from litellm import acompletion
+
     try:
         result = await _completion_with_fallback_impl(
             messages=messages,
@@ -217,6 +224,8 @@ async def get_embeddings(
     model_name: SupportedModel = "voyage-law-2",
 ) -> EmbeddingResponse:
     """Generate embeddings using the specified model."""
+    import litellm
+
     model = get_model(model_name)
     try:
         kwargs: dict[str, Any] = {

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import importlib
 import os
 import time
 from collections.abc import Awaitable, Callable
@@ -194,6 +196,8 @@ async def acompletion_with_fallback(
     if _consecutive_total_failures >= _CIRCUIT_BREAKER_THRESHOLD:
         raise CircuitBreakerError("LLM service unavailable: too many consecutive failures")
 
+    # Load the heavy litellm import off the event loop on first use; cached afterward.
+    await asyncio.to_thread(importlib.import_module, "litellm")
     from litellm import acompletion
 
     try:
@@ -222,6 +226,7 @@ async def get_embeddings(
     model_name: SupportedModel = "voyage-law-2",
 ) -> EmbeddingResponse:
     """Generate embeddings using the specified model."""
+    await asyncio.to_thread(importlib.import_module, "litellm")
     import litellm
 
     model = get_model(model_name)

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -8,9 +8,7 @@ from typing import TYPE_CHECKING, Any
 from src.core.logging import get_logger
 from src.utils.llm_usage import track_usage
 
-# litellm is heavy to import (provider SDKs, tokenizers; hundreds of MB resident). Defer it
-# to first use so a process that only serves reads never loads it. Annotations are strings
-# via `from __future__ import annotations`, so the types below are needed only for checking.
+# litellm is heavy to import; defer it to first use.
 if TYPE_CHECKING:
     from litellm import EmbeddingResponse, ModelResponse
 

--- a/packages/backend/src/utils/llm_usage.py
+++ b/packages/backend/src/utils/llm_usage.py
@@ -4,18 +4,22 @@ LLM Usage Tracking Utilities
 Shared utilities for tracking, aggregating, and logging LLM token usage across the codebase.
 """
 
+from __future__ import annotations
+
 import contextvars
 import logging
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
-
-from litellm import ModelResponse
+from typing import TYPE_CHECKING, Any
 
 from src.core.config import config
 from src.core.logging import get_logger
+
+# ModelResponse is only used in annotations; defer the heavy litellm import (see src/llm.py).
+if TYPE_CHECKING:
+    from litellm import ModelResponse
 
 logger = get_logger(__name__)
 

--- a/packages/backend/src/utils/llm_usage.py
+++ b/packages/backend/src/utils/llm_usage.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 from src.core.config import config
 from src.core.logging import get_logger
 
-# ModelResponse is only used in annotations; defer the heavy litellm import (see src/llm.py).
+# litellm is heavy to import; defer it (annotation-only here).
 if TYPE_CHECKING:
     from litellm import ModelResponse
 


### PR DESCRIPTION
Two memory wins (the litellm-log-level change was dropped; litellm stays at INFO per discussion).

## MALLOC_ARENA_MAX=2
The crawler uses thread pools; glibc spins up many per-thread arenas that hoard freed memory and inflate idle RSS (the memory line on the Railway bill). Capping arenas lets memory return to the OS, negligible perf cost.

## Lazy-import litellm
litellm is heavy to import (provider SDKs, tokenizers). It was imported at module top in `llm.py` and `llm_usage.py` so it loaded at boot. Deferred to first use (`TYPE_CHECKING` + local imports); verified it's no longer in `sys.modules` after importing the app's modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)