### PR TITLE
fix(crawler): stop best_first discovery on relevance-exhaustion

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -194,6 +194,12 @@ DEFAULT_NO_POLICY_PAGE_BUDGET = int(os.getenv("CRAWLER_NO_POLICY_PAGE_BUDGET", "
 # pipeline's MIN_LEGAL_SCORE_THRESHOLD for accepting a page into analysis.
 CONVERGENCE_LEGAL_SCORE = 0.2
 
+# Grace window for best_first relevance-exhaustion: once no own-score policy lead remains in
+# the frontier, keep crawling boost-only links for this many pages before giving up, so a
+# policy reachable only via a non-policy page is still discovered. Any newly-found real lead
+# resets the window. Small because real policies sit ≤1-2 hops from the homepage/footer.
+CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
+
 # Minimum extracted body text length to treat static fetch as sufficient (low URL score) and
 # to skip SPA hydration waits in the browser fetch path.
 MIN_CONTENT_LENGTH_FOR_SPA_CHECK = 500
@@ -1498,7 +1504,20 @@ class ClauseaCrawler:
         self._locale_seen_keys: set[str] = set()
         self.url_queue: deque[tuple[str, int]] = deque()  # For BFS
         self.url_stack: list[tuple[str, int]] = []  # For DFS
-        self.url_priority_queue: list[tuple[float, str, int]] = []  # For best-first (scored URLs)
+        # best-first frontier: (-score, url, depth, base_score). `score` orders the queue and
+        # may include a policy-hub parent boost; `base_score` is the URL's own relevance.
+        self.url_priority_queue: list[tuple[float, str, int, float]] = []
+        # Queued-but-not-yet-crawled best_first URLs whose OWN score clears the gate. When this
+        # reaches zero, every genuinely policy-relevant lead has been crawled and only boost-only
+        # links remain — the signal to stop discovery rather than grind through boosted noise.
+        self._frontier_real_leads: int = 0
+        # Crawled pages with policy-grade content; gates the relevance-exhaustion stop.
+        self._policy_pages_found: int = 0
+        # Crawled pages since the frontier last gained a real lead. Once no real lead remains,
+        # we keep crawling boost-only links for a grace window (CRAWL_EXHAUSTION_GRACE) so a
+        # policy reachable only via a non-policy page is still discovered; any new real lead
+        # resets this. Guards against stopping the instant real leads hit zero.
+        self._crawls_since_new_lead: int = 0
         self._sitemap_seeded: bool = False  # True when sitemaps provided seed URLs
         # Best policy-relevance score assigned to each queued URL (anchor-aware).
         # Consulted by the browser-fetch gate so opaque policy URLs discovered via
@@ -3515,6 +3534,35 @@ class ClauseaCrawler:
         if prev is None or score > prev:
             self._url_scores[key] = score
 
+    def _enqueue_best_first(self, url: str, depth: int, score: float, base_score: float) -> None:
+        """Push a URL onto the best-first frontier, counting real (un-boosted) leads.
+
+        `score` orders the queue (may include a policy-hub parent boost); `base_score` is the
+        URL's own relevance and is the only thing that counts toward _frontier_real_leads, so a
+        link that only clears the gate via a parent boost never keeps the crawl alive.
+        """
+        heapq.heappush(self.url_priority_queue, (-score, url, depth, base_score))
+        if base_score >= self.min_legal_score:
+            self._frontier_real_leads += 1
+            # A fresh real lead resets the grace window so discovery follows it.
+            self._crawls_since_new_lead = 0
+
+    def _relevance_exhausted(self) -> bool:
+        """True for best_first once the own-score policy frontier is exhausted past the grace window.
+
+        Stops when we have captured policy content, no URL whose own score clears the gate
+        remains queued, AND a grace window of boost-only crawls has passed without surfacing a
+        new real lead — so a policy reachable only via a non-policy page is still found, but we
+        don't grind through boosted noise (the dominant timeout cause on large sites). BFS has
+        no per-URL priority, so this never applies there.
+        """
+        return (
+            self.strategy == "best_first"
+            and self._policy_pages_found >= 1
+            and self._frontier_real_leads <= 0
+            and self._crawls_since_new_lead >= CRAWL_EXHAUSTION_GRACE
+        )
+
     def add_urls_to_queue(
         self,
         links: list[dict[str, str]],
@@ -3595,7 +3643,7 @@ class ClauseaCrawler:
                     )
                     self.queued_urls.discard(url)
                     continue
-                heapq.heappush(self.url_priority_queue, (-score, url, depth + 1))
+                self._enqueue_best_first(url, depth + 1, score, base_score)
                 logger.debug(
                     f"Added to Best-First queue: {url} (score: {score:.2f}, anchor: {anchor_text})"
                 )
@@ -3640,7 +3688,7 @@ class ClauseaCrawler:
                     self.url_stack.append((url, 1))
                     logger.debug(f"Added potential legal URL to DFS stack: {url}")
                 elif self.strategy == "best_first":
-                    heapq.heappush(self.url_priority_queue, (-score, url, 1))
+                    self._enqueue_best_first(url, 1, score, score)
                     logger.debug(
                         f"Added potential legal URL to Best-First queue: {url} (score: {score:.2f})"
                     )
@@ -3652,7 +3700,9 @@ class ClauseaCrawler:
         elif self.strategy == "dfs" and self.url_stack:
             return self.url_stack.pop()
         elif self.strategy == "best_first" and self.url_priority_queue:
-            _, url, depth = heapq.heappop(self.url_priority_queue)
+            _, url, depth, base_score = heapq.heappop(self.url_priority_queue)
+            if base_score >= self.min_legal_score:
+                self._frontier_real_leads -= 1
             return url, depth
         return None
 
@@ -3763,6 +3813,9 @@ class ClauseaCrawler:
             # Initialize
             base_url = self.normalize_url(base_url)
             self.stats = CrawlStats()
+            self._frontier_real_leads = 0
+            self._policy_pages_found = 0
+            self._crawls_since_new_lead = 0
 
             # Add base URL to queue. Base URLs are explicit seeds (crawl_base_urls) and
             # are always crawled regardless of score; record a generous score so the
@@ -3779,7 +3832,7 @@ class ClauseaCrawler:
                 logger.debug(f"Added base URL to DFS stack: {base_url} (depth: 0)")
             elif self.strategy == "best_first":
                 score = self.url_scorer.score_url(base_url)
-                heapq.heappush(self.url_priority_queue, (-score, base_url, 0))
+                self._enqueue_best_first(base_url, 0, score, score)
                 logger.debug(f"Added base URL to Best-First queue: {base_url} (score: {score:.2f})")
 
             # Create session with connection pooling
@@ -3814,7 +3867,7 @@ class ClauseaCrawler:
                         elif self.strategy == "dfs":
                             self.url_stack.append((url, 0))
                         elif self.strategy == "best_first":
-                            heapq.heappush(self.url_priority_queue, (-score, url, 0))
+                            self._enqueue_best_first(url, 0, score, score)
                         seeded += 1
                     if seeded:
                         self._sitemap_seeded = True
@@ -3860,6 +3913,9 @@ class ClauseaCrawler:
                     # Process results
                     for result, (url, depth) in zip(batch_results, batch, strict=True):
                         self.stats.total_urls += 1
+                        # Counts toward the relevance-exhaustion grace window; add_urls_to_queue
+                        # resets it to 0 if this page surfaces a new own-score policy lead.
+                        self._crawls_since_new_lead += 1
 
                         if result.success:
                             self.stats.crawled_urls += 1
@@ -3871,6 +3927,7 @@ class ClauseaCrawler:
                             ):
                                 found_policy = True
                                 pages_since_policy_hit = 0
+                                self._policy_pages_found += 1
                             else:
                                 pages_since_policy_hit += 1
 
@@ -3906,6 +3963,15 @@ class ClauseaCrawler:
                             f"🧭 Crawl converged: {pages_since_policy_hit} consecutive pages "
                             f"with no policy content (budget {self.no_policy_page_budget}); "
                             f"stopping discovery at {len(self.visited_urls)} pages."
+                        )
+                        break
+
+                    if self._relevance_exhausted():
+                        logger.info(
+                            f"🧭 Crawl relevance-exhausted: {self._policy_pages_found} policy "
+                            f"page(s) found and no own-score lead left after a "
+                            f"{CRAWL_EXHAUSTION_GRACE}-page grace; stopping discovery at "
+                            f"{len(self.visited_urls)} pages (only boost-only links remained)."
                         )
                         break
 
@@ -3965,6 +4031,9 @@ class ClauseaCrawler:
                 self.url_queue.clear()
                 self.url_stack.clear()
                 self.url_priority_queue.clear()
+                self._frontier_real_leads = 0
+                self._policy_pages_found = 0
+                self._crawls_since_new_lead = 0
                 self.results.clear()
                 # Clear caches between different base URLs
                 if self.robots_checker:

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -194,10 +194,8 @@ DEFAULT_NO_POLICY_PAGE_BUDGET = int(os.getenv("CRAWLER_NO_POLICY_PAGE_BUDGET", "
 # pipeline's MIN_LEGAL_SCORE_THRESHOLD for accepting a page into analysis.
 CONVERGENCE_LEGAL_SCORE = 0.2
 
-# Grace window for best_first relevance-exhaustion: once no own-score policy lead remains in
-# the frontier, keep crawling boost-only links for this many pages before giving up, so a
-# policy reachable only via a non-policy page is still discovered. Any newly-found real lead
-# resets the window. Small because real policies sit ≤1-2 hops from the homepage/footer.
+# Boost-only pages to keep crawling after the own-score frontier empties, in case one links a
+# policy reachable no other way. A new real lead resets it. See _relevance_exhausted.
 CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
 
 # Minimum extracted body text length to treat static fetch as sufficient (low URL score) and
@@ -1504,19 +1502,10 @@ class ClauseaCrawler:
         self._locale_seen_keys: set[str] = set()
         self.url_queue: deque[tuple[str, int]] = deque()  # For BFS
         self.url_stack: list[tuple[str, int]] = []  # For DFS
-        # best-first frontier: (-score, url, depth, base_score). `score` orders the queue and
-        # may include a policy-hub parent boost; `base_score` is the URL's own relevance.
+        # best-first frontier: (-score, url, depth, base_score). base_score excludes parent boost.
         self.url_priority_queue: list[tuple[float, str, int, float]] = []
-        # Queued-but-not-yet-crawled best_first URLs whose OWN score clears the gate. When this
-        # reaches zero, every genuinely policy-relevant lead has been crawled and only boost-only
-        # links remain — the signal to stop discovery rather than grind through boosted noise.
-        self._frontier_real_leads: int = 0
-        # Crawled pages with policy-grade content; gates the relevance-exhaustion stop.
+        self._frontier_real_leads: int = 0  # queued URLs whose own score clears the gate
         self._policy_pages_found: int = 0
-        # Crawled pages since the frontier last gained a real lead. Once no real lead remains,
-        # we keep crawling boost-only links for a grace window (CRAWL_EXHAUSTION_GRACE) so a
-        # policy reachable only via a non-policy page is still discovered; any new real lead
-        # resets this. Guards against stopping the instant real leads hit zero.
         self._crawls_since_new_lead: int = 0
         self._sitemap_seeded: bool = False  # True when sitemaps provided seed URLs
         # Best policy-relevance score assigned to each queued URL (anchor-aware).
@@ -3535,27 +3524,14 @@ class ClauseaCrawler:
             self._url_scores[key] = score
 
     def _enqueue_best_first(self, url: str, depth: int, score: float, base_score: float) -> None:
-        """Push a URL onto the best-first frontier, counting real (un-boosted) leads.
-
-        `score` orders the queue (may include a policy-hub parent boost); `base_score` is the
-        URL's own relevance and is the only thing that counts toward _frontier_real_leads, so a
-        link that only clears the gate via a parent boost never keeps the crawl alive.
-        """
+        """Push to the frontier; only an own-score lead (not a boost-only link) counts as real."""
         heapq.heappush(self.url_priority_queue, (-score, url, depth, base_score))
         if base_score >= self.min_legal_score:
             self._frontier_real_leads += 1
-            # A fresh real lead resets the grace window so discovery follows it.
             self._crawls_since_new_lead = 0
 
     def _relevance_exhausted(self) -> bool:
-        """True for best_first once the own-score policy frontier is exhausted past the grace window.
-
-        Stops when we have captured policy content, no URL whose own score clears the gate
-        remains queued, AND a grace window of boost-only crawls has passed without surfacing a
-        new real lead — so a policy reachable only via a non-policy page is still found, but we
-        don't grind through boosted noise (the dominant timeout cause on large sites). BFS has
-        no per-URL priority, so this never applies there.
-        """
+        """True once policy content is found and only boost-only links remain past the grace window."""
         return (
             self.strategy == "best_first"
             and self._policy_pages_found >= 1
@@ -3913,9 +3889,9 @@ class ClauseaCrawler:
                     # Process results
                     for result, (url, depth) in zip(batch_results, batch, strict=True):
                         self.stats.total_urls += 1
-                        # Counts toward the relevance-exhaustion grace window; add_urls_to_queue
-                        # resets it to 0 if this page surfaces a new own-score policy lead.
-                        self._crawls_since_new_lead += 1
+                        self._crawls_since_new_lead += (
+                            1  # reset in _enqueue_best_first on a new lead
+                        )
 
                         if result.success:
                             self.stats.crawled_urls += 1

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -99,7 +99,7 @@ def test_add_urls_to_queue_respects_rel_nofollow_and_meta():
     all_urls = (
         {u for u, _ in crawler.url_queue}
         | {u for u, _ in crawler.url_stack}
-        | {u for _, u, _ in crawler.url_priority_queue}
+        | {u for _, u, _, _ in crawler.url_priority_queue}
     )
     assert "https://example.com/privacy" not in all_urls
 
@@ -109,7 +109,7 @@ def test_add_urls_to_queue_respects_rel_nofollow_and_meta():
     all_urls2 = (
         {u for u, _ in crawler2.url_queue}
         | {u for u, _ in crawler2.url_stack}
-        | {u for _, u, _ in crawler2.url_priority_queue}
+        | {u for _, u, _, _ in crawler2.url_priority_queue}
     )
     assert "https://example.com/privacy" in all_urls2
 

--- a/packages/backend/tests/unit/crawler/relevance_exhaustion_integration_test.py
+++ b/packages/backend/tests/unit/crawler/relevance_exhaustion_integration_test.py
@@ -1,0 +1,97 @@
+"""End-to-end test of the best_first relevance-exhaustion stop over a controlled link graph.
+
+Mocks only the fetch layer (network + content scoring); the real crawl loop, URL scoring,
+parent-boost, real-lead counting, grace window, and stop condition all run for real. Proves
+the two properties that matter under a quality-first crawl:
+
+1. Every policy page is found — including one reachable ONLY through a non-policy (boost-only)
+   page (the "/privacy then /random then /legal" case).
+2. The crawl still terminates early instead of grinding through a long tail of boost-only junk.
+"""
+
+import pytest
+
+from src.crawler import CRAWL_EXHAUSTION_GRACE, ClauseaCrawler, CrawlResult
+
+DOMAIN = "t.test"
+SEED = f"https://{DOMAIN}/"
+
+# Graph: the seed is a policy hub (title has policy keywords) so its links get a parent boost.
+# /privacy, /terms, /cookies have high OWN scores (real leads). /cookies is reachable ONLY via
+# the boost-only /deephub. A long tail of /junkNN pages are boost-only noise.
+_JUNK = [f"https://{DOMAIN}/junk{n:02d}" for n in range(30)]
+
+
+def _links(*urls: str) -> list[dict[str, str]]:
+    return [{"url": u, "text": ""} for u in urls]
+
+
+# url -> (legal_score, title, discovered_links)
+_GRAPH: dict[str, tuple[float, str, list[dict[str, str]]]] = {
+    SEED: (
+        0.0,
+        "Privacy and Terms",
+        _links(
+            f"https://{DOMAIN}/privacy",
+            f"https://{DOMAIN}/terms",
+            f"https://{DOMAIN}/deephub",
+            *_JUNK,
+        ),
+    ),
+    f"https://{DOMAIN}/privacy": (0.9, "Privacy Policy", []),
+    f"https://{DOMAIN}/terms": (0.9, "Terms of Service", []),
+    # Non-hub junk page whose ONLY link is a high-own-score policy reachable nowhere else.
+    f"https://{DOMAIN}/deephub": (0.0, "Help", _links(f"https://{DOMAIN}/cookies")),
+    f"https://{DOMAIN}/cookies": (0.9, "Cookie Policy", []),
+}
+for _j in _JUNK:
+    _GRAPH[_j] = (0.0, "Stuff", [])
+
+
+@pytest.mark.asyncio
+async def test_relevance_exhaustion_finds_all_policies_and_stops_early(monkeypatch):
+    crawler = ClauseaCrawler(
+        strategy="best_first",
+        min_legal_score=2.5,
+        max_depth=5,
+        max_pages=200,  # high, so the relevance-exhaustion stop is what terminates, not the cap
+        max_concurrent=1,  # one page per batch so the grace window is checked exactly per page
+        respect_robots_txt=False,
+        use_browser=False,
+        allowed_domains=[DOMAIN],
+    )
+
+    async def fake_fetch(_session, url: str) -> CrawlResult:
+        score, title, links = _GRAPH.get(url, (0.0, "", []))
+        return CrawlResult(
+            url=url,
+            title=title,
+            content="x" * 600,
+            markdown="x",
+            metadata={"title": title},
+            status_code=200,
+            success=True,
+            legal_score=score,
+            discovered_links=links,
+        )
+
+    async def no_sitemaps(_session, _base):
+        return []
+
+    monkeypatch.setattr(crawler, "fetch_page", fake_fetch)
+    monkeypatch.setattr(crawler, "_discover_sitemap_urls", no_sitemaps)
+
+    await crawler.crawl(SEED, cleanup=False)
+    visited = crawler.visited_urls
+
+    # 1. Quality: every policy page was crawled — including /cookies, reachable only via the
+    #    boost-only /deephub. Nothing dropped.
+    assert f"https://{DOMAIN}/privacy" in visited
+    assert f"https://{DOMAIN}/terms" in visited
+    assert f"https://{DOMAIN}/cookies" in visited
+
+    # 2. Termination: the crawl stopped without grinding the whole junk tail. It crawls at most
+    #    the grace window's worth of junk after the last real lead, far fewer than all 30.
+    junk_visited = sum(1 for j in _JUNK if j in visited)
+    assert junk_visited <= CRAWL_EXHAUSTION_GRACE, f"crawled too much junk: {junk_visited}"
+    assert len(visited) < len(_JUNK), "should not have crawled the entire junk tail"

--- a/packages/backend/tests/unit/crawler/relevance_exhaustion_integration_test.py
+++ b/packages/backend/tests/unit/crawler/relevance_exhaustion_integration_test.py
@@ -1,12 +1,7 @@
-"""End-to-end test of the best_first relevance-exhaustion stop over a controlled link graph.
+"""Relevance-exhaustion stop over a controlled link graph (only the fetch layer is mocked).
 
-Mocks only the fetch layer (network + content scoring); the real crawl loop, URL scoring,
-parent-boost, real-lead counting, grace window, and stop condition all run for real. Proves
-the two properties that matter under a quality-first crawl:
-
-1. Every policy page is found — including one reachable ONLY through a non-policy (boost-only)
-   page (the "/privacy then /random then /legal" case).
-2. The crawl still terminates early instead of grinding through a long tail of boost-only junk.
+Asserts both quality and termination: every policy is found — including one reachable only
+via a boost-only junk page — while the long junk tail is skipped after the grace window.
 """
 
 import pytest

--- a/packages/backend/tests/unit/crawler/state_test.py
+++ b/packages/backend/tests/unit/crawler/state_test.py
@@ -1,6 +1,61 @@
 """Unit tests for ClauseaCrawler depth and state management."""
 
-from src.crawler import ClauseaCrawler
+from src.crawler import CRAWL_EXHAUSTION_GRACE, ClauseaCrawler
+
+
+class TestRelevanceExhaustion:
+    """The best_first relevance-exhaustion stop: stop once every own-score policy lead is
+    crawled and a grace window of boost-only crawls surfaced nothing new."""
+
+    def test_boost_only_link_is_not_a_real_lead(self) -> None:
+        crawler = ClauseaCrawler(strategy="best_first", min_legal_score=2.5)
+        # Boosted score clears the gate, but the URL's own score does not.
+        crawler._enqueue_best_first("https://x.com/random", 1, 3.0, 0.0)
+        assert crawler._frontier_real_leads == 0
+
+    def test_own_score_link_is_a_real_lead_and_pop_decrements(self) -> None:
+        crawler = ClauseaCrawler(strategy="best_first", min_legal_score=2.5)
+        crawler._enqueue_best_first("https://x.com/privacy", 1, 8.0, 8.0)
+        assert crawler._frontier_real_leads == 1
+        crawler.get_next_url()  # popping the lead decrements the counter
+        assert crawler._frontier_real_leads == 0
+
+    def test_new_real_lead_resets_grace_window(self) -> None:
+        crawler = ClauseaCrawler(strategy="best_first", min_legal_score=2.5)
+        crawler._crawls_since_new_lead = 5
+        crawler._enqueue_best_first("https://x.com/legal", 1, 4.0, 4.0)
+        assert crawler._crawls_since_new_lead == 0
+
+    def test_does_not_stop_while_a_real_lead_is_queued(self) -> None:
+        # The /privacy -> /random -> /legal case: /legal is a real lead, so we never give up
+        # while it is queued, regardless of intervening boost-only pages.
+        crawler = ClauseaCrawler(strategy="best_first", min_legal_score=2.5)
+        crawler._policy_pages_found = 1
+        crawler._enqueue_best_first("https://x.com/legal", 1, 4.0, 4.0)
+        crawler._crawls_since_new_lead = CRAWL_EXHAUSTION_GRACE + 5
+        assert crawler._relevance_exhausted() is False
+
+    def test_stops_only_after_grace_once_leads_exhausted(self) -> None:
+        crawler = ClauseaCrawler(strategy="best_first", min_legal_score=2.5)
+        crawler._policy_pages_found = 1
+        crawler._frontier_real_leads = 0
+        crawler._crawls_since_new_lead = CRAWL_EXHAUSTION_GRACE - 1
+        assert crawler._relevance_exhausted() is False  # grace not yet elapsed
+        crawler._crawls_since_new_lead = CRAWL_EXHAUSTION_GRACE
+        assert crawler._relevance_exhausted() is True
+
+    def test_never_stops_before_any_policy_found(self) -> None:
+        crawler = ClauseaCrawler(strategy="best_first", min_legal_score=2.5)
+        crawler._frontier_real_leads = 0
+        crawler._crawls_since_new_lead = CRAWL_EXHAUSTION_GRACE * 2
+        assert crawler._relevance_exhausted() is False  # no policy page found yet
+
+    def test_does_not_apply_to_bfs(self) -> None:
+        crawler = ClauseaCrawler(strategy="bfs", min_legal_score=2.5)
+        crawler._policy_pages_found = 5
+        crawler._frontier_real_leads = 0
+        crawler._crawls_since_new_lead = CRAWL_EXHAUSTION_GRACE * 2
+        assert crawler._relevance_exhausted() is False
 
 
 class TestCrawlerState:
@@ -86,5 +141,5 @@ class TestCrawlerState:
         import heapq
 
         crawler = ClauseaCrawler(strategy="best_first")
-        heapq.heappush(crawler.url_priority_queue, (-5.0, "https://example.com/a", 1))
+        heapq.heappush(crawler.url_priority_queue, (-5.0, "https://example.com/a", 1, 5.0))
         assert crawler._get_pending_url_count() == 1

--- a/packages/backend/tests/unit/crawler/url_scorer_test.py
+++ b/packages/backend/tests/unit/crawler/url_scorer_test.py
@@ -228,7 +228,7 @@ class TestParentPageBoost:
         )
 
         assert len(crawler.url_priority_queue) == 1
-        neg_score, url, _depth = crawler.url_priority_queue[0]
+        neg_score, url, _depth, _base = crawler.url_priority_queue[0]
         actual_score = -neg_score
 
         # Score should exceed the base URL score thanks to the parent boost
@@ -258,7 +258,7 @@ class TestParentPageBoost:
             page_metadata={"title": "Legal Resources"},
         )
 
-        queued = {url for _neg, url, _depth in crawler.url_priority_queue}
+        queued = {url for _neg, url, _depth, _base in crawler.url_priority_queue}
         assert "https://example.com/template/holiday" not in queued
         assert "https://example.com/templates/legal-case/exp9" not in queued
         # The boost still works for non-excluded opaque policy URLs.


### PR DESCRIPTION
## Problem

Slow-SPA products (Airbnb-type) never get indexed: their crawl runs to the ~400-page cap, and at ~20–55s/page that exceeds the 2h pipeline ceiling (`MAX_PIPELINE_DURATION_SECONDS`) → the job is killed → the product is never indexed (zero quality).

## Root cause (measured, not assumed)

The scorer is well-tuned — `/e/...`, `/rooms/...` score **0.0**. But `_compute_parent_page_boost` adds **+3.0 to every link** on a policy-hub page, lifting that junk over the 2.5 discovery gate. So the best_first frontier floods with non-policy pages and the crawl grinds on. (Verified by probing the live scorer + crawls; the earlier "BFS wanders into junk" theory in the closed #76 was wrong — this is parent-boost flooding, and the policies are actually found in the *first* ~17 pages.)

## Fix — relevance-exhaustion stop (quality-neutral)

Track each URL's **own** score separately from the parent boost. Stop discovery only when **all three** hold:
1. ≥1 policy page has been found, and
2. no queued URL has an own-score ≥ the gate (only boost-only links remain), and
3. a grace window (`CRAWLER_EXHAUSTION_GRACE`, default 10) of boost-only crawls surfaced no new own-score lead.

**Why this doesn't drop documents:** the only pages ever skipped are boost-only — pages the scorer itself rates non-policy. Every page with its *own* policy signal (path or anchor) is a real lead and is always crawled. A policy reachable **only via a non-policy page** is still found: crawling that page surfaces the policy as a new real lead and **resets the grace window** (the `/privacy → /random → /legal` case). This is recall-preserving, not a speed-for-recall trade — speed is just the side effect of not grinding boost-only noise. BFS (the fallback pass) has no per-URL priority and is unaffected.

## Explicitly NOT included
- No hard page-cap reduction (a smaller cap could cut a late-ranked policy).
- No `parent_boost` removal (it's what rescues genuinely opaque policy URLs like Amazon's `/gp/help/...?nodeId=`).

## Tests
- **7 unit** (`state_test.py`): real-lead counting, boost-only ≠ real lead, grace reset on new lead, "never stop while a real lead is queued", grace gating, no-stop-before-any-policy, BFS exempt.
- **1 integration** (`relevance_exhaustion_integration_test.py`): mocks the fetch layer, runs the real crawl loop over a link graph where `/cookies` is reachable **only** through a boost-only junk page — asserts all three policies (`/privacy`, `/terms`, `/cookies`) are crawled while the 30-page junk tail is skipped after the grace window.
- Full backend unit suite green (578), `ruff` + `ty` clean.

## Verification note
Live end-to-end on Airbnb was unreliable — repeated crawls tonight throttled my IP (0 pages, seed-fetch blocked), a test-environment artifact, not the change. The deterministic integration test covers the same property without that flakiness. A separate task tracks the bot-wall / seed-fetch failure class (Amazon, Notion, throttled Airbnb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)