### PR TITLE
fix(worker): sweep orphaned jobs periodically, not just at boot

### DIFF
--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -5,8 +5,9 @@ The web service only creates pending pipeline_jobs; this process executes them, 
 service on the same image:  uv run python worker.py
 
 Concurrency and poll interval are env-tunable:
-  PIPELINE_WORKER_CONCURRENCY  (default 2)  max jobs running at once
-  PIPELINE_WORKER_POLL_SECONDS (default 3)  idle poll interval
+  PIPELINE_WORKER_CONCURRENCY         (default 2)    max jobs running at once
+  PIPELINE_WORKER_POLL_SECONDS        (default 3)    idle poll interval
+  PIPELINE_WORKER_STALE_SWEEP_SECONDS (default 300)  how often to reap orphaned jobs
 """
 
 from __future__ import annotations
@@ -24,6 +25,18 @@ logger = get_logger(__name__)
 
 _CONCURRENCY = max(1, int(os.getenv("PIPELINE_WORKER_CONCURRENCY", "2")))
 _POLL_SECONDS = float(os.getenv("PIPELINE_WORKER_POLL_SECONDS", "3"))
+_STALE_SWEEP_SECONDS = float(os.getenv("PIPELINE_WORKER_STALE_SWEEP_SECONDS", "300"))
+
+
+async def _sweep_stale(repo: PipelineRepository) -> None:
+    """Reap jobs orphaned by a crash. Runs at startup and periodically: mark_stale only
+    catches jobs already past the staleness threshold, so a one-shot boot sweep leaves jobs
+    orphaned shortly before the restart stuck until the next boot. Active jobs refresh their
+    timestamp well within the threshold, so a running job is never reaped."""
+    async with db_session() as db:
+        reaped = await repo.mark_stale_as_failed(db)
+    if reaped:
+        logger.info("Reaped %d stale job(s) as failed", reaped)
 
 
 async def _run_job(job_id: str) -> None:
@@ -55,15 +68,17 @@ async def main() -> None:
             pass  # add_signal_handler is unavailable on Windows; signals are a Unix/prod concern
 
     # Reap jobs orphaned by a previous crash before claiming new work.
-    async with db_session() as db:
-        reaped = await repo.mark_stale_as_failed(db)
-        if reaped:
-            logger.info("Worker startup: marked %d stale job(s) as failed", reaped)
+    await _sweep_stale(repo)
+    last_sweep = loop.time()
 
     logger.info("Pipeline worker started (concurrency=%d, poll=%.1fs)", _CONCURRENCY, _POLL_SECONDS)
     running: set[asyncio.Task[None]] = set()
 
     while not stop.is_set():
+        if loop.time() - last_sweep >= _STALE_SWEEP_SECONDS:
+            await _sweep_stale(repo)
+            last_sweep = loop.time()
+
         if len(running) >= _CONCURRENCY:
             await _sleep_or_stop(stop, _POLL_SECONDS)
             continue


### PR DESCRIPTION
## Problem

`mark_stale_as_failed` only ran **once at worker startup**. A job orphaned shortly before/at a restart (claimed → `crawling`, but <30 min old at boot) is missed by that boot's sweep and lingers as `crawling` until the *next* restart. During today's re-run, ~16 such orphans piled up after a redeploy: they block their products (the active orphan stops `find_or_create_active` from re-seeding) and are never reaped.

## Fix

Run the stale sweep on a timer inside the poll loop (`PIPELINE_WORKER_STALE_SWEEP_SECONDS`, default 300s), in addition to the boot sweep. Active jobs refresh their timestamp well within the 30-min staleness threshold, so a genuinely-running job is never reaped — only true orphans.

## Test

Reaping logic (`mark_stale_as_failed` targeting only in-progress, never pending) is covered by `tests/unit/pipeline_stale_jobs_test.py` (#63). This change adds the periodic trigger; loop-timing isn't unit-tested (brittle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)