### PR TITLE
fix(seo): shorten homepage title to 48 chars

### DIFF
--- a/packages/frontend/app/layout.tsx
+++ b/packages/frontend/app/layout.tsx
@@ -39,7 +39,7 @@ export const viewport: Viewport = {
 
 export const metadata = {
   metadataBase: new URL(siteUrl),
-  title: "Clausea AI - Legal documents were not written for you... until now",
+  title: "Clausea AI - Privacy Policies & Terms, Made Easy",
   description:
     "Navigate legal complexities with AI precision. Understand privacy policies, terms of service, cookie policies, and other legal agreements instantly.",
   keywords: [
@@ -68,8 +68,7 @@ export const metadata = {
     locale: "en_US",
     url: siteUrl,
     siteName: "Clausea AI",
-    title:
-      "Clausea AI - Legal documents were not written for you... until now",
+    title: "Clausea AI - Privacy Policies & Terms, Made Easy",
     description:
       "Navigate legal complexities with ease. Understand privacy policies, terms of service, cookie policies, and other legal agreements instantly.",
     images: [
@@ -83,8 +82,7 @@ export const metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title:
-      "Clausea AI - Legal documents were not written for you... until now",
+    title: "Clausea AI - Privacy Policies & Terms, Made Easy",
     description:
       "Navigate legal complexities with AI precision. Understand privacy policies, terms of service, cookie policies, and other legal agreements instantly.",
     images: [`${siteUrl}/og`],


### PR DESCRIPTION
## Why

The homepage `<title>` was **\"Clausea AI - Legal documents were not written for you... until now\"** (66 chars) — truncated in Google SERPs (~60-char limit) and long in the browser tab. The tagline is good brand/hero copy but weak as a keyword-bearing title.

## What

Replace with **\"Clausea AI - Privacy Policies & Terms, Made Easy\"** (48 chars) across all three metadata titles in `app/layout.tsx`:
- `metadata.title`
- `openGraph.title`
- `twitter.title`

Brand-first (consistent with the other page titles), leads with the two primary search terms (privacy policy / terms of service), hyphen not em dash to match siblings.

Split out of #69 (which already merged); this is the leftover title change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)