### PR TITLE
fix(worker): stop crashloop — requeue must not create a 2nd active job per product

### DIFF
--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -186,6 +186,12 @@ class PipelineRepository(BaseRepository):
 
         Makes the worker self-healing: orphaned jobs (failed by mark_stale_as_failed) and
         transient failures retry. ``no_documents`` is terminal and deliberately not retried.
+
+        At most one active job per product (enforced by the uniq_active_job_per_product
+        partial index): products that already have an active job are skipped, and only one
+        failed job per remaining product is revived — reactivating a second would raise a
+        DuplicateKeyError. A missing "attempts" field doesn't match ``$lt`` in MongoDB, so
+        pre-existing jobs are matched via ``$exists`` and get attempts=1 on the next claim.
         """
         fresh_steps = [
             {
@@ -200,29 +206,43 @@ class PipelineRepository(BaseRepository):
             }
             for name in ("crawling", "summarizing", "generating_overview")
         ]
-        result = await db[self.COLLECTION].update_many(
-            # A missing "attempts" field does not match $lt in MongoDB, so pre-existing
-            # jobs (written before the field existed) are matched via $exists and get
-            # attempts=1 on the next claim's $inc.
-            {
-                "status": "failed",
-                "$or": [{"attempts": {"$lt": max_attempts}}, {"attempts": {"$exists": False}}],
-            },
-            {
-                "$set": {
-                    "status": "pending",
-                    "active": True,
-                    "steps": fresh_steps,
-                    "error": None,
-                    "error_detail": None,
-                    "started_at": None,
-                    "completed_at": None,
-                    "last_heartbeat": None,
-                    "updated_at": datetime.now(),
-                }
-            },
+        claimed_slugs: set[str] = set(
+            await db[self.COLLECTION].distinct("product_slug", {"active": True})
         )
-        count = result.modified_count
+        candidates: list[dict[str, Any]] = (
+            await db[self.COLLECTION]
+            .find(
+                {
+                    "status": "failed",
+                    "$or": [{"attempts": {"$lt": max_attempts}}, {"attempts": {"$exists": False}}],
+                }
+            )
+            .to_list(length=None)
+        )
+
+        count = 0
+        for job in candidates:
+            slug = job["product_slug"]
+            if slug in claimed_slugs:  # product already has (or just got) an active job
+                continue
+            claimed_slugs.add(slug)
+            await db[self.COLLECTION].update_one(
+                {"id": job["id"]},
+                {
+                    "$set": {
+                        "status": "pending",
+                        "active": True,
+                        "steps": fresh_steps,
+                        "error": None,
+                        "error_detail": None,
+                        "started_at": None,
+                        "completed_at": None,
+                        "last_heartbeat": None,
+                        "updated_at": datetime.now(),
+                    }
+                },
+            )
+            count += 1
         if count:
             logger.info(
                 "Re-queued %d failed job(s) for retry (max_attempts=%d)", count, max_attempts

--- a/packages/backend/tests/unit/pipeline_stale_jobs_test.py
+++ b/packages/backend/tests/unit/pipeline_stale_jobs_test.py
@@ -28,23 +28,60 @@ async def test_mark_stale_targets_only_in_progress_not_pending():
     assert set(eligible) == {"crawling", "summarizing", "generating_overview"}
 
 
+def _failed_jobs_collection(active_slugs, candidates):
+    """Mock collection: distinct() returns active slugs, find().to_list() returns candidates."""
+    collection = MagicMock()
+    collection.distinct = AsyncMock(return_value=active_slugs)
+    cursor = MagicMock()
+    cursor.to_list = AsyncMock(return_value=candidates)
+    collection.find = MagicMock(return_value=cursor)
+    collection.update_one = AsyncMock()
+    return collection
+
+
 @pytest.mark.asyncio
 async def test_requeue_failed_only_retries_under_attempt_cap():
-    collection = MagicMock()
-    collection.update_many = AsyncMock(return_value=MagicMock(modified_count=2))
+    collection = _failed_jobs_collection(
+        active_slugs=[],
+        candidates=[{"id": "a", "product_slug": "alpha"}, {"id": "b", "product_slug": "beta"}],
+    )
     db = MagicMock()
     db.__getitem__.return_value = collection
 
     requeued = await PipelineRepository().requeue_failed_jobs(db, max_attempts=4)
 
-    query = collection.update_many.call_args.args[0]
-    update = collection.update_many.call_args.args[1]
+    query = collection.find.call_args.args[0]
     # Only failed jobs are retried; no_documents stays terminal.
     assert query["status"] == "failed"
     # Under the cap OR missing the field (pre-existing jobs) — $lt alone skips missing fields.
     assert {"attempts": {"$lt": 4}} in query["$or"]
     assert {"attempts": {"$exists": False}} in query["$or"]
+    update = collection.update_one.call_args.args[1]
     assert update["$set"]["status"] == "pending"
     # Steps reset so a retry doesn't carry stale terminal step state.
     assert all(s["status"] == "pending" for s in update["$set"]["steps"])
     assert requeued == 2
+
+
+@pytest.mark.asyncio
+async def test_requeue_never_creates_second_active_job_per_product():
+    # Regression: reactivating a failed job for a product that already has an active job (or
+    # a second failed job for the same product) violates uniq_active_job_per_product and
+    # previously crashed the worker on boot.
+    collection = _failed_jobs_collection(
+        active_slugs=["foo"],  # foo already has an active job
+        candidates=[
+            {"id": "1", "product_slug": "foo"},  # skipped — already active
+            {"id": "2", "product_slug": "bar"},  # requeued
+            {"id": "3", "product_slug": "bar"},  # skipped — bar already revived above
+            {"id": "4", "product_slug": "baz"},  # requeued
+        ],
+    )
+    db = MagicMock()
+    db.__getitem__.return_value = collection
+
+    requeued = await PipelineRepository().requeue_failed_jobs(db, max_attempts=4)
+
+    assert requeued == 2
+    revived_ids = {call.args[0]["id"] for call in collection.update_one.call_args_list}
+    assert revived_ids == {"2", "4"}

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -32,14 +32,21 @@ _MAX_ATTEMPTS = max(1, int(os.getenv("PIPELINE_MAX_ATTEMPTS", "4")))
 
 async def _sweep_stale(repo: PipelineRepository) -> None:
     """Self-heal the queue (boot + periodic): reap crash-orphaned in-progress jobs, then
-    re-queue failed ones (orphans + transient failures) up to _MAX_ATTEMPTS."""
-    async with db_session() as db:
-        reaped = await repo.mark_stale_as_failed(db)
-        requeued = await repo.requeue_failed_jobs(db, _MAX_ATTEMPTS)
-    if reaped:
-        logger.info("Reaped %d stale job(s) as failed", reaped)
-    if requeued:
-        logger.info("Re-queued %d failed job(s) for retry", requeued)
+    re-queue failed ones (orphans + transient failures) up to _MAX_ATTEMPTS.
+
+    Best-effort: a sweep error must never stop the worker from claiming jobs (a single
+    failure here previously crashlooped the whole worker), so failures are logged, not raised.
+    """
+    try:
+        async with db_session() as db:
+            reaped = await repo.mark_stale_as_failed(db)
+            requeued = await repo.requeue_failed_jobs(db, _MAX_ATTEMPTS)
+        if reaped:
+            logger.info("Reaped %d stale job(s) as failed", reaped)
+        if requeued:
+            logger.info("Re-queued %d failed job(s) for retry", requeued)
+    except Exception as exc:  # noqa: BLE001 - the queue self-heal must not kill the worker
+        logger.error("Stale sweep failed (continuing): %s", exc, exc_info=True)
 
 
 async def _run_job(job_id: str) -> None:


### PR DESCRIPTION
## Impact (production was down)

The pipeline **worker has been down since #75** — 0 jobs processed for ~2.5h, ~87 pending unclaimed, ~111 failed never retried. Products stopped indexing entirely. Confirmed from the prod DB (no job updated in hours) and the Railway worker logs (crashloop traceback).

## Root cause

`requeue_failed_jobs` (added in #75) bulk-flipped every failed job to `active: true` via one `update_many`. But `pipeline_jobs` has a **partial unique index `uniq_active_job_per_product`** (at most one active job per product). A product that had *both* a failed job and an already-active job hit:

```
pymongo.errors.DuplicateKeyError: E11000 ... index: uniq_active_job_per_product
  dup key: { product_slug: "myfitnesspal" }
```

That raised inside the **boot sweep** (`worker.main` → `_sweep_stale`, unguarded) → the worker crashed on every start → Railway marked the deploy failed and never brought it up. One stale duplicate froze the whole queue.

## Fix

1. **`requeue_failed_jobs` can no longer create a duplicate active job.** It now skips products that already have an active job and revives **at most one** failed job per product (`distinct` active slugs + `find` candidates + per-job `update_one`, deduping by `product_slug`). Reactivating a second job for a product is impossible by construction.
2. **`worker._sweep_stale` is best-effort** — sweep errors are logged, not raised, so a self-heal failure can never again stop the worker from claiming jobs (defense in depth).

## Verification

- Root cause read directly from the Railway crashloop traceback (DuplicateKeyError on `uniq_active_job_per_product`).
- New regression test `test_requeue_never_creates_second_active_job_per_product`: a product with an existing active job is skipped, and a second failed job for the same product is not revived.
- Full backend unit suite green (579), `ruff` + `ty` clean.

Once deployed, the worker boots, the sweep requeues the backlog safely (≤1 active per product), and it drains `pending` + retries failures as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)