### PR TITLE
fix(crawler): gate every strategy on relevance to stop large-site wander

### DIFF
--- a/packages/backend/src/core/config.py
+++ b/packages/backend/src/core/config.py
@@ -16,7 +16,10 @@ def _env_bool(name: str, default: bool) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
-_DISCOVERY_PAGE_CAP = 1000
+# With the relevance gate applied to every strategy, only policy-scoring URLs enter the
+# frontier, so the discovery pass exhausts long before this cap on a normal site. It is a
+# backstop against pathological sites with hundreds of legal sub-pages, not a recall limit.
+_DISCOVERY_PAGE_CAP = 150
 _DISCOVERY_DEPTH_CAP = 3
 
 
@@ -176,7 +179,6 @@ class CrawlerConfig:
         self.fallback_min_legal_score: float = float(
             os.getenv("CRAWLER_FALLBACK_MIN_LEGAL_SCORE", "1.5")
         )
-        self.crawler_strategy: str = os.getenv("CRAWLER_STRATEGY", "bfs").strip().lower()
 
         self.min_docs_before_fallback: int = int(os.getenv("CRAWLER_MIN_DOCS_BEFORE_FALLBACK", "2"))
         _req = os.getenv("CRAWLER_REQUIRED_DOC_TYPES", "privacy_policy,terms_of_service")

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -189,7 +189,7 @@ ACCEPT_HEADER = (
 # consecutive pages with no policy-relevant content. Bounds the "wander the whole
 # marketing site" failure mode (BFS + min_legal_score=0 crawls every same-domain link)
 # without capping recall on genuinely inter-linked legal pages.
-DEFAULT_NO_POLICY_PAGE_BUDGET = int(os.getenv("CRAWLER_NO_POLICY_PAGE_BUDGET", "50"))
+DEFAULT_NO_POLICY_PAGE_BUDGET = int(os.getenv("CRAWLER_NO_POLICY_PAGE_BUDGET", "15"))
 # A crawled page counts as a policy hit at/above this normalized legal_score; matches the
 # pipeline's MIN_LEGAL_SCORE_THRESHOLD for accepting a page into analysis.
 CONVERGENCE_LEGAL_SCORE = 0.2
@@ -1393,7 +1393,7 @@ class ClauseaCrawler:
         follow_nofollow: bool = False,  # Whether to follow links marked rel="nofollow"
         respect_meta_robots: bool = True,  # Respect <meta name="robots" content="nofollow"> on pages
         min_legal_score: float = 2.0,
-        strategy: str = "bfs",  # "bfs", "dfs", "best_first"
+        strategy: str = "bfs",  # "bfs", "best_first"
         ignore_robots_for_domains: list[str]
         | None = None,  # List of domains to ignore robots.txt for
         max_retries: int = 3,  # Maximum retry attempts for transient errors
@@ -1424,7 +1424,7 @@ class ClauseaCrawler:
             user_agent: User agent string
             follow_external_links: Whether to follow external links
             min_legal_score: Minimum score to consider a URL legal-relevant
-            strategy: Crawling strategy ("bfs", "dfs", "best_first")
+            strategy: Crawling strategy ("bfs", "best_first")
             ignore_robots_for_domains: List of domains to ignore robots.txt for
             max_retries: Maximum retry attempts for transient network errors (default: 3)
             log_file_path: Optional path to log file for crawl session (e.g., "logs/20240101_123456_companyid_crawl.log")
@@ -1497,7 +1497,6 @@ class ClauseaCrawler:
         # region-qualified locales (jurisdiction-distinct) are always preserved.
         self._locale_seen_keys: set[str] = set()
         self.url_queue: deque[tuple[str, int]] = deque()  # For BFS
-        self.url_stack: list[tuple[str, int]] = []  # For DFS
         self.url_priority_queue: list[tuple[float, str, int]] = []  # For best-first (scored URLs)
         self._sitemap_seeded: bool = False  # True when sitemaps provided seed URLs
         # Best policy-relevance score assigned to each queued URL (anchor-aware).
@@ -3581,20 +3580,21 @@ class ClauseaCrawler:
             if score >= self.min_legal_score:
                 policy_lead_found = True
 
+            # Gate every strategy on relevance, not just best_first. A link scoring below
+            # the threshold is off-topic (marketing, help, product pages) and must never
+            # enter the frontier — otherwise BFS follows every same-domain link and wanders
+            # the whole site. min_legal_score=0 means "crawl everything" and is preserved.
+            if self.min_legal_score > 0 and score < self.min_legal_score:
+                logger.debug(
+                    f"Skipping URL below min_legal_score ({score:.2f} < {self.min_legal_score}): {url}"
+                )
+                continue
+
             self.queued_urls.add(url)
             if self.strategy == "bfs":
                 self.url_queue.append((url, depth + 1))
                 logger.debug(f"Added to BFS queue: {url} (depth: {depth + 1})")
-            elif self.strategy == "dfs":
-                self.url_stack.append((url, depth + 1))
-                logger.debug(f"Added to DFS stack: {url} (depth: {depth + 1})")
             elif self.strategy == "best_first":
-                if score < self.min_legal_score:
-                    logger.debug(
-                        f"Skipping URL below min_legal_score ({score:.2f} < {self.min_legal_score}): {url}"
-                    )
-                    self.queued_urls.discard(url)
-                    continue
                 heapq.heappush(self.url_priority_queue, (-score, url, depth + 1))
                 logger.debug(
                     f"Added to Best-First queue: {url} (score: {score:.2f}, anchor: {anchor_text})"
@@ -3636,9 +3636,6 @@ class ClauseaCrawler:
                 if self.strategy == "bfs":
                     self.url_queue.append((url, 1))
                     logger.debug(f"Added potential legal URL to BFS queue: {url}")
-                elif self.strategy == "dfs":
-                    self.url_stack.append((url, 1))
-                    logger.debug(f"Added potential legal URL to DFS stack: {url}")
                 elif self.strategy == "best_first":
                     heapq.heappush(self.url_priority_queue, (-score, url, 1))
                     logger.debug(
@@ -3649,8 +3646,6 @@ class ClauseaCrawler:
         """Get next URL from queue based on strategy."""
         if self.strategy == "bfs" and self.url_queue:
             return self.url_queue.popleft()
-        elif self.strategy == "dfs" and self.url_stack:
-            return self.url_stack.pop()
         elif self.strategy == "best_first" and self.url_priority_queue:
             _, url, depth = heapq.heappop(self.url_priority_queue)
             return url, depth
@@ -3725,8 +3720,6 @@ class ClauseaCrawler:
         """Return the number of URLs waiting in the active queue/stack."""
         if self.strategy == "bfs":
             return len(self.url_queue)
-        elif self.strategy == "dfs":
-            return len(self.url_stack)
         elif self.strategy == "best_first":
             return len(self.url_priority_queue)
         return 0
@@ -3774,9 +3767,6 @@ class ClauseaCrawler:
             if self.strategy == "bfs":
                 self.url_queue.append((base_url, 0))
                 logger.debug(f"Added base URL to BFS queue: {base_url} (depth: 0)")
-            elif self.strategy == "dfs":
-                self.url_stack.append((base_url, 0))
-                logger.debug(f"Added base URL to DFS stack: {base_url} (depth: 0)")
             elif self.strategy == "best_first":
                 score = self.url_scorer.score_url(base_url)
                 heapq.heappush(self.url_priority_queue, (-score, base_url, 0))
@@ -3811,8 +3801,6 @@ class ClauseaCrawler:
                         self.queued_urls.add(url)
                         if self.strategy == "bfs":
                             self.url_queue.append((url, 0))
-                        elif self.strategy == "dfs":
-                            self.url_stack.append((url, 0))
                         elif self.strategy == "best_first":
                             heapq.heappush(self.url_priority_queue, (-score, url, 0))
                         seeded += 1
@@ -3963,7 +3951,6 @@ class ClauseaCrawler:
                 self._locale_seen_keys.clear()
                 self._sitemap_seeded = False
                 self.url_queue.clear()
-                self.url_stack.clear()
                 self.url_priority_queue.clear()
                 self.results.clear()
                 # Clear caches between different base URLs

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -689,7 +689,6 @@ class PolicyDocumentPipeline:
         self,
         max_depth: int | None = None,
         max_pages: int | None = None,
-        crawler_strategy: str | None = None,
         concurrent_limit: int | None = None,
         delay_between_requests: float | None = None,
         timeout: int | None = None,
@@ -714,7 +713,6 @@ class PolicyDocumentPipeline:
         Args:
             max_depth: Maximum crawl depth per product (default: ``CrawlerConfig`` / env)
             max_pages: Maximum pages to crawl per product
-            crawler_strategy: Default ClauseaCrawler strategy when not overridden per pass
             concurrent_limit: Maximum concurrent requests
             delay_between_requests: Delay between requests in seconds
             timeout: Request timeout in seconds
@@ -738,9 +736,6 @@ class PolicyDocumentPipeline:
         self.max_pages = max_pages if max_pages is not None else c.max_pages
         self.discovery_max_pages, self.discovery_max_depth = discovery_crawl_limits(
             self.max_pages, self.max_depth
-        )
-        self.crawler_strategy = (
-            crawler_strategy if crawler_strategy is not None else c.crawler_strategy
         )
         self.concurrent_limit = (
             concurrent_limit if concurrent_limit is not None else c.concurrent_limit
@@ -812,7 +807,7 @@ class PolicyDocumentPipeline:
         max_depth: int | None = None,
         max_pages: int | None = None,
         min_legal_score: float | None = None,
-        strategy: str | None = None,
+        strategy: str,
         progress_phase: str | None = None,
     ) -> ClauseaCrawler:
         """Create a configured crawler instance for a specific product."""
@@ -852,7 +847,7 @@ class PolicyDocumentPipeline:
             user_agent=self.user_agent,
             follow_external_links=False,
             min_legal_score=min_legal_score if min_legal_score is not None else 0.0,
-            strategy=strategy or self.crawler_strategy,
+            strategy=strategy,
             log_file_path=log_file_path,
             use_browser=self.use_browser,
             browser_concurrency=self.browser_concurrency,
@@ -1234,7 +1229,6 @@ class PolicyDocumentPipeline:
                 "discovery_strategy": self.discovery_strategy,
                 "discovery_min_legal_score": self.discovery_min_legal_score,
                 "fallback_strategy": self.fallback_strategy,
-                "default_strategy": self.crawler_strategy,
             },
             stats={"mode": "hybrid"},
         )

--- a/packages/backend/tests/unit/config_test.py
+++ b/packages/backend/tests/unit/config_test.py
@@ -51,7 +51,7 @@ class TestCrawlerConfig:
         monkeypatch.setenv("CRAWLER_MAX_DEPTH", "9")
         c = CrawlerConfig()
         d_pages, d_depth = discovery_crawl_limits(c.max_pages, c.max_depth)
-        assert d_pages == 1000
+        assert d_pages == 150
         assert d_depth == 3
 
         monkeypatch.setenv("CRAWLER_MAX_PAGES", "50")
@@ -63,7 +63,7 @@ class TestCrawlerConfig:
 
     def test_crawler_env_overrides(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CRAWLER_DISCOVERY_MIN_LEGAL_SCORE", "3.1")
-        monkeypatch.setenv("CRAWLER_DISCOVERY_STRATEGY", "DFS")
+        monkeypatch.setenv("CRAWLER_DISCOVERY_STRATEGY", "Best_First")
         monkeypatch.setenv("CRAWLER_REQUIRED_DOC_TYPES", "privacy_policy,cookie_policy")
         monkeypatch.setenv("CRAWLER_USE_BROWSER", "false")
         monkeypatch.setenv("CRAWLER_RESPECT_ROBOTS_TXT", "0")
@@ -72,7 +72,7 @@ class TestCrawlerConfig:
 
         c = CrawlerConfig()
         assert c.discovery_min_legal_score == pytest.approx(3.1)
-        assert c.discovery_strategy == "dfs"
+        assert c.discovery_strategy == "best_first"
         assert c.required_doc_types == ["privacy_policy", "cookie_policy"]
         assert c.use_browser is False
         assert c.respect_robots_txt is False

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -96,21 +96,13 @@ def test_add_urls_to_queue_respects_rel_nofollow_and_meta():
 
     # By default follow_nofollow=False -> the specific nofollow link should be skipped
     crawler.add_urls_to_queue(links, "https://example.com", depth=0, page_metadata=None)
-    all_urls = (
-        {u for u, _ in crawler.url_queue}
-        | {u for u, _ in crawler.url_stack}
-        | {u for _, u, _ in crawler.url_priority_queue}
-    )
+    all_urls = {u for u, _ in crawler.url_queue} | {u for _, u, _ in crawler.url_priority_queue}
     assert "https://example.com/privacy" not in all_urls
 
     # If follow_nofollow enabled, the specific link should be added
     crawler2 = ClauseaCrawler(follow_nofollow=True)
     crawler2.add_urls_to_queue(links, "https://example.com", depth=0, page_metadata=None)
-    all_urls2 = (
-        {u for u, _ in crawler2.url_queue}
-        | {u for u, _ in crawler2.url_stack}
-        | {u for _, u, _ in crawler2.url_priority_queue}
-    )
+    all_urls2 = {u for u, _ in crawler2.url_queue} | {u for _, u, _ in crawler2.url_priority_queue}
     assert "https://example.com/privacy" in all_urls2
 
     # Verify queued_urls tracking works with follow_nofollow
@@ -191,15 +183,15 @@ def test_sitemap_seeded_skips_speculative_legal_urls():
     crawler = ClauseaCrawler()
     crawler._sitemap_seeded = True
 
-    links = [{"url": "https://example.com/page", "text": "Page"}]
+    links = [{"url": "https://example.com/privacy-policy", "text": "Privacy Policy"}]
     crawler.add_urls_to_queue(links, "https://example.com", depth=0)
 
-    # Only the explicitly discovered link should be queued — no speculative
-    # legal paths like /privacy, /legal, /terms.
+    # The discovered policy link is queued, but no speculative paths like
+    # /legal or /terms are generated because sitemaps already seeded the crawl.
     queued = {u for u, _ in crawler.url_queue}
-    assert "https://example.com/page" in queued
-    assert "https://example.com/privacy" not in queued
+    assert "https://example.com/privacy-policy" in queued
     assert "https://example.com/legal" not in queued
+    assert "https://example.com/terms" not in queued
 
 
 def test_no_sitemap_falls_back_to_speculative_legal_urls():
@@ -207,11 +199,13 @@ def test_no_sitemap_falls_back_to_speculative_legal_urls():
     crawler = ClauseaCrawler()
     assert crawler._sitemap_seeded is False
 
+    # An off-topic discovered link is filtered by the relevance gate, so it alone
+    # is not a policy lead — which is exactly what triggers speculative probing.
     links = [{"url": "https://example.com/page", "text": "Page"}]
     crawler.add_urls_to_queue(links, "https://example.com", depth=0)
 
     queued = {u for u, _ in crawler.url_queue}
-    assert "https://example.com/page" in queued
+    assert "https://example.com/page" not in queued
     # Fallback speculative URLs should be present
     assert "https://example.com/privacy" in queued
     assert "https://example.com/legal" in queued

--- a/packages/backend/tests/unit/crawler/state_test.py
+++ b/packages/backend/tests/unit/crawler/state_test.py
@@ -32,7 +32,8 @@ class TestCrawlerState:
 
     def test_add_urls_to_queue_does_not_enqueue_duplicates(self) -> None:
         """Test that the same URL is not added to the BFS queue twice."""
-        crawler = ClauseaCrawler(strategy="bfs")
+        # min_legal_score=0 keeps this focused on dedup, not the relevance gate.
+        crawler = ClauseaCrawler(strategy="bfs", min_legal_score=0)
         base_url = "https://example.com"
 
         links = [
@@ -47,6 +48,25 @@ class TestCrawlerState:
         # Try to add the same URL again — should be deduplicated
         crawler.add_urls_to_queue(links, base_url, depth=1)
         assert len(crawler.url_queue) == 1
+
+    def test_bfs_queue_rejects_urls_below_min_legal_score(self) -> None:
+        """BFS must drop off-topic links, not just best_first.
+
+        Regression: the relevance gate previously only applied to best_first, so the
+        BFS fallback pass followed every same-domain link and wandered large sites.
+        """
+        crawler = ClauseaCrawler(strategy="bfs", min_legal_score=2.0)
+        base_url = "https://example.com"
+
+        links = [
+            {"url": "https://example.com/privacy", "text": "Privacy Policy"},
+            {"url": "https://example.com/blog/how-to-cook-pasta", "text": "Pasta"},
+        ]
+        crawler.add_urls_to_queue(links, base_url, depth=0)
+
+        queued = {u for u, _ in crawler.url_queue}
+        assert "https://example.com/privacy" in queued
+        assert "https://example.com/blog/how-to-cook-pasta" not in queued
 
     def test_state_cleared_between_crawl_multiple_runs(self) -> None:
         """Test that queued_urls and _sitemap_seeded are cleared between runs."""
@@ -74,12 +94,6 @@ class TestCrawlerState:
         crawler.url_queue.append(("https://example.com/a", 1))
         crawler.url_queue.append(("https://example.com/b", 1))
         assert crawler._get_pending_url_count() == 2
-
-    def test_get_pending_url_count_dfs(self) -> None:
-        """Test _get_pending_url_count returns DFS stack length."""
-        crawler = ClauseaCrawler(strategy="dfs")
-        crawler.url_stack.append(("https://example.com/a", 1))
-        assert crawler._get_pending_url_count() == 1
 
     def test_get_pending_url_count_best_first(self) -> None:
         """Test _get_pending_url_count returns priority queue length."""


### PR DESCRIPTION
## Problem

Crawls of large consumer sites never converged — 23andMe reached 82 pages, Airbnb 121, both still climbing until the 2h pipeline ceiling. This blocked those products from ever being indexed.

## Root cause

The `min_legal_score` relevance gate in `add_urls_to_queue` was **only applied to the `best_first` frontier**. The `bfs` and `dfs` branches appended every same-domain link unconditionally. The **fallback crawl pass runs BFS**, so once it fired it followed help articles, blog posts, and product pages across the whole domain — the convergence budget (50 consecutive non-policy pages) almost never tripped because a footer policy link on every page kept resetting the counter.

## Fix

- **Hoist the score gate above the strategy branch.** A link scoring below `min_legal_score` never enters the frontier, regardless of strategy. `min_legal_score=0` still means "crawl everything" (preserved for that caller). This makes the BFS fallback as focused as discovery.
- **Remove the dead `dfs` strategy** — never configured in production, no call site sets it. Deletes `url_stack` and all its branches.
- **Remove the redundant `CrawlerConfig.crawler_strategy` field** — both pipeline passes (discovery=`best_first`, fallback=`bfs`) always pass an explicit strategy, so the fallback field was dead. `_create_crawler_for_product`'s `strategy` arg is now required.
- **Tighten backstops** now that only policy-scoring URLs enter the queue: convergence budget `50 → 15`, discovery page cap `1000 → 150`. These are env-tunable backstops, not recall limits — the gated frontier exhausts long before them on a normal site.

Net -9 lines.

## Expected behavior

23andMe / Airbnb crawls now queue only policy-scoring URLs, exhaust the frontier in ~5–15 pages, and complete instead of wandering to the timeout.

## Tests

- New regression test: BFS drops off-topic links (`/blog/how-to-cook-pasta`) while keeping `/privacy`.
- Updated fixtures that relied on BFS queuing arbitrary low-score URLs to reflect the correct gated behavior.
- Full backend unit suite green (570 tests), `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)