### PR TITLE
fix(pipeline): don't fail pending jobs on worker restart

### DIFF
--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -15,6 +15,11 @@ from src.repositories.base_repository import BaseRepository
 
 _TERMINAL_STATUSES = list(TERMINAL_PIPELINE_STATUSES)
 
+# Statuses for a job that was actively executing and can be left orphaned by a worker
+# crash. A "pending" job is only queued — never started — so a restart must leave it
+# pending for the worker to pick up, not fail it. Only these can be marked stale.
+_ORPHANABLE_STATUSES = ["crawling", "summarizing", "generating_overview"]
+
 logger = get_logger(__name__)
 
 
@@ -176,10 +181,14 @@ class PipelineRepository(BaseRepository):
     async def mark_stale_as_failed(
         self, db: AgnosticDatabase, stale_threshold_minutes: int = 30
     ) -> int:
-        """Mark all non-terminal jobs older than the threshold as failed.
+        """Mark stale in-progress jobs older than the threshold as failed.
 
         Used on startup to recover from server crashes that left jobs orphaned.
         Uses last_heartbeat if available, otherwise falls back to updated_at.
+
+        Only jobs that were actively executing are eligible — "pending" jobs are queued,
+        not orphaned, so a restart leaves them for the worker to pick up rather than
+        failing the whole backlog.
 
         Returns the number of jobs marked as failed.
         """
@@ -188,7 +197,7 @@ class PipelineRepository(BaseRepository):
         cutoff = datetime.now() - timedelta(minutes=stale_threshold_minutes)
         result = await db[self.COLLECTION].update_many(
             {
-                "status": {"$nin": _TERMINAL_STATUSES},
+                "status": {"$in": _ORPHANABLE_STATUSES},
                 "$or": [
                     {"last_heartbeat": {"$lt": cutoff}},
                     {"last_heartbeat": None, "updated_at": {"$lt": cutoff}},

--- a/packages/backend/tests/unit/pipeline_stale_jobs_test.py
+++ b/packages/backend/tests/unit/pipeline_stale_jobs_test.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.repositories.pipeline_repository import _ORPHANABLE_STATUSES, PipelineRepository
+from src.repositories.pipeline_repository import PipelineRepository
 
 
 @pytest.mark.asyncio
@@ -21,8 +21,8 @@ async def test_mark_stale_targets_only_in_progress_not_pending():
 
     await PipelineRepository().mark_stale_as_failed(db)
 
-    query = collection.update_many.call_args.args[0]
-    assert query["status"] == {"$in": _ORPHANABLE_STATUSES}
-    assert "pending" not in _ORPHANABLE_STATUSES
-    # The orphanable set is exactly the actively-executing statuses.
-    assert set(_ORPHANABLE_STATUSES) == {"crawling", "summarizing", "generating_overview"}
+    eligible = collection.update_many.call_args.args[0]["status"]["$in"]
+    # A queued job was never started, so a restart must not fail it.
+    assert "pending" not in eligible
+    # Only actively-executing statuses can be orphaned by a crash.
+    assert set(eligible) == {"crawling", "summarizing", "generating_overview"}

--- a/packages/backend/tests/unit/pipeline_stale_jobs_test.py
+++ b/packages/backend/tests/unit/pipeline_stale_jobs_test.py
@@ -1,0 +1,28 @@
+"""A worker restart must not fail queued (pending) jobs.
+
+mark_stale_as_failed recovers jobs orphaned by a crash. A "pending" job is only queued —
+never started — so a restart must leave it pending for the worker to pick up. Failing the
+whole backlog on every restart would be fatal for a large re-run.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.repositories.pipeline_repository import _ORPHANABLE_STATUSES, PipelineRepository
+
+
+@pytest.mark.asyncio
+async def test_mark_stale_targets_only_in_progress_not_pending():
+    collection = MagicMock()
+    collection.update_many = AsyncMock(return_value=MagicMock(modified_count=0))
+    db = MagicMock()
+    db.__getitem__.return_value = collection
+
+    await PipelineRepository().mark_stale_as_failed(db)
+
+    query = collection.update_many.call_args.args[0]
+    assert query["status"] == {"$in": _ORPHANABLE_STATUSES}
+    assert "pending" not in _ORPHANABLE_STATUSES
+    # The orphanable set is exactly the actively-executing statuses.
+    assert set(_ORPHANABLE_STATUSES) == {"crawling", "summarizing", "generating_overview"}


### PR DESCRIPTION
## Problem

During the prod re-run, a single worker restart flipped **63 queued products to `failed`** at once, all with error *"Server restart — job was orphaned."* The restart was almost certainly an OOM crash from the concurrent-browser bug (#62) — but the queue wipe is a separate, independent bug.

## Root cause

`mark_stale_as_failed` (run on worker boot to recover crashed jobs) marked **every non-terminal job** older than the threshold as failed — including `pending` jobs that were only **queued, never started**. So any worker restart fails the entire backlog, not just the job that was actually in flight when it died. Fatal for a large (130-product) re-run that restarts several times.

## Fix

Restrict stale recovery to **actively-executing** statuses (`crawling`, `summarizing`, `generating_overview`). `pending` jobs are queued, not orphaned — they stay pending across restarts so the worker picks them up.

## Test

`tests/unit/pipeline_stale_jobs_test.py`: asserts the stale query targets only the orphanable in-progress statuses and never `pending`.

## Deploy

Pairs with #62 — both want one worker redeploy. After deploy I'll re-seed the products that were wrongly failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)