### PR TITLE
feat(features): real capability cards + icon/Model-Agnostic cleanup

### DIFF
--- a/packages/frontend/app/(site)/features/page.tsx
+++ b/packages/frontend/app/(site)/features/page.tsx
@@ -1,4 +1,4 @@
-import { Lock, Shield, Zap } from "lucide-react";
+import { Bell, FileText, Gauge, Globe, Lock, Shield, Zap } from "lucide-react";
 import type { Metadata } from "next";
 
 import AsymmetricGrid from "@/components/clausea/AsymmetricGrid";
@@ -74,6 +74,54 @@ export default function FeaturesPage() {
         {/* Technical Specs */}
         <section className="py-24 px-4 md:px-8 max-w-7xl mx-auto">
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12">
+            <div className="space-y-4">
+              <div className="w-12 h-12 rounded-2xl bg-primary/10 text-primary flex items-center justify-center">
+                <Globe className="w-6 h-6" />
+              </div>
+              <h4 className="text-xl font-bold font-display">
+                Whole-Site Coverage
+              </h4>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                We crawl a vendor&apos;s entire policy surface — privacy, terms,
+                cookies, DPA, subprocessors — not just the one page you paste.
+              </p>
+            </div>
+            <div className="space-y-4">
+              <div className="w-12 h-12 rounded-2xl bg-accent/20 text-accent-foreground flex items-center justify-center">
+                <FileText className="w-6 h-6" />
+              </div>
+              <h4 className="text-xl font-bold font-display">
+                Plain-English Summaries
+              </h4>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Dense legalese turned into clear, decision-ready answers anyone
+                on your team can act on.
+              </p>
+            </div>
+            <div className="space-y-4">
+              <div className="w-12 h-12 rounded-2xl bg-primary/10 text-primary flex items-center justify-center">
+                <Gauge className="w-6 h-6" />
+              </div>
+              <h4 className="text-xl font-bold font-display">
+                Risk &amp; Compliance Signals
+              </h4>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Every document is analyzed for GDPR/CCPA-relevant clauses and
+                the risk areas that matter to you.
+              </p>
+            </div>
+            <div className="space-y-4">
+              <div className="w-12 h-12 rounded-2xl bg-accent/20 text-accent-foreground flex items-center justify-center">
+                <Bell className="w-6 h-6" />
+              </div>
+              <h4 className="text-xl font-bold font-display">
+                Change Monitoring
+              </h4>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                We re-check policies on a schedule and surface exactly what
+                changed, so a quiet update never catches you off guard.
+              </p>
+            </div>
             <div className="space-y-4">
               <div className="w-12 h-12 rounded-2xl bg-primary/10 text-primary flex items-center justify-center">
                 <Shield className="w-6 h-6" />

--- a/packages/frontend/app/(site)/features/page.tsx
+++ b/packages/frontend/app/(site)/features/page.tsx
@@ -1,4 +1,4 @@
-import { Cpu, Lock, Shield, Zap } from "lucide-react";
+import { Lock, Shield, Zap } from "lucide-react";
 import type { Metadata } from "next";
 
 import AsymmetricGrid from "@/components/clausea/AsymmetricGrid";
@@ -12,7 +12,7 @@ const siteUrl = (
 export const metadata: Metadata = {
   title: "Features - Advanced Legal Infrastructure | Clausea AI",
   description:
-    "Discover Clausea's advanced legal document intelligence features: zero-train policy, sub-second retrieval, SOC2 Type II security, and model-agnostic architecture. Built for enterprise legal and compliance.",
+    "Discover Clausea's advanced legal document intelligence features: zero-train policy, sub-second retrieval, and SOC2 Type II security. Built for enterprise legal and compliance.",
   keywords: [
     "legal document analysis features",
     "AI legal agents",
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Features - Advanced Legal Infrastructure | Clausea AI",
     description:
-      "Discover Clausea's advanced legal document intelligence features: zero-train policy, sub-second retrieval, SOC2 Type II security, and model-agnostic architecture.",
+      "Discover Clausea's advanced legal document intelligence features: zero-train policy, sub-second retrieval, and SOC2 Type II security.",
     url: `${siteUrl}/features`,
     siteName: "Clausea AI",
     images: [
@@ -73,9 +73,9 @@ export default function FeaturesPage() {
 
         {/* Technical Specs */}
         <section className="py-24 px-4 md:px-8 max-w-7xl mx-auto">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-12">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12">
             <div className="space-y-4">
-              <div className="w-12 h-12 rounded-2xl bg-primary text-secondary flex items-center justify-center">
+              <div className="w-12 h-12 rounded-2xl bg-primary/10 text-primary flex items-center justify-center">
                 <Shield className="w-6 h-6" />
               </div>
               <h4 className="text-xl font-bold font-display">
@@ -87,7 +87,7 @@ export default function FeaturesPage() {
               </p>
             </div>
             <div className="space-y-4">
-              <div className="w-12 h-12 rounded-2xl bg-secondary text-primary flex items-center justify-center">
+              <div className="w-12 h-12 rounded-2xl bg-accent/20 text-accent-foreground flex items-center justify-center">
                 <Zap className="w-6 h-6" />
               </div>
               <h4 className="text-xl font-bold font-display">
@@ -106,16 +106,6 @@ export default function FeaturesPage() {
               <p className="text-sm text-muted-foreground leading-relaxed">
                 Enterprise security built-in. Data encryption at rest and in
                 transit with strict role-based access.
-              </p>
-            </div>
-            <div className="space-y-4">
-              <div className="w-12 h-12 rounded-2xl bg-primary/10 text-primary flex items-center justify-center">
-                <Cpu className="w-6 h-6" />
-              </div>
-              <h4 className="text-xl font-bold font-display">Model Agnostic</h4>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Switch between specialized models for different document types:
-                from contracts to compliance policies.
               </p>
             </div>
           </div>


### PR DESCRIPTION
From a live review of `/features`:

**Removed**
- The **Model Agnostic** card — an under-the-hood detail, not a user feature (also dropped its meta-description mentions and the unused `Cpu` import).

**Fixed**
- The **black icon chips**: "Zero-Train Policy" and "Sub-Second Retrieval" used solid `bg-primary`/`bg-secondary` fills that render as black squares in the editorial theme. Switched to soft tints (`bg-primary/10`, `bg-accent/20`).

**Added — four real capabilities that actually matter to users** (leading the grid, ahead of the infra/trust cards):
- **Whole-Site Coverage** — crawls a vendor's entire policy surface (privacy, terms, cookies, DPA, subprocessors), not just one pasted URL.
- **Plain-English Summaries** — the explainer that powers every product page.
- **Risk & Compliance Signals** — per-document GDPR/CCPA-relevant analysis.
- **Change Monitoring** — scheduled re-checks + diffs.

Grid is now 7 cards (responsive 1/2/3 cols). ESLint clean.

> ⚠️ **One thing to confirm:** the **Change Monitoring** card should only ship if scheduled monitoring is actually live for users today. The other three are demonstrably shipped (they power the product pages). If monitoring is still in-dev, say so and I'll pull that card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)