### PR TITLE
feat(crawler): store-as-you-crawl + per-page heartbeat

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -12,7 +12,7 @@ import random
 import re
 import time
 from collections import OrderedDict, deque
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
@@ -1417,6 +1417,10 @@ class ClauseaCrawler:
         use_tika_for_binaries: bool = False,
         use_pdfminer_for_pdf: bool = False,
         progress_callback: Callable[[int, int], None] | None = None,  # Optional progress callback
+        # Optional per-result hook fired for every processed CrawlResult (success and
+        # failure). Lets callers stream each page to classification/storage as it is
+        # produced instead of batching at the end of a multi-hour crawl.
+        result_callback: Callable[[CrawlResult], Awaitable[None]] | None = None,
     ):
         """
         Initialize the ClauseaCrawler.
@@ -1472,6 +1476,7 @@ class ClauseaCrawler:
 
         # Progress callback for external monitoring
         self.progress_callback = progress_callback
+        self.result_callback = result_callback
         # Number of processed URLs at the last progress report (for cadence).
         self._last_progress_report = 0
 
@@ -3725,6 +3730,16 @@ class ClauseaCrawler:
         )
         self.progress_callback(self.stats.crawled_urls, total_known)
 
+    async def _emit_result(self, result: CrawlResult) -> None:
+        """Forward a processed result to the streaming callback, if one is set.
+
+        Fired for every result (success and failure) so the callback can both store
+        documents (on success) and bump a job heartbeat (always). A None callback is
+        a no-op, preserving the original batch-at-end behavior.
+        """
+        if self.result_callback is not None:
+            await self.result_callback(result)
+
     async def _drain_render_retries(self, session: aiohttp.ClientSession) -> None:
         """Serially re-attempt renders that failed during the concurrent crawl.
 
@@ -3750,6 +3765,8 @@ class ClauseaCrawler:
                     self.failed_urls.discard(url)
                     self.results.append(result)
                     logger.info(f"✅ Recovered on serial retry: {url}")
+                    # Stream recovered pages so they are stored like any other result.
+                    await self._emit_result(result)
                 else:
                     logger.warning(f"❌ Still failed after serial retry: {url}")
         finally:
@@ -3942,6 +3959,11 @@ class ClauseaCrawler:
                             # a count to avoid recording large volumes of probe 404s.
                             if result.blocked_by_robots_txt:
                                 self.results.append(result)
+
+                        # Stream every processed result (success and failure) so the
+                        # pipeline can classify+store as pages arrive and keep the job
+                        # heartbeat fresh during long crawls.
+                        await self._emit_result(result)
 
                     # Progress update — emitted on a threshold crossing so it
                     # survives batched jumps in total_urls (see helper docstring).

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -814,6 +814,7 @@ class PolicyDocumentPipeline:
         min_legal_score: float | None = None,
         strategy: str | None = None,
         progress_phase: str | None = None,
+        result_callback: Callable[[CrawlResult], Awaitable[None]] | None = None,
     ) -> ClauseaCrawler:
         """Create a configured crawler instance for a specific product."""
         from datetime import datetime
@@ -860,6 +861,7 @@ class PolicyDocumentPipeline:
             allowed_paths=product.crawl_allowed_paths,
             denied_paths=product.crawl_denied_paths,
             progress_callback=progress_callback,
+            result_callback=result_callback,
         )
 
     async def _store_documents(self, documents: list[Document]) -> int:
@@ -1354,9 +1356,25 @@ class PolicyDocumentPipeline:
             processed_urls: set[str] = set()
             seen_fingerprints: set[str] = set()
             total_results = 0
+            processed_documents: list[Document] = []
+
+            # Stream each crawled result through classification + storage as it is
+            # produced, so a crawl killed at the time ceiling or by a stall keeps the
+            # work done so far instead of losing everything in an end-of-crawl batch.
+            # The shared *processed_urls* / *seen_fingerprints* sets dedupe across the
+            # per-result calls exactly as the old batch call did. _store_documents is
+            # idempotent (dedupes by URL/fingerprint), so re-arrivals are safe.
+            async def result_callback(result: CrawlResult) -> None:
+                docs = await self._classify_results(
+                    [result], product, processed_urls, seen_fingerprints
+                )
+                if docs:
+                    stored = await self._store_documents(docs)
+                    self.stats.policy_documents_stored += stored
+                    processed_documents.extend(docs)
 
             # ----------------------------------------------------------
-            # Stage 1: Crawl (pure fetching, no classification)
+            # Stage 1: Crawl (streams classify + store per page)
             # ----------------------------------------------------------
 
             # Discovery pass (precision-first)
@@ -1370,6 +1388,7 @@ class PolicyDocumentPipeline:
                 min_legal_score=self.discovery_min_legal_score,
                 strategy=self.discovery_strategy,
                 progress_phase="discovery",
+                result_callback=result_callback,
             )
             discovery_results = await self._crawl_base_urls(discovery_crawler, crawl_urls)
             logger_discovery.info(
@@ -1377,15 +1396,8 @@ class PolicyDocumentPipeline:
             )
             total_results += len(discovery_results)
 
-            # ----------------------------------------------------------
-            # Stage 2: Classify + Score
-            # ----------------------------------------------------------
-
-            processed_documents = await self._classify_results(
-                discovery_results, product, processed_urls, seen_fingerprints
-            )
-
-            # Fallback deep crawl (recall-first) if coverage is low
+            # Fallback deep crawl (recall-first) if coverage is low. The decision runs
+            # on the documents already streamed+stored during the discovery pass.
             if self._should_fallback_crawl(processed_documents):
                 logger_discovery.info(
                     f"discovery coverage insufficient for '{product.name}'; starting fallback deep crawl (max_depth={self.max_depth}, max_pages={self.max_pages})"
@@ -1397,6 +1409,7 @@ class PolicyDocumentPipeline:
                     min_legal_score=self.fallback_min_legal_score,
                     strategy=self.fallback_strategy,
                     progress_phase="fallback",
+                    result_callback=result_callback,
                 )
                 fallback_results = await self._crawl_base_urls(fallback_crawler, crawl_urls)
                 logger_discovery.info(
@@ -1404,23 +1417,14 @@ class PolicyDocumentPipeline:
                 )
                 total_results += len(fallback_results)
 
-                fallback_docs = await self._classify_results(
-                    fallback_results, product, processed_urls, seen_fingerprints
-                )
-                processed_documents.extend(fallback_docs)
-
             self.stats.total_urls_crawled += total_results
             self.stats.total_documents_found += total_results
 
             logger.info(f"📄 Found {total_results} pages for {product.name}")
 
-            # Store processed documents
             if processed_documents:
-                stored_count = await self._store_documents(processed_documents)
-                self.stats.policy_documents_stored += stored_count
                 logger.info(
-                    f"💾 Stored {stored_count}/{len(processed_documents)} "
-                    f"policy documents for {product.name}"
+                    f"💾 Stored {len(processed_documents)} policy documents for {product.name}"
                 )
             else:
                 logger.info(f"No policy documents found for {product.name}")

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -299,6 +299,16 @@ class PipelineService:
                 if message is not None:
                     step.message = message
                     update_data[f"steps.{i}.message"] = message
+
+                # Steady crawl progress must keep the job alive. The in-process stall
+                # guard checks updated_at (bumped by update_fields) and the cross-process
+                # stale-job sweeper prefers last_heartbeat; set the latter here so both
+                # see forward progress even when the monotonic clamp leaves no other
+                # field changed. The crawler reports every PROGRESS_REPORT_INTERVAL pages,
+                # which stays well inside the stall window even at slow speeds.
+                now = datetime.now()
+                job.last_heartbeat = now
+                update_data["last_heartbeat"] = now
                 break
 
         if not update_data:

--- a/packages/backend/tests/unit/crawler/result_callback_test.py
+++ b/packages/backend/tests/unit/crawler/result_callback_test.py
@@ -1,0 +1,143 @@
+"""The per-result callback streams every processed page out of the crawler.
+
+Long crawls must persist progress incrementally rather than batching all storage at the
+end, so the pipeline registers a ``result_callback`` that fires once for every processed
+result — success AND failure — as it is produced. A None callback must be a zero-behavior
+change no-op.
+"""
+
+import pytest
+
+from src.crawler import ClauseaCrawler, CrawlResult
+
+DOMAIN = "cb.test"
+SEED = f"https://{DOMAIN}/"
+
+# Seed links to one good policy page and one page that fails to fetch. Both must reach the
+# callback: the success so it can be stored, the failure so the heartbeat still advances.
+_GRAPH: dict[str, tuple[bool, list[dict[str, str]]]] = {
+    SEED: (
+        True,
+        [
+            {"url": f"https://{DOMAIN}/privacy", "text": ""},
+            {"url": f"https://{DOMAIN}/dead", "text": ""},
+        ],
+    ),
+    f"https://{DOMAIN}/privacy": (True, []),
+    f"https://{DOMAIN}/dead": (False, []),
+}
+
+
+def _fake_fetch():
+    async def fake_fetch(_session, url: str) -> CrawlResult:
+        success, links = _GRAPH.get(url, (False, []))
+        return CrawlResult(
+            url=url,
+            title="",
+            content="x" * 600 if success else "",
+            markdown="x",
+            metadata={},
+            status_code=200 if success else 0,
+            success=success,
+            discovered_links=links,
+        )
+
+    return fake_fetch
+
+
+async def _no_sitemaps(_session, _base):
+    return []
+
+
+def _crawler(result_callback) -> ClauseaCrawler:
+    return ClauseaCrawler(
+        max_depth=3,
+        max_pages=50,
+        max_concurrent=1,
+        respect_robots_txt=False,
+        use_browser=False,
+        allowed_domains=[DOMAIN],
+        result_callback=result_callback,
+    )
+
+
+@pytest.mark.asyncio
+async def test_callback_fires_once_per_processed_result_success_and_failure(monkeypatch):
+    seen: list[tuple[str, bool]] = []
+
+    async def callback(result: CrawlResult) -> None:
+        seen.append((result.url, result.success))
+
+    crawler = _crawler(callback)
+    monkeypatch.setattr(crawler, "fetch_page", _fake_fetch())
+    monkeypatch.setattr(crawler, "_discover_sitemap_urls", _no_sitemaps)
+
+    await crawler.crawl(SEED, cleanup=False)
+
+    seen_urls = [url for url, _ in seen]
+    # Every processed URL reached the callback exactly once — including the failure.
+    assert seen_urls.count(SEED) == 1
+    assert seen_urls.count(f"https://{DOMAIN}/privacy") == 1
+    assert seen_urls.count(f"https://{DOMAIN}/dead") == 1
+    assert (f"https://{DOMAIN}/dead", False) in seen
+
+
+@pytest.mark.asyncio
+async def test_callback_fires_across_multiple_seeds(monkeypatch):
+    seen: list[str] = []
+
+    async def callback(result: CrawlResult) -> None:
+        seen.append(result.url)
+
+    crawler = _crawler(callback)
+    monkeypatch.setattr(crawler, "fetch_page", _fake_fetch())
+    monkeypatch.setattr(crawler, "_discover_sitemap_urls", _no_sitemaps)
+
+    await crawler.crawl_multiple([SEED, SEED])
+
+    # The instance-level callback survives the per-seed state reset, so both passes report.
+    assert seen.count(f"https://{DOMAIN}/privacy") == 2
+
+
+@pytest.mark.asyncio
+async def test_none_callback_is_a_noop(monkeypatch):
+    crawler = _crawler(None)
+    monkeypatch.setattr(crawler, "fetch_page", _fake_fetch())
+    monkeypatch.setattr(crawler, "_discover_sitemap_urls", _no_sitemaps)
+
+    # No error, and the crawl still produces results exactly as before.
+    results = await crawler.crawl(SEED, cleanup=False)
+    assert any(r.url == f"https://{DOMAIN}/privacy" and r.success for r in results)
+
+
+@pytest.mark.asyncio
+async def test_recovered_render_retry_reaches_callback(monkeypatch):
+    """A page recovered on the serial render-retry pass is streamed like any other result."""
+    seen: list[str] = []
+
+    async def callback(result: CrawlResult) -> None:
+        seen.append(result.url)
+
+    crawler = _crawler(callback)
+    crawler._render_retry_queue = [f"https://{DOMAIN}/late"]
+
+    async def fetch_page(_session, url: str) -> CrawlResult:
+        return CrawlResult(
+            url=url,
+            title="",
+            content="x" * 600,
+            markdown="x",
+            metadata={},
+            status_code=200,
+            success=True,
+        )
+
+    monkeypatch.setattr(crawler, "fetch_page", fetch_page)
+
+    from typing import cast
+
+    import aiohttp
+
+    await crawler._drain_render_retries(session=cast(aiohttp.ClientSession, None))
+
+    assert seen == [f"https://{DOMAIN}/late"]

--- a/packages/backend/tests/unit/pipeline_heartbeat_test.py
+++ b/packages/backend/tests/unit/pipeline_heartbeat_test.py
@@ -1,0 +1,70 @@
+"""Crawl-progress updates refresh the job heartbeat so steady progress keeps it alive.
+
+The stall guard cancels a job whose updated_at goes stale; the cross-process sweeper prefers
+last_heartbeat. A per-page progress update therefore writes both, even when the monotonic
+progress clamp leaves no other field changed, so a slow-but-advancing crawl is never killed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.pipeline_job import PipelineJob
+from src.repositories.pipeline_repository import PipelineRepository
+from src.services.pipeline_service import PipelineService
+
+
+def _job() -> PipelineJob:
+    return PipelineJob(product_slug="x", product_name="X", url="https://x.com", status="crawling")
+
+
+@pytest.mark.asyncio
+async def test_progress_update_bumps_last_heartbeat():
+    repo = MagicMock(spec=PipelineRepository)
+    repo.update_fields = AsyncMock(return_value=None)
+    svc = PipelineService(pipeline_repo=repo)
+    job = _job()
+
+    await svc._update_step_progress(
+        MagicMock(), job, "crawling", current=10, total=100, message="Crawling..."
+    )
+
+    assert repo.update_fields.await_count == 1
+    _db, job_id, fields = repo.update_fields.await_args.args
+    assert job_id == job.id
+    assert "last_heartbeat" in fields
+    assert job.last_heartbeat is not None
+    # update_fields itself also bumps updated_at, the field the in-process stall guard reads.
+
+
+@pytest.mark.asyncio
+async def test_repeat_progress_at_clamped_percent_still_heartbeats():
+    """Even when the monotonic clamp blocks a percent change, the heartbeat still fires."""
+    repo = MagicMock(spec=PipelineRepository)
+    repo.update_fields = AsyncMock(return_value=None)
+    svc = PipelineService(pipeline_repo=repo)
+    job = _job()
+
+    # First update advances the high-water mark.
+    await svc._update_step_progress(MagicMock(), job, "crawling", current=80, total=100)
+    # Second update would move the bar backwards (frontier grew); percent is clamped, but the
+    # crawl is still making progress and must keep the job alive.
+    await svc._update_step_progress(MagicMock(), job, "crawling", current=80, total=200)
+
+    assert repo.update_fields.await_count == 2
+    _db, _job_id, fields = repo.update_fields.await_args.args
+    assert "last_heartbeat" in fields
+
+
+@pytest.mark.asyncio
+async def test_terminal_step_progress_does_not_heartbeat():
+    """A late progress update for a finished step is dropped — no heartbeat, no overwrite."""
+    repo = MagicMock(spec=PipelineRepository)
+    repo.update_fields = AsyncMock(return_value=None)
+    svc = PipelineService(pipeline_repo=repo)
+    job = _job()
+    job.steps[0].status = "completed"
+
+    await svc._update_step_progress(MagicMock(), job, "crawling", current=10, total=100)
+
+    repo.update_fields.assert_not_awaited()

--- a/packages/backend/tests/unit/pipeline_incremental_store_test.py
+++ b/packages/backend/tests/unit/pipeline_incremental_store_test.py
@@ -1,0 +1,171 @@
+"""_process_product stores documents incrementally as the crawl produces them.
+
+A multi-hour crawl killed at the time ceiling must keep the work already done, so each
+crawled result is classified and stored inside the crawler's per-result callback rather
+than in one end-of-crawl batch. This test drives _process_product with a fake crawler that
+fires the registered callback per result, and asserts:
+  - _store_documents is invoked as results arrive (interleaved with the crawl), not once;
+  - the streamed documents drive the _should_fallback_crawl decision;
+  - policy_documents_stored is counted once (no redundant final batch store).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.crawler import CrawlResult
+from src.models.document import DocType, Document
+from src.models.product import Product
+from src.pipeline import PolicyDocumentPipeline
+
+
+def _result(url: str) -> CrawlResult:
+    # Distinct content per URL so the near-duplicate fingerprint filter in
+    # _classify_results keeps each page (real policy pages have different text).
+    return CrawlResult(
+        url=url,
+        title="",
+        content=f"unique content for {url} " * 30,
+        markdown="x",
+        metadata={},
+        status_code=200,
+        success=True,
+    )
+
+
+def _doc(url: str, doc_type: DocType) -> Document:
+    return Document(
+        id=url,
+        url=url,
+        product_id="prod-1",
+        doc_type=doc_type,
+        title="T",
+        text="t" * 400,
+        markdown="t",
+    )
+
+
+class _FakeCrawler:
+    """Stands in for ClauseaCrawler: replays canned results through the result_callback."""
+
+    def __init__(self, results: list[CrawlResult], result_callback) -> None:
+        self._results = results
+        self._result_callback = result_callback
+
+    async def crawl_multiple(self, _urls: list[str]) -> list[CrawlResult]:
+        for result in self._results:
+            if self._result_callback is not None:
+                await self._result_callback(result)
+        return list(self._results)
+
+
+@pytest.mark.asyncio
+async def test_streams_store_per_result_and_counts_once(monkeypatch):
+    product = Product(
+        id="prod-1",
+        name="Acme",
+        slug="acme",
+        domains=["acme.com"],
+        crawl_base_urls=["https://acme.com/"],
+    )
+
+    discovery = [_result("https://acme.com/privacy"), _result("https://acme.com/terms")]
+
+    # Record the order of classify vs store calls to prove interleaving (not one batch).
+    call_log: list[str] = []
+
+    async def fake_process_crawl_result(result: CrawlResult, _product):
+        call_log.append(f"classify:{result.url}")
+        doc_type = "privacy_policy" if "privacy" in result.url else "terms_of_service"
+        return _doc(result.url, doc_type)
+
+    stored: list[str] = []
+
+    async def fake_store_documents(documents):
+        for document in documents:
+            call_log.append(f"store:{document.url}")
+            stored.append(document.url)
+        return len(documents)
+
+    pipeline = PolicyDocumentPipeline(
+        min_docs_before_fallback=1,
+        required_doc_types=["privacy_policy", "terms_of_service"],
+    )
+
+    monkeypatch.setattr(pipeline, "_process_crawl_result", fake_process_crawl_result)
+    monkeypatch.setattr(pipeline, "_store_documents", AsyncMock(side_effect=fake_store_documents))
+    monkeypatch.setattr(pipeline, "_start_crawl_session", AsyncMock(return_value=None))
+    monkeypatch.setattr(pipeline, "_finish_crawl_session", AsyncMock(return_value=None))
+
+    def fake_create_crawler(_product, **kwargs):
+        return _FakeCrawler(discovery, kwargs.get("result_callback"))
+
+    monkeypatch.setattr(pipeline, "_create_crawler_for_product", fake_create_crawler)
+
+    documents = await pipeline._process_product(product)
+
+    # Storage interleaved with classification, one store per result as it arrived.
+    assert call_log == [
+        "classify:https://acme.com/privacy",
+        "store:https://acme.com/privacy",
+        "classify:https://acme.com/terms",
+        "store:https://acme.com/terms",
+    ]
+    # Both doc types present -> coverage satisfied -> no fallback crawl ran.
+    assert {document.url for document in documents} == {
+        "https://acme.com/privacy",
+        "https://acme.com/terms",
+    }
+    # Counted once: two stored, no redundant end-of-crawl batch store.
+    assert pipeline.stats.policy_documents_stored == 2
+    assert stored == ["https://acme.com/privacy", "https://acme.com/terms"]
+
+
+@pytest.mark.asyncio
+async def test_streamed_docs_drive_fallback_decision(monkeypatch):
+    product = Product(
+        id="prod-1",
+        name="Acme",
+        slug="acme",
+        domains=["acme.com"],
+        crawl_base_urls=["https://acme.com/"],
+    )
+
+    # Discovery yields only a privacy policy; required types include terms -> fallback fires.
+    discovery = [_result("https://acme.com/privacy")]
+    fallback = [_result("https://acme.com/terms")]
+    passes = iter([discovery, fallback])
+
+    async def fake_process_crawl_result(result: CrawlResult, _product):
+        doc_type = "privacy_policy" if "privacy" in result.url else "terms_of_service"
+        return _doc(result.url, doc_type)
+
+    pipeline = PolicyDocumentPipeline(
+        min_docs_before_fallback=1,
+        required_doc_types=["privacy_policy", "terms_of_service"],
+    )
+
+    store_mock = AsyncMock(side_effect=lambda documents: len(documents))
+    monkeypatch.setattr(pipeline, "_process_crawl_result", fake_process_crawl_result)
+    monkeypatch.setattr(pipeline, "_store_documents", store_mock)
+    monkeypatch.setattr(pipeline, "_start_crawl_session", AsyncMock(return_value=None))
+    monkeypatch.setattr(pipeline, "_finish_crawl_session", AsyncMock(return_value=None))
+
+    crawlers_created: list[_FakeCrawler] = []
+
+    def fake_create_crawler(_product, **kwargs):
+        crawler = _FakeCrawler(next(passes), kwargs.get("result_callback"))
+        crawlers_created.append(crawler)
+        return crawler
+
+    monkeypatch.setattr(pipeline, "_create_crawler_for_product", fake_create_crawler)
+
+    documents = await pipeline._process_product(product)
+
+    # The fallback pass ran because the discovery-streamed docs lacked terms_of_service.
+    assert len(crawlers_created) == 2
+    assert {document.doc_type for document in documents} == {
+        "privacy_policy",
+        "terms_of_service",
+    }
+    assert pipeline.stats.policy_documents_stored == 2


### PR DESCRIPTION
## What changes for users / the running system

Long (multi-hour) crawls now persist progress **incrementally** instead of storing every document in a single batch at the very end. Today `PolicyDocumentPipeline._process_product` stores documents only after the entire multi-seed crawl + classification finishes, so a crawl killed at the 2h ceiling or cancelled by the stall guard loses **all** work. After this change, each crawled page is classified and stored as soon as it is produced, and the job heartbeat advances per progress report — so partial crawls keep their results and steady-but-slow crawls are no longer killed for "stalling".

No behavioural change to crawl coverage, dedup, or the fallback decision: the same shared dedup state and the same `_should_fallback_crawl` decision drive both passes; only *when* storage happens moved (per-page instead of end-of-crawl).

## Behavioural changes

- **Crawler (`crawler.py`)**: new optional `result_callback: Callable[[CrawlResult], Awaitable[None]]` on `ClauseaCrawler`. It fires once for **every** processed result — success *and* failure — in the main batch loop, plus for pages recovered on the serial render-retry pass. A `None` callback is a zero-behaviour-change no-op. The callback is an instance attribute and is *not* cleared by the per-seed state reset in `crawl_multiple`, so it fires across all seeds.
- **Pipeline (`pipeline.py`)**: `_process_product` registers a streaming `result_callback` that classifies the single result (reusing `_classify_results([result], ...)` with the shared `processed_urls` / `seen_fingerprints` dedup sets) and, if it yields a document, stores it immediately and bumps `policy_documents_stored`. The redundant end-of-crawl batch `_classify_results` + `_store_documents` calls are removed so work isn't done twice and the stored count isn't double-counted. `processed_documents` is still accumulated, so `_should_fallback_crawl` works after the discovery pass and the final return is unchanged. `_create_crawler_for_product` gained a `result_callback` param, threaded to both the discovery and fallback crawlers.
- **Heartbeat (`pipeline_service.py`)**: `_update_step_progress` now sets `last_heartbeat` (and `updated_at`, already bumped by `update_fields`) on every crawl-progress update, even when the monotonic percent clamp leaves no other field changed. This keeps both the in-process stall guard (reads `updated_at`) and the cross-process stale-job sweeper (prefers `last_heartbeat`) seeing forward progress. The stall timeout and 2h ceiling are unchanged (left for a separate PR).

## Reviewer note — semantics of per-single-result classification

`_classify_results` already operates result-by-result with caller-provided dedup sets, so calling it with `[result]` repeatedly is equivalent to the old batch call for URL/fingerprint dedup. The only cross-document decision is `_should_fallback_crawl`, which runs on the accumulated `processed_documents` *after* the discovery crawl returns — that is preserved. No other cross-doc coverage decision exists in this path. Please confirm you're comfortable that incremental `_store_documents` calls (each opens its own `db_session` and dedups by URL/fingerprint) are acceptable vs. one batched session per product.

## Verification

From `packages/backend`:

- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean (169 files)
- `uv run ty check .` — clean
- `uv run pytest tests/unit -q` — **588 passed**

New tests:
- `tests/unit/crawler/result_callback_test.py` — callback fires once per processed result (success + failure), across multiple seeds, recovered render-retries reach it, None is a no-op.
- `tests/unit/pipeline_incremental_store_test.py` — storage interleaves per result (not one batch), streamed docs drive `_should_fallback_crawl`, `policy_documents_stored` counted once.
- `tests/unit/pipeline_heartbeat_test.py` — a progress update bumps `last_heartbeat`; a clamped repeat still heartbeats; a terminal step is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)