### PR TITLE
fix(crawler): stop dropping fetchable sites (large headers + Brotli)

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -2133,6 +2133,10 @@ class ClauseaCrawler:
             logger.warning("Browser setup failed for %s: %s", url, e)
             return None
         page: Page = await context.new_page()
+        # Camoufox/Firefox fails to decompress Brotli ("br") response bodies, leaving the DOM
+        # full of compressed garbage — common on Cloudflare-fronted sites (OpenAI, etc.), which
+        # serve br by default. Request gzip only so the browser decodes content correctly.
+        await page.set_extra_http_headers({"Accept-Encoding": "gzip, deflate"})
 
         try:
             # Only block heavy media. CSS and fonts are often required for SPA rendering

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -205,6 +205,10 @@ MIN_CONTENT_LENGTH_FOR_SPA_CHECK = 500
 # Browser fetch: short polling attempts when initial DOM text is below MIN_CONTENT_LENGTH_FOR_SPA_CHECK.
 SPA_HYDRATION_RETRIES = 3
 
+# aiohttp's default 8190-byte header cap rejects sites with large headers (e.g. Notion's CSP)
+# with HTTP 400, failing every fetch for that domain. Raise it so we don't lose those sites.
+MAX_HEADER_BYTES = 65_536
+
 # Browser navigation budget. A render is a fallback for pages the static fetch couldn't
 # use, so it gets a tight cap: a page that hasn't reached domcontentloaded in this long is
 # almost always hung or bot-walled, not a slow policy page. Bounded by the static timeout.
@@ -3815,7 +3819,12 @@ class ClauseaCrawler:
             connector = aiohttp.TCPConnector(limit=self.max_concurrent)
             timeout = aiohttp.ClientTimeout(total=self.timeout)
 
-            async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+            async with aiohttp.ClientSession(
+                connector=connector,
+                timeout=timeout,
+                max_line_size=MAX_HEADER_BYTES,
+                max_field_size=MAX_HEADER_BYTES,
+            ) as session:
                 # Discover sitemaps and use their URLs as depth-0 seeds.
                 # This gives every sitemap URL the full max_depth of crawling
                 # and avoids wasting requests on speculative path guessing.
@@ -4068,7 +4077,12 @@ async def test_specific_url(url: str) -> CrawlResult:
     connector = aiohttp.TCPConnector(limit=1)
     timeout = aiohttp.ClientTimeout(total=30)
 
-    async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
+    async with aiohttp.ClientSession(
+        connector=connector,
+        timeout=timeout,
+        max_line_size=MAX_HEADER_BYTES,
+        max_field_size=MAX_HEADER_BYTES,
+    ) as session:
         result = await crawler.fetch_page(session, url)
 
         if result.success:


### PR DESCRIPTION
Two independent client-side bugs were causing whole products to return **0 pages → never indexed**. Both looked like bot-walls; neither was.

## 1. Large response headers → HTTP 400 (e.g. Notion)
aiohttp's default header cap is **8190 bytes** (`max_line_size`/`max_field_size`). Notion ships a very large CSP header that overflows it, so aiohttp raised **HTTP 400** on every fetch (robots, sitemap, page). Fix: raise both limits to 64 KB on the crawler's `ClientSession`s.
**Verified:** `notion.com/privacy` HTTP 400 (0 chars) → **200 (34,827 chars)**.

## 2. Brotli responses rendered as garbage (e.g. OpenAI, Cloudflare sites)
Camoufox/Firefox does **not decompress Brotli (`br`)** response bodies — the DOM fills with compressed bytes, extraction yields nothing, page dropped. Cloudflare serves `br` by default, so this silently lost many sites. Confirmed it's not anti-bot (`cf-mitigated` absent). Fix: override `Accept-Encoding: gzip, deflate` on browser pages so the server sends gzip, which the browser decodes.
**Verified:** `openai.com/policies/privacy-policy` "render no usable content" → **200, "Europe privacy policy | OpenAI" (29,975 chars)**.

## Impact
Quality fix (the priority): products that were entirely un-indexable now fetch and extract. Both changes are tiny and site-agnostic. Lint + type clean; backend unit suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)