### PR TITLE
feat(products): match domains in product search

### DIFF
--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -141,13 +141,14 @@ class ProductRepository(BaseRepository):
         limit: int,
         search: str = "",
     ) -> tuple[list[Product], int]:
-        """Get a paginated list of products with optional name/description/category search.
+        """Get a paginated list of products with optional name/description/category/domain search.
 
         Args:
             db: Database instance
             skip: Number of documents to skip
             limit: Maximum number of documents to return
-            search: Case-insensitive search string matched against name, description, categories
+            search: Case-insensitive search string matched against name, description,
+                categories, and domains
 
         Returns:
             Tuple of (products, total_count)
@@ -162,6 +163,7 @@ class ProductRepository(BaseRepository):
                     {"name": {"$regex": escaped_search, "$options": "i"}},
                     {"description": {"$regex": escaped_search, "$options": "i"}},
                     {"categories": {"$regex": escaped_search, "$options": "i"}},
+                    {"domains": {"$regex": escaped_search, "$options": "i"}},
                 ]
             }
             total, items_data = await asyncio.gather(

--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -158,12 +158,20 @@ class ProductRepository(BaseRepository):
             # Escape so user input is matched literally — raw regex metacharacters
             # would 500 on invalid patterns or open a ReDoS vector.
             escaped_search = re.escape(search)
+            # Stored domains are bare hosts (e.g. "anthropic.com"), but users often
+            # paste a full URL. Strip scheme/www and any path so "https://www.anthropic.com/"
+            # still matches. Fall back to the raw term if normalization empties it
+            # (e.g. the user typed only "https://") so we don't match every product.
+            normalized_domain = re.sub(
+                r"^(https?://)?(www\.)?", "", search.strip(), flags=re.IGNORECASE
+            ).split("/")[0]
+            domain_search = re.escape(normalized_domain) or escaped_search
             query = {
                 "$or": [
                     {"name": {"$regex": escaped_search, "$options": "i"}},
                     {"description": {"$regex": escaped_search, "$options": "i"}},
                     {"categories": {"$regex": escaped_search, "$options": "i"}},
-                    {"domains": {"$regex": escaped_search, "$options": "i"}},
+                    {"domains": {"$regex": domain_search, "$options": "i"}},
                 ]
             }
             total, items_data = await asyncio.gather(

--- a/packages/backend/tests/unit/product_repository_search_test.py
+++ b/packages/backend/tests/unit/product_repository_search_test.py
@@ -62,6 +62,48 @@ async def test_find_paginated_escapes_regex_metacharacters() -> None:
             re.compile(pattern)  # must be a valid (literal) pattern
 
 
+def _domains_pattern(query: dict[str, Any]) -> str:
+    for clause in query["$or"]:
+        if "domains" in clause:
+            return clause["domains"]["$regex"]
+    raise AssertionError("expected a domains clause in the query")
+
+
+@pytest.mark.parametrize(
+    "search",
+    [
+        "https://www.anthropic.com/",
+        "www.anthropic.com",
+        "http://anthropic.com",
+        "anthropic.com",
+    ],
+)
+@pytest.mark.asyncio
+async def test_find_paginated_normalizes_pasted_urls_for_domain_match(search: str) -> None:
+    repo = ProductRepository()
+    db, captured_queries = _fake_db_capturing_queries()
+
+    await repo.find_paginated(db, skip=0, limit=10, search=search)
+
+    assert captured_queries, "expected the search query to reach the collection"
+    for query in captured_queries:
+        assert _domains_pattern(query) == re.escape("anthropic.com")
+
+
+@pytest.mark.asyncio
+async def test_find_paginated_domain_falls_back_when_normalization_is_empty() -> None:
+    repo = ProductRepository()
+    db, captured_queries = _fake_db_capturing_queries()
+    scheme_only = "https://"
+
+    await repo.find_paginated(db, skip=0, limit=10, search=scheme_only)
+
+    # Normalization strips everything, so the domains clause must fall back to the
+    # raw escaped term rather than an empty pattern that matches every product.
+    for query in captured_queries:
+        assert _domains_pattern(query) == re.escape(scheme_only)
+
+
 @pytest.mark.asyncio
 async def test_find_paginated_without_search_uses_empty_query() -> None:
     repo = ProductRepository()


### PR DESCRIPTION
## What this PR does

Product search now matches against each product's `domains` array, not just `name`, `description`, and `categories`. Typing a company name like **anthropic** surfaces **Claude**, because `anthropic.com` lives in its `domains`.

## Why

Users naturally search by the company/brand domain they know, but a product's display name often differs from its domain (Claude ↔ anthropic.com). Without matching domains, those searches returned nothing even though the data was there.

## How to test

1. On `/products`, type `anthropic` → Claude appears in the results.
2. Type a partial domain like `anthrop` → still matches (substring, case-insensitive).
3. Search by name (e.g. `claude`) or category → unchanged, still works.
4. Empty search → full paginated list, unchanged.

The match reuses the existing escaped, case-insensitive `$or` regex in `find_paginated`; since `domains` is an array, Mongo matches if any element matches (same semantics as the existing `categories` clause).
