### PR TITLE
feat(landing): live analyzed-product count in hero

### DIFF
--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -195,6 +195,10 @@ class ProductRepository(BaseRepository):
     # Product Overview Storage Operations
     # ============================================================================
 
+    async def count_product_overviews(self, db: AgnosticDatabase) -> int:
+        """Count products that have a completed analysis (a stored overview)."""
+        return await db.product_overviews.count_documents({})
+
     async def get_product_overview(
         self, db: AgnosticDatabase, product_slug: str
     ) -> dict[str, Any] | None:

--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -196,8 +196,12 @@ class ProductRepository(BaseRepository):
     # ============================================================================
 
     async def count_product_overviews(self, db: AgnosticDatabase) -> int:
-        """Count products that have a completed analysis (a stored overview)."""
-        return await db.product_overviews.count_documents({})
+        """Count products that have a completed analysis (a stored overview).
+
+        Uses estimated_document_count() — an O(1) metadata read — since this counts
+        the whole collection with no filter (consistent with get_products_paginated).
+        """
+        return await db.product_overviews.estimated_document_count()
 
     async def get_product_overview(
         self, db: AgnosticDatabase, product_slug: str

--- a/packages/backend/src/routes/products.py
+++ b/packages/backend/src/routes/products.py
@@ -87,6 +87,19 @@ async def get_all_products(
     return ProductsPage(items=products, total=total, page=page, pages=pages)
 
 
+class ProductStats(BaseModel):
+    analyzed_count: int
+
+
+@router.get("/stats", response_model=ProductStats)
+async def get_product_stats(
+    db: AgnosticDatabase = Depends(get_db),
+    service: ProductService = Depends(create_product_service),
+) -> ProductStats:
+    """Public catalog stats for the landing page (count of analyzed products)."""
+    return ProductStats(analyzed_count=await service.count_analyzed_products(db))
+
+
 @router.get("/{slug}/overview", response_model=ProductOverview)
 async def get_product_overview(
     slug: str,

--- a/packages/backend/src/services/product_service.py
+++ b/packages/backend/src/services/product_service.py
@@ -223,6 +223,10 @@ class ProductService:
         """
         await self._product_repo.delete_product_overview(db, slug)
 
+    async def count_analyzed_products(self, db: AgnosticDatabase) -> int:
+        """Count products with a completed analysis (a stored overview)."""
+        return await self._product_repo.count_product_overviews(db)
+
     async def get_product_overview_data(
         self, db: AgnosticDatabase, product_slug: str
     ) -> dict[str, Any] | None:

--- a/packages/backend/tests/unit/product_service_db_test.py
+++ b/packages/backend/tests/unit/product_service_db_test.py
@@ -221,3 +221,15 @@ async def test_get_product_documents(
     assert documents[0].id == "doc1"
     assert documents[0].summary == "JSON SUMMARY"
     mock_document_repo.find_by_product_id_with_analysis.assert_called_once_with(mock_db, "123")
+
+
+@pytest.mark.asyncio
+async def test_count_analyzed_products(
+    product_service: ProductService, mock_product_repo: MagicMock, mock_db: MagicMock
+) -> None:
+    mock_product_repo.count_product_overviews = AsyncMock(return_value=7)
+
+    count = await product_service.count_analyzed_products(mock_db)
+
+    assert count == 7
+    mock_product_repo.count_product_overviews.assert_awaited_once_with(mock_db)

--- a/packages/frontend/app/(site)/page.tsx
+++ b/packages/frontend/app/(site)/page.tsx
@@ -4,15 +4,32 @@ import GSAPInit from "@/components/clausea/GSAPInit";
 import { Header } from "@/components/clausea/Header";
 import Hero from "@/components/clausea/Hero";
 import { Footer, Pricing } from "@/components/clausea/PricingAndFooter";
+import { apiEndpoints } from "@lib/config";
 
-export default function LandingPage() {
+// Live count of analyzed products for the hero. Returns null on failure so the
+// hero omits the stat rather than showing a stale or fabricated number.
+async function getAnalyzedCount(): Promise<number | null> {
+  try {
+    const res = await fetch(apiEndpoints.productStats(), {
+      next: { revalidate: 300 },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { analyzed_count?: number };
+    return typeof data.analyzed_count === "number" ? data.analyzed_count : null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function LandingPage() {
+  const analyzedCount = await getAnalyzedCount();
   return (
     <div className="min-h-screen bg-background text-foreground selection:bg-foreground selection:text-background w-full overflow-x-hidden overflow-y-visible">
       <GSAPInit />
       <div className="grid grid-cols-12 max-w-[1600px] mx-auto border-x border-border min-h-screen overflow-visible">
         <Header />
         <main className="col-span-12 flex flex-col w-full pb-8 overflow-visible">
-          <Hero />
+          <Hero analyzedCount={analyzedCount} />
           <ComplexityToClarity />
           <AsymmetricGrid />
           <Pricing />

--- a/packages/frontend/components/clausea/Hero.tsx
+++ b/packages/frontend/components/clausea/Hero.tsx
@@ -9,7 +9,7 @@ import { useRef } from "react";
 
 import { Button } from "@/components/ui/button";
 
-export default function Hero() {
+export default function Hero({ analyzedCount }: { analyzedCount?: number | null }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const isInView = useInView(containerRef, { once: true, amount: 0.3 });
 
@@ -68,8 +68,15 @@ export default function Hero() {
         </div>
         <div className="flex items-center gap-4 text-[10px] md:text-[11px] uppercase tracking-[0.15em] font-medium">
           <span className="text-foreground">Active Monitoring</span>
-          <span className="text-muted-foreground">●</span>
-          <span className="text-muted-foreground">24 Services Analyzed</span>
+          {typeof analyzedCount === "number" && analyzedCount > 0 && (
+            <>
+              <span className="text-muted-foreground">●</span>
+              <span className="text-muted-foreground">
+                {analyzedCount} {analyzedCount === 1 ? "Service" : "Services"}{" "}
+                Analyzed
+              </span>
+            </>
+          )}
         </div>
       </motion.div>
     </section>

--- a/packages/frontend/lib/config.ts
+++ b/packages/frontend/lib/config.ts
@@ -13,6 +13,7 @@ export const apiEndpoints = {
   documents: () => getBackendUrl("/documents"),
   analysis: () => getBackendUrl("/analysis"),
   products: () => getBackendUrl("/products"),
+  productStats: () => getBackendUrl("/products/stats"),
   users: () => getBackendUrl("/users"),
   metaSummary: (slug: string) => getBackendUrl(`/products/${slug}/overview`),
 } as const;


### PR DESCRIPTION
## Why

The landing hero showed **\"24 Services Analyzed\"** — a hardcoded string in \`components/clausea/Hero.tsx\`, unrelated to real data. It was both wrong (catalog is ~130 products; analyzed count is whatever has a completed overview) and frozen (never moves as the backfill completes).

## What

Wire it to a **live count of products with a completed overview** (you picked this over total-catalog).

**Backend**
- \`ProductRepository.count_product_overviews\` — \`product_overviews.count_documents({})\`.
- \`ProductService.count_analyzed_products\`.
- Public \`GET /products/stats\` → \`{ "analyzed_count": N }\`, declared **before** \`/{slug}\` so it isn't captured as a slug.

**Frontend**
- Landing page (server component) fetches the count with a 5-min \`revalidate\` and passes \`analyzedCount\` to \`<Hero>\`.
- \`Hero\` renders the stat only when it's a positive number (and pluralizes). On fetch failure it returns \`null\` and the hero **omits** the stat — no stale or fabricated number shown.

## Notes

- Count is live, so it currently reads low (~4) while the catalog backfill runs, then climbs toward 130. That's intended/truthful.
- Verified: backend \`ty\`/\`ruff\` + new service test green; frontend \`tsc\` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)