### PR TITLE
fix(crawler): dedup pure-translation URL variants, preserve region locales

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -47,6 +47,9 @@ _LOCALE_QUERY_KEYS = frozenset(
     {"l", "lang", "hl", "locale", "lr", "language", "setlang", "uselang", "ui_locale"}
 )
 # Bare ISO 639-1 language codes (no region) used as path segments or query values.
+# "hr" (Croatian) and "uk" (Ukrainian) are deliberately excluded: as path segments they
+# collide with /hr/ (HR/employee policies) and /uk/ (UK-GDPR region), both legally
+# distinct documents we must not collapse. Ukrainian still dedups via its full name.
 _LANGUAGE_CODES = frozenset(
     {
         "ar",
@@ -63,7 +66,6 @@ _LANGUAGE_CODES = frozenset(
         "fr",
         "he",
         "hi",
-        "hr",
         "hu",
         "id",
         "it",
@@ -83,7 +85,6 @@ _LANGUAGE_CODES = frozenset(
         "sv",
         "th",
         "tr",
-        "uk",
         "vi",
         "zh",
     }
@@ -3914,6 +3915,7 @@ class ClauseaCrawler:
                 self.visited_urls.clear()
                 self.failed_urls.clear()
                 self.queued_urls.clear()
+                self._locale_seen_keys.clear()
                 self._sitemap_seeded = False
                 self.url_queue.clear()
                 self.url_stack.clear()

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -40,6 +40,141 @@ logger_proxy = get_logger(__name__, component="crawler:proxy")
 
 _TLD_EXTRACT = tldextract.TLDExtract(suffix_list_urls=())
 
+# Query keys that toggle only the UI/translation language of an otherwise identical
+# document. A value carrying a region qualifier (e.g. "en-GB", "pt_BR") is treated as
+# jurisdiction-distinct and never stripped.
+_LOCALE_QUERY_KEYS = frozenset(
+    {"l", "lang", "hl", "locale", "lr", "language", "setlang", "uselang", "ui_locale"}
+)
+# Bare ISO 639-1 language codes (no region) used as path segments or query values.
+_LANGUAGE_CODES = frozenset(
+    {
+        "ar",
+        "bg",
+        "cs",
+        "da",
+        "de",
+        "el",
+        "en",
+        "es",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "id",
+        "it",
+        "ja",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "nl",
+        "no",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sk",
+        "sl",
+        "sv",
+        "th",
+        "tr",
+        "uk",
+        "vi",
+        "zh",
+    }
+)
+# Full language names some sites use as path segments / query values (e.g. Steam's
+# ``?l=ukrainian``). Region-flavored names (brazilian, latam) are deliberately omitted
+# so regionally-distinct policies survive.
+_LANGUAGE_NAMES = frozenset(
+    {
+        "arabic",
+        "bulgarian",
+        "czech",
+        "danish",
+        "dutch",
+        "english",
+        "finnish",
+        "french",
+        "german",
+        "greek",
+        "hungarian",
+        "indonesian",
+        "italian",
+        "japanese",
+        "koreana",
+        "korean",
+        "norwegian",
+        "polish",
+        "portuguese",
+        "romanian",
+        "russian",
+        "schinese",
+        "tchinese",
+        "spanish",
+        "swedish",
+        "thai",
+        "turkish",
+        "ukrainian",
+        "vietnamese",
+    }
+)
+_ENGLISH_TOKENS = frozenset({"en", "english"})
+
+
+def _is_bare_language(token: str) -> bool:
+    """True if ``token`` names a language with no region qualifier.
+
+    Region-qualified locales (``en-GB``, ``pt_BR``) and region words return False so
+    that jurisdiction-distinct documents are never collapsed as mere translations.
+    """
+    lowered = token.lower()
+    if "-" in lowered or "_" in lowered:
+        return False
+    return lowered in _LANGUAGE_CODES or lowered in _LANGUAGE_NAMES
+
+
+def locale_canonical_key(parsed: ParseResult) -> tuple[str, bool, bool]:
+    """Reduce a URL to a key shared by all pure-translation variants of one document.
+
+    Returns ``(key, had_language_signal, is_english)``. ``key`` strips bare-language
+    path segments and locale query params; ``had_language_signal`` is True when the URL
+    carried any such translation marker; ``is_english`` is True when that marker was the
+    English variant (kept in preference to other translations).
+    """
+    segments = [seg for seg in parsed.path.split("/") if seg]
+    kept_segments: list[str] = []
+    had_signal = False
+    is_english = False
+    for seg in segments:
+        if _is_bare_language(seg):
+            had_signal = True
+            if seg.lower() in _ENGLISH_TOKENS:
+                is_english = True
+            continue
+        kept_segments.append(seg)
+
+    kept_query: list[tuple[str, str]] = []
+    for key, value in parse_qsl(parsed.query, keep_blank_values=True):
+        if key.lower() in _LOCALE_QUERY_KEYS and _is_bare_language(value):
+            had_signal = True
+            if value.lower() in _ENGLISH_TOKENS:
+                is_english = True
+            continue
+        kept_query.append((key, value))
+
+    canonical_path = "/" + "/".join(kept_segments)
+    canonical = urlunparse(
+        (parsed.scheme, parsed.netloc, canonical_path, "", urlencode(kept_query), "")
+    )
+    return canonical, had_signal, is_english
+
+
 # Standard user agent string following RFC 7231 format
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (compatible; ClauseaBot/2.0; +https://www.clausea.co/bot.html; lvndry@proton.me)"
@@ -1345,6 +1480,10 @@ class ClauseaCrawler:
         self.visited_urls: set[str] = set()
         self.failed_urls: set[str] = set()
         self.queued_urls: set[str] = set()  # Prevents duplicate queue entries
+        # Maps a language-stripped "canonical key" to the variant we kept, so pure
+        # translation duplicates of an already-seen document are skipped while
+        # region-qualified locales (jurisdiction-distinct) are always preserved.
+        self._locale_seen_keys: set[str] = set()
         self.url_queue: deque[tuple[str, int]] = deque()  # For BFS
         self.url_stack: list[tuple[str, int]] = []  # For DFS
         self.url_priority_queue: list[tuple[float, str, int]] = []  # For best-first (scored URLs)
@@ -2678,6 +2817,19 @@ class ClauseaCrawler:
             if pattern.search(url):
                 logger.debug(f"❌ URL {url} rejected: matches skip pattern {pattern.pattern}")
                 return False
+
+        # Skip pure-translation duplicates of a document we've already admitted. The
+        # canonical key strips only bare-language markers, so region-qualified locales
+        # (jurisdiction-distinct, e.g. en-GB vs en-US, /eu vs /us) keep separate keys
+        # and are always crawled. We keep the language-less or English variant when one
+        # exists; otherwise the first translation seen.
+        canonical_key, had_language_signal, is_english = locale_canonical_key(
+            self._parse_url(self.normalize_url(url))
+        )
+        if had_language_signal and not is_english and canonical_key in self._locale_seen_keys:
+            logger.debug(f"❌ URL {url} rejected: translation duplicate of {canonical_key}")
+            return False
+        self._locale_seen_keys.add(canonical_key)
 
         logger.debug(f"✅ URL {url} accepted for crawling at depth {depth}")
         return True

--- a/packages/backend/tests/unit/crawler/locale_dedup_test.py
+++ b/packages/backend/tests/unit/crawler/locale_dedup_test.py
@@ -58,6 +58,14 @@ def test_region_variants_are_each_crawled() -> None:
     assert crawler.should_crawl_url(base + "/en-GB", base, 1) is True
 
 
+def test_hr_and_uk_path_segments_are_not_treated_as_languages() -> None:
+    # /hr/ = HR/employee policy, /uk/ = UK-GDPR region — legally distinct, never collapse.
+    for region in ("hr", "uk"):
+        key, had_signal, _ = locale_canonical_key(urlparse(f"https://example.com/{region}/privacy"))
+        assert key == f"https://example.com/{region}/privacy"
+        assert had_signal is False
+
+
 def test_english_variant_kept_over_other_translations() -> None:
     crawler = _crawler()
     base = "https://legal.epicgames.com/parental-consent"

--- a/packages/backend/tests/unit/crawler/locale_dedup_test.py
+++ b/packages/backend/tests/unit/crawler/locale_dedup_test.py
@@ -1,0 +1,67 @@
+"""Pure-translation URL variants are deduped; region-qualified locales are preserved.
+
+Sites like Steam (``?l=ukrainian`` over a path-locale matrix) and Epic (``?lang=…``)
+expose the same legal document in dozens of translations. Each one browser-renders and
+times out, so a single crawl burned ~30 min on hundreds of redundant fetches. We keep
+the canonical/English variant and skip the rest — but anything carrying a region
+qualifier (jurisdiction-distinct, e.g. GDPR vs CCPA) is always crawled.
+"""
+
+from urllib.parse import urlparse
+
+from src.crawler import ClauseaCrawler, locale_canonical_key
+
+
+def _crawler() -> ClauseaCrawler:
+    return ClauseaCrawler(allowed_domains=None, follow_external_links=False)
+
+
+def test_canonical_key_strips_language_query_param() -> None:
+    key, had_signal, is_english = locale_canonical_key(
+        urlparse("https://store.steampowered.com/privacy_agreement?l=ukrainian")
+    )
+    assert key == "https://store.steampowered.com/privacy_agreement"
+    assert had_signal is True
+    assert is_english is False
+
+
+def test_canonical_key_strips_bare_language_path_segment() -> None:
+    key, had_signal, _ = locale_canonical_key(
+        urlparse("https://store.steampowered.com/privacy_agreement/german")
+    )
+    assert key == "https://store.steampowered.com/privacy_agreement"
+    assert had_signal is True
+
+
+def test_canonical_key_preserves_region_qualified_locale() -> None:
+    # en-GB vs en-US can differ legally — must NOT collapse.
+    key, had_signal, _ = locale_canonical_key(urlparse("https://example.com/privacy/en-GB"))
+    assert key == "https://example.com/privacy/en-GB"
+    assert had_signal is False
+
+
+def test_translation_variants_collapse_to_one_crawl() -> None:
+    crawler = _crawler()
+    base = "https://store.steampowered.com/privacy_agreement"
+    # Canonical (language-less) admitted first.
+    assert crawler.should_crawl_url(base, base, 1) is True
+    # Every translation of the same agreement is now skipped.
+    assert crawler.should_crawl_url(base + "/german?l=ukrainian", base, 1) is False
+    assert crawler.should_crawl_url(base + "/italian?l=french", base, 1) is False
+
+
+def test_region_variants_are_each_crawled() -> None:
+    crawler = _crawler()
+    base = "https://example.com/privacy"
+    assert crawler.should_crawl_url(base + "/eu", base, 1) is True
+    assert crawler.should_crawl_url(base + "/us", base, 1) is True
+    assert crawler.should_crawl_url(base + "/en-GB", base, 1) is True
+
+
+def test_english_variant_kept_over_other_translations() -> None:
+    crawler = _crawler()
+    base = "https://legal.epicgames.com/parental-consent"
+    # English admitted, registering the canonical key.
+    assert crawler.should_crawl_url(base + "?lang=en", base, 1) is True
+    # A non-English sibling is then a redundant translation.
+    assert crawler.should_crawl_url(base + "?lang=fr", base, 1) is False


### PR DESCRIPTION
## Problem

Watching the prod re-run, the worker's two concurrency slots were stuck for ~30 min on **Steam** and **Epic**, both grinding through a locale-variant URL explosion:

- Steam: `store.steampowered.com/privacy_agreement/{german,italian,portuguese,spanish,…}?l={ukrainian,vietnamese,…}` — the same privacy agreement across a ~28 path-locale × ~28 `?l=` query-locale matrix.
- Epic: `?lang=ar/bg/cs/…` on `parental-consent`, `uefn`, `refund-policy`, `fan-art-policy`.

Every variant is a translated duplicate of a doc we already have. Each browser-renders, times out at 20s, defers, and fails (`281 processed, 82 successful` on Steam alone). This is not a stall or OOM (memory steady at 246 MB) — it's crawl inefficiency gating throughput, which kept `pending` at 116 and `overviews` at 3.

## Fix

`should_crawl_url` now skips a URL when it is only a **translation** of one already admitted. A canonical key strips bare-language markers:

- locale query params: `?l=`, `?lang=`, `?hl=`, `?locale=`, … (when the value is a bare language)
- bare-language path segments: `/de`, `/fr`, `/german`, `/spanish`, …

We keep the language-less or English variant; the rest collapse to it.

**Recall-safe by construction:** region-qualified locales (`en-GB` vs `en-US`, `/eu` vs `/us`, `pt-BR`) keep *distinct* keys and are always crawled — so a jurisdiction-distinct policy (GDPR vs CCPA) can never be the one dropped. Region-flavored names like `brazilian`/`latam` are deliberately excluded from the language list. This honors recall-over-speed: a pure translation carries identical legal meaning for an English analysis, so collapsing it loses nothing.

## Impact

Collapses Steam's ~784-URL matrix and Epic's `?lang=` sets to one canonical doc each, freeing the worker to draw down the pending queue.

## Tests

New `tests/unit/crawler/locale_dedup_test.py` (6 tests): query/path language stripping, region-qualified preservation, translation collapse, per-region crawling, English-preferred-over-other-translations. Full crawler suite (138) green; full-project `ty check` + `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)