### PR TITLE
fix(test): type stall-watchdog helper status param as PipelineJobStatus

### DIFF
--- a/packages/backend/tests/unit/pipeline_stall_watchdog_test.py
+++ b/packages/backend/tests/unit/pipeline_stall_watchdog_test.py
@@ -11,13 +11,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.models.pipeline_job import PipelineJob
+from src.models.pipeline_job import PipelineJob, PipelineJobStatus
 from src.repositories.pipeline_repository import PipelineRepository
 from src.services import pipeline_service as ps
 from src.services.pipeline_service import PipelineService, _PipelineStalled
 
 
-def _job(status: str, updated_at: datetime) -> PipelineJob:
+def _job(status: PipelineJobStatus, updated_at: datetime) -> PipelineJob:
     job = PipelineJob(product_slug="x", product_name="X", url="https://x.com", status=status)
     job.updated_at = updated_at
     return job


### PR DESCRIPTION
Fixes the red CI on main from #66: the `_job` test helper passed a plain `str` where `PipelineJob.status` expects the status `Literal`, failing `ty check`. CI runs `ty` over the whole repo (incl `tests/`) on Python 3.12; the per-file local check missed it. Annotates the param with `PipelineJobStatus`.

Verified with full-project `uv run ty check` + `ruff check` (no path) + pytest — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)