### PR TITLE
fix(sitemap): list /products + analyzed product pages

### DIFF
--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -195,6 +195,15 @@ class ProductRepository(BaseRepository):
     # Product Overview Storage Operations
     # ============================================================================
 
+    async def list_analyzed_overviews(self, db: AgnosticDatabase) -> list[dict[str, Any]]:
+        """Slug + last-updated for every product that has a completed overview.
+
+        Used to build the sitemap: only analyzed products carry real content worth
+        indexing (the rest render an 'indexation in progress' placeholder).
+        """
+        cursor = db.product_overviews.find({}, {"_id": 0, "product_slug": 1, "updated_at": 1})
+        return await cursor.to_list(length=None)
+
     async def count_product_overviews(self, db: AgnosticDatabase) -> int:
         """Count products that have a completed analysis (a stored overview).
 

--- a/packages/backend/src/routes/products.py
+++ b/packages/backend/src/routes/products.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from math import ceil
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
@@ -98,6 +99,25 @@ async def get_product_stats(
 ) -> ProductStats:
     """Public catalog stats for the landing page (count of analyzed products)."""
     return ProductStats(analyzed_count=await service.count_analyzed_products(db))
+
+
+class SitemapEntry(BaseModel):
+    slug: str
+    last_modified: datetime | None = None
+
+
+@router.get("/sitemap", response_model=list[SitemapEntry])
+async def get_products_sitemap(
+    db: AgnosticDatabase = Depends(get_db),
+    service: ProductService = Depends(create_product_service),
+) -> list[SitemapEntry]:
+    """Analyzed products (slug + last update) for the public sitemap."""
+    rows = await service.list_analyzed_products_for_sitemap(db)
+    return [
+        SitemapEntry(slug=row["product_slug"], last_modified=row.get("updated_at"))
+        for row in rows
+        if row.get("product_slug")
+    ]
 
 
 @router.get("/{slug}/overview", response_model=ProductOverview)

--- a/packages/backend/src/services/product_service.py
+++ b/packages/backend/src/services/product_service.py
@@ -227,6 +227,12 @@ class ProductService:
         """Count products with a completed analysis (a stored overview)."""
         return await self._product_repo.count_product_overviews(db)
 
+    async def list_analyzed_products_for_sitemap(
+        self, db: AgnosticDatabase
+    ) -> list[dict[str, Any]]:
+        """Slug + last-updated for every product with a completed overview (sitemap)."""
+        return await self._product_repo.list_analyzed_overviews(db)
+
     async def get_product_overview_data(
         self, db: AgnosticDatabase, product_slug: str
     ) -> dict[str, Any] | None:

--- a/packages/backend/tests/unit/product_service_db_test.py
+++ b/packages/backend/tests/unit/product_service_db_test.py
@@ -233,3 +233,16 @@ async def test_count_analyzed_products(
 
     assert count == 7
     mock_product_repo.count_product_overviews.assert_awaited_once_with(mock_db)
+
+
+@pytest.mark.asyncio
+async def test_list_analyzed_products_for_sitemap(
+    product_service: ProductService, mock_product_repo: MagicMock, mock_db: MagicMock
+) -> None:
+    rows = [{"product_slug": "notion", "updated_at": None}]
+    mock_product_repo.list_analyzed_overviews = AsyncMock(return_value=rows)
+
+    result = await product_service.list_analyzed_products_for_sitemap(mock_db)
+
+    assert result == rows
+    mock_product_repo.list_analyzed_overviews.assert_awaited_once_with(mock_db)

--- a/packages/frontend/app/sitemap.ts
+++ b/packages/frontend/app/sitemap.ts
@@ -4,24 +4,23 @@ import { getBackendUrl } from "@lib/config";
 
 const siteUrl = process.env.NEXT_PUBLIC_APP_URL || "https://clausea.co";
 
-interface Product {
+interface SitemapProduct {
   slug: string;
-  name: string;
-  updated_at?: string;
+  last_modified?: string | null;
 }
 
-async function getProducts(): Promise<Product[]> {
+// Only products with a completed analysis are listed — the rest render an
+// "indexation in progress" placeholder not worth indexing. The /products/sitemap
+// endpoint returns every analyzed product (not just one page), with a real lastmod.
+async function getAnalyzedProducts(): Promise<SitemapProduct[]> {
   try {
-    const backendUrl = getBackendUrl("/products");
-    const response = await fetch(backendUrl, {
-      next: { revalidate: 3600 }, // Revalidate every hour
+    const response = await fetch(getBackendUrl("/products/sitemap"), {
+      next: { revalidate: 3600 },
     });
-
     if (!response.ok) {
       console.warn("Failed to fetch products for sitemap");
       return [];
     }
-
     const products = await response.json();
     return Array.isArray(products) ? products : [];
   } catch (error) {
@@ -55,6 +54,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
+      url: `${baseUrl}/products`,
+      lastModified: now,
+      changeFrequency: "daily",
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/contact`,
       lastModified: now,
       changeFrequency: "monthly",
@@ -74,16 +79,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  // Dynamic product pages
-  const products = await getProducts();
-  const productPages: MetadataRoute.Sitemap = products.map((product) => ({
-    url: `${baseUrl}/products/${product.slug}`,
-    lastModified: product.updated_at
-      ? new Date(product.updated_at)
-      : new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.7,
-  }));
+  // Dynamic product pages (analyzed products only)
+  const products = await getAnalyzedProducts();
+  const productPages: MetadataRoute.Sitemap = products
+    .filter((product) => product.slug)
+    .map((product) => ({
+      url: `${baseUrl}/products/${product.slug}`,
+      lastModified: product.last_modified
+        ? new Date(product.last_modified)
+        : now,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    }));
 
   return [...staticPages, ...productPages];
 }

--- a/packages/frontend/app/sitemap.ts
+++ b/packages/frontend/app/sitemap.ts
@@ -9,9 +9,7 @@ interface SitemapProduct {
   last_modified?: string | null;
 }
 
-// Only products with a completed analysis are listed — the rest render an
-// "indexation in progress" placeholder not worth indexing. The /products/sitemap
-// endpoint returns every analyzed product (not just one page), with a real lastmod.
+// Analyzed products only — unanalyzed pages are placeholder content, not worth indexing.
 async function getAnalyzedProducts(): Promise<SitemapProduct[]> {
   try {
     const response = await fetch(getBackendUrl("/products/sitemap"), {
@@ -84,8 +82,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const productPages: MetadataRoute.Sitemap = products
     .filter((product) => product.slug)
     .map((product) => {
-      // Guard against a malformed date: an Invalid Date would throw during
-      // sitemap serialization and take down the whole sitemap with a 500.
+      // An Invalid Date would throw during serialization and 500 the whole sitemap.
       const parsed = product.last_modified
         ? new Date(product.last_modified)
         : null;

--- a/packages/frontend/app/sitemap.ts
+++ b/packages/frontend/app/sitemap.ts
@@ -83,14 +83,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const products = await getAnalyzedProducts();
   const productPages: MetadataRoute.Sitemap = products
     .filter((product) => product.slug)
-    .map((product) => ({
-      url: `${baseUrl}/products/${product.slug}`,
-      lastModified: product.last_modified
+    .map((product) => {
+      // Guard against a malformed date: an Invalid Date would throw during
+      // sitemap serialization and take down the whole sitemap with a 500.
+      const parsed = product.last_modified
         ? new Date(product.last_modified)
-        : now,
-      changeFrequency: "weekly" as const,
-      priority: 0.7,
-    }));
+        : null;
+      const lastModified =
+        parsed && !Number.isNaN(parsed.getTime()) ? parsed : now;
+      return {
+        url: `${baseUrl}/products/${product.slug}`,
+        lastModified,
+        changeFrequency: "weekly" as const,
+        priority: 0.7,
+      };
+    });
 
   return [...staticPages, ...productPages];
 }


### PR DESCRIPTION
## Why

The sitemap (`app/sitemap.ts`) emitted **zero product URLs** and omitted the catalog page:

- `getProducts()` fetched `GET /products` — which returns a **paginated object** `{ items, total, page, pages }` — then did `Array.isArray(products) ? products : []`. An object isn't an array, so it always returned `[]`. (It would also have only seen page 1 = 20, and listed unanalyzed "indexation in progress" pages.)
- `/products` (the catalog index) wasn't in `staticPages` at all.

## What

- **Backend:** new public `GET /products/sitemap` → `[{ slug, last_modified }]` for **only products with a completed overview** (`ProductRepository.list_analyzed_overviews`, using each overview's `updated_at` as `lastmod`). Unanalyzed products render a placeholder and are deliberately excluded — thin content we don't want indexed.
- **Frontend:** add `/products` to `staticPages`; rewrite the product-page fetch to consume `/products/sitemap` with a real `lastmod`. Products enter the sitemap automatically (1h revalidate) as they complete — no manual step.

## Result

`/products` + every analyzed product page now appear in `sitemap.xml` (~4 today, growing with the backfill). Backend `ty`/`ruff` + new service test green; frontend `tsc` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)