### PR TITLE
feat(pipeline): abort stalled jobs via a no-progress watchdog

### DIFF
--- a/packages/backend/src/models/pipeline_job.py
+++ b/packages/backend/src/models/pipeline_job.py
@@ -25,6 +25,7 @@ class PipelineErrorCode(StrEnum):
     overview_not_persisted = "overview_not_persisted"
     internal_error = "internal_error"
     timed_out = "timed_out"
+    stalled = "stalled"
 
 
 PipelineJobStatus = Literal[

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -5,6 +5,8 @@ execution of the full crawl -> summarize -> overview pipeline.
 """
 
 import asyncio
+import contextlib
+import os
 from datetime import datetime
 from typing import Any
 
@@ -20,7 +22,13 @@ from src.analyser import (
 from src.core.database import db_session
 from src.core.logging import get_logger
 from src.models.document import Document
-from src.models.pipeline_job import CrawlError, CrawlSkip, PipelineErrorCode, PipelineJob
+from src.models.pipeline_job import (
+    TERMINAL_PIPELINE_STATUSES,
+    CrawlError,
+    CrawlSkip,
+    PipelineErrorCode,
+    PipelineJob,
+)
 from src.models.product import Product
 from src.pipeline import PolicyDocumentPipeline
 from src.prompts.analysis_prompts import OVERVIEW_CORE_DOC_TYPES
@@ -30,7 +38,15 @@ from src.utils.domain import extract_domain as _extract_domain
 
 logger = get_logger(__name__)
 
-MAX_PIPELINE_DURATION_SECONDS = 7200  # 2 hours
+MAX_PIPELINE_DURATION_SECONDS = 7200  # 2 hours — hard ceiling backstop
+# Abort a job that makes no forward progress (no page/document/step update bumps updated_at)
+# for this long. Bounds *inactivity*, not total runtime: a slow-but-advancing pipeline runs to
+# the hard ceiling, while a wedged one frees its worker slot fast instead of clogging it.
+STALL_TIMEOUT_SECONDS = float(os.getenv("PIPELINE_STALL_TIMEOUT_SECONDS", "900"))  # 15 min
+
+
+class _PipelineStalled(Exception):
+    """Raised internally when a job makes no progress within STALL_TIMEOUT_SECONDS."""
 
 
 def _domain_to_product_name(domain: str) -> str:
@@ -140,6 +156,51 @@ class PipelineService:
             logger.info(f"Active pipeline job already exists for {product.slug}: {job.id}")
 
         return {"already_indexed": False, "job": job}
+
+    async def _await_with_stall_guard(
+        self, core_task: asyncio.Task[None], job_id: str, started_at: datetime
+    ) -> None:
+        """Await the pipeline core, cancelling it if the job stalls (no progress for the timeout).
+
+        Progress is any step/page/document update, each of which bumps the job's updated_at. A
+        pipeline that is still advancing — even slowly through the model cascade — is never
+        cancelled; only one wedged with zero forward progress is, freeing the worker slot rather
+        than holding it to the 2h ceiling.
+        """
+        poll = min(60.0, STALL_TIMEOUT_SECONDS)
+        while True:
+            done, _ = await asyncio.wait({core_task}, timeout=poll)
+            if core_task in done:
+                await core_task  # propagate any error the core didn't handle internally
+                return
+
+            async with db_session() as watchdog_db:
+                fresh = await self._pipeline_repo.find_by_id(watchdog_db, job_id)
+            if fresh is None or fresh.status in TERMINAL_PIPELINE_STATUSES:
+                await core_task
+                return
+
+            last_progress = fresh.updated_at or started_at
+            if (datetime.now() - last_progress).total_seconds() > STALL_TIMEOUT_SECONDS:
+                core_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await core_task
+                raise _PipelineStalled
+
+    async def _mark_aborted(
+        self, db: AgnosticDatabase, job: PipelineJob, code: PipelineErrorCode, detail: str
+    ) -> None:
+        """Mark a job failed after a stall/timeout abort, flagging any running steps."""
+        job.status = "failed"
+        job.error = code
+        job.error_detail = detail
+        job.completed_at = datetime.now()
+        for step in job.steps:
+            if step.status == "running":
+                step.status = "failed"
+                step.message = detail
+                step.completed_at = datetime.now()
+        await self._pipeline_repo.update(db, job)
 
     async def _update_step(
         self,
@@ -707,24 +768,33 @@ class PipelineService:
 
                     await self._pipeline_repo.update(db, job)
 
+            core_task = asyncio.create_task(_run_pipeline_core())
+            started_at = job.started_at or datetime.now()
             try:
                 await asyncio.wait_for(
-                    _run_pipeline_core(),
+                    self._await_with_stall_guard(core_task, job_id, started_at),
                     timeout=MAX_PIPELINE_DURATION_SECONDS,
                 )
+            except _PipelineStalled:
+                stall_minutes = int(STALL_TIMEOUT_SECONDS // 60)
+                logger.error("Pipeline job %s stalled (no progress for %dm)", job_id, stall_minutes)
+                await self._mark_aborted(
+                    db,
+                    job,
+                    PipelineErrorCode.stalled,
+                    f"Stalled — no progress for {stall_minutes} minutes. Usually a site that's "
+                    "hard to crawl/render or a temporary model issue; try again.",
+                )
             except TimeoutError:
+                # Hard ceiling: the guard's wait_for fired but core_task is a separate task.
+                core_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await core_task
                 logger.error(
                     "Pipeline job %s timed out after %s seconds",
                     job_id,
                     MAX_PIPELINE_DURATION_SECONDS,
                 )
-                job.status = "failed"
-                job.error = PipelineErrorCode.timed_out
-                job.error_detail = "Pipeline timed out after 2 hours"
-                job.completed_at = datetime.now()
-                for step in job.steps:
-                    if step.status == "running":
-                        step.status = "failed"
-                        step.message = "Pipeline timed out after 2 hours"
-                        step.completed_at = datetime.now()
-                await self._pipeline_repo.update(db, job)
+                await self._mark_aborted(
+                    db, job, PipelineErrorCode.timed_out, "Pipeline timed out after 2 hours"
+                )

--- a/packages/backend/tests/unit/pipeline_stall_watchdog_test.py
+++ b/packages/backend/tests/unit/pipeline_stall_watchdog_test.py
@@ -1,0 +1,67 @@
+"""The stall watchdog cancels a wedged pipeline but never a progressing one.
+
+It bounds *inactivity* (no page/doc/step update), not total runtime, so a slow-but-advancing
+pipeline runs to the hard ceiling while a stuck one frees its worker slot fast.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.pipeline_job import PipelineJob
+from src.repositories.pipeline_repository import PipelineRepository
+from src.services import pipeline_service as ps
+from src.services.pipeline_service import PipelineService, _PipelineStalled
+
+
+def _job(status: str, updated_at: datetime) -> PipelineJob:
+    job = PipelineJob(product_slug="x", product_name="X", url="https://x.com", status=status)
+    job.updated_at = updated_at
+    return job
+
+
+@asynccontextmanager
+async def _fake_session():
+    yield MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_stall_guard_cancels_a_stuck_pipeline(monkeypatch):
+    monkeypatch.setattr(ps, "STALL_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(ps, "db_session", _fake_session)
+    repo = MagicMock(spec=PipelineRepository)
+    repo.find_by_id = AsyncMock(return_value=_job("crawling", datetime.now() - timedelta(hours=1)))
+    svc = PipelineService(pipeline_repo=repo)
+
+    cancelled = asyncio.Event()
+
+    async def never_progresses() -> None:
+        try:
+            await asyncio.sleep(100)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    core = asyncio.create_task(never_progresses())
+    with pytest.raises(_PipelineStalled):
+        await svc._await_with_stall_guard(core, "job-x", datetime.now() - timedelta(hours=1))
+    assert cancelled.is_set()  # the wedged core was cancelled → worker slot freed
+
+
+@pytest.mark.asyncio
+async def test_stall_guard_lets_a_progressing_pipeline_finish(monkeypatch):
+    monkeypatch.setattr(ps, "STALL_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(ps, "db_session", _fake_session)
+    repo = MagicMock(spec=PipelineRepository)
+    repo.find_by_id = AsyncMock(return_value=_job("summarizing", datetime.now()))
+    svc = PipelineService(pipeline_repo=repo)
+
+    async def finishes_quickly() -> None:
+        await asyncio.sleep(0.05)
+
+    core = asyncio.create_task(finishes_quickly())
+    await svc._await_with_stall_guard(core, "job-x", datetime.now())  # no raise
+    assert core.done() and core.exception() is None

--- a/packages/frontend/lib/pipeline-errors.ts
+++ b/packages/frontend/lib/pipeline-errors.ts
@@ -20,6 +20,8 @@ export const PIPELINE_ERROR_CODE_MESSAGES: Record<string, string> = {
   internal_error: "Something went wrong while analyzing this site.",
   timed_out:
     "Analysis took too long and timed out. Please try again, as large sites may need another attempt.",
+  stalled:
+    "Analysis stalled with no progress, usually on a site that's hard to crawl or a temporary issue. Please try again.",
 };
 
 export function resolvePipelineErrorMessage(


### PR DESCRIPTION
## Problem

A render-heavy or wedged crawl can hold a worker slot until the **2h pipeline ceiling**, producing nothing and starving the (concurrency-2) queue. During the prod re-run, a couple of slow-render seeds occupied both slots and throughput dropped to ~zero.

A blunt **total-duration cap is the wrong fix** — a healthy pipeline (crawl many pages + per-document analysis through the rate-limited free-model cascade) legitimately runs well past any short cap, so lowering `MAX_PIPELINE_DURATION_SECONDS` would kill *progressing* jobs.

## Fix — bound inactivity, not runtime

Every progress event (page crawled, document analyzed, step transition) already bumps the job's `updated_at`. The new stall watchdog awaits the pipeline core and cancels it **only when `updated_at` goes stale for `PIPELINE_STALL_TIMEOUT_SECONDS` (default 900s / 15 min)**:

- A slow-but-advancing pipeline runs to the **2h hard ceiling untouched** (kept as a backstop).
- A wedged one frees its worker slot in ~15 min, marked failed with a new **`stalled`** error code (15 min chosen to sit safely above the worst-case gap between progress events — a single doc through the cascade with retries).

15 min is above a normal inter-step gap (a single doc through the cascade) but well below the 2h clog.

## Changes
- `pipeline_service.py`: `_await_with_stall_guard` (poll `updated_at`, cancel on stall) + `_mark_aborted` helper; `run_pipeline` races the core task against the guard under the 2h `wait_for`.
- `pipeline_job.py`: new `PipelineErrorCode.stalled`.
- `pipeline-errors.ts`: user-facing copy for `stalled`.

## Test
`tests/unit/pipeline_stall_watchdog_test.py`: the guard cancels a never-progressing core (frees the slot) and lets a progressing one finish untouched. Full suite green (560 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)