### PR TITLE
feat(pipeline): drop arbitrary 2h wall-clock ceiling; stall guard is liveness

### DIFF
--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -38,10 +38,14 @@ from src.utils.domain import extract_domain as _extract_domain
 
 logger = get_logger(__name__)
 
-MAX_PIPELINE_DURATION_SECONDS = 7200  # 2 hours — hard ceiling backstop
+# Optional absolute wall-clock backstop, OFF by default (0 / unset → no cap). Liveness comes from
+# the stall guard (below) plus the crawler's max_pages work bound, so a legitimately long crawl of
+# a large/multi-jurisdiction site runs to completion. Set PIPELINE_MAX_DURATION_SECONDS > 0 only if
+# you want a hard ceiling regardless of forward progress.
+MAX_PIPELINE_DURATION_SECONDS = float(os.getenv("PIPELINE_MAX_DURATION_SECONDS", "0"))
 # Abort a job that makes no forward progress (no page/document/step update bumps updated_at)
-# for this long. Bounds *inactivity*, not total runtime: a slow-but-advancing pipeline runs to
-# the hard ceiling, while a wedged one frees its worker slot fast instead of clogging it.
+# for this long. Bounds *inactivity*, not total runtime: a slow-but-advancing pipeline runs
+# indefinitely, while a wedged one frees its worker slot fast instead of clogging it.
 STALL_TIMEOUT_SECONDS = float(os.getenv("PIPELINE_STALL_TIMEOUT_SECONDS", "900"))  # 15 min
 
 
@@ -165,7 +169,8 @@ class PipelineService:
         Progress is any step/page/document update, each of which bumps the job's updated_at. A
         pipeline that is still advancing — even slowly through the model cascade — is never
         cancelled; only one wedged with zero forward progress is, freeing the worker slot rather
-        than holding it to the 2h ceiling.
+        than holding it indefinitely. This is the primary liveness bound now that the absolute
+        wall-clock cap is off by default.
         """
         poll = min(60.0, STALL_TIMEOUT_SECONDS)
         while True:
@@ -781,10 +786,16 @@ class PipelineService:
             core_task = asyncio.create_task(_run_pipeline_core())
             started_at = job.started_at or datetime.now()
             try:
-                await asyncio.wait_for(
-                    self._await_with_stall_guard(core_task, job_id, started_at),
-                    timeout=MAX_PIPELINE_DURATION_SECONDS,
-                )
+                # Liveness is the stall guard (no-progress) + the crawler's max_pages bound. The
+                # absolute wall-clock cap is an opt-in backstop: only wrap when explicitly enabled
+                # (PIPELINE_MAX_DURATION_SECONDS > 0), so long legitimate crawls run to completion.
+                if MAX_PIPELINE_DURATION_SECONDS > 0:
+                    await asyncio.wait_for(
+                        self._await_with_stall_guard(core_task, job_id, started_at),
+                        timeout=MAX_PIPELINE_DURATION_SECONDS,
+                    )
+                else:
+                    await self._await_with_stall_guard(core_task, job_id, started_at)
             except _PipelineStalled:
                 stall_minutes = int(STALL_TIMEOUT_SECONDS // 60)
                 logger.error("Pipeline job %s stalled (no progress for %dm)", job_id, stall_minutes)
@@ -796,15 +807,20 @@ class PipelineService:
                     "hard to crawl/render or a temporary model issue; try again.",
                 )
             except TimeoutError:
-                # Hard ceiling: the guard's wait_for fired but core_task is a separate task.
+                # Opt-in hard ceiling fired (PIPELINE_MAX_DURATION_SECONDS > 0). The guard's
+                # wait_for timed out but core_task is a separate task, so cancel it explicitly.
                 core_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await core_task
+                cap_seconds = int(MAX_PIPELINE_DURATION_SECONDS)
                 logger.error(
                     "Pipeline job %s timed out after %s seconds",
                     job_id,
-                    MAX_PIPELINE_DURATION_SECONDS,
+                    cap_seconds,
                 )
                 await self._mark_aborted(
-                    db, job, PipelineErrorCode.timed_out, "Pipeline timed out after 2 hours"
+                    db,
+                    job,
+                    PipelineErrorCode.timed_out,
+                    f"Pipeline timed out after {cap_seconds} seconds",
                 )

--- a/packages/backend/tests/unit/pipeline_service_test.py
+++ b/packages/backend/tests/unit/pipeline_service_test.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -6,6 +7,7 @@ import pytest
 
 from src.models.pipeline_job import PipelineErrorCode, PipelineJob, PipelineStep
 from src.repositories.pipeline_repository import PipelineRepository
+from src.services import pipeline_service as ps
 from src.services.pipeline_service import PipelineService
 
 
@@ -280,3 +282,113 @@ async def test_update_step_progress_is_monotonic(pipeline_service, mock_repo, mo
     # Genuine forward progress advances the bar.
     await pipeline_service._update_step_progress(mock_db, job, "crawling", current=30, total=40)
     assert job.steps[0].progress_percent == 75.0
+
+
+def _pipeline_run_patches(mock_db, fake_pipeline, product_svc):
+    """The patch set that lets run_pipeline reach the stall-guard wiring deterministically."""
+
+    @asynccontextmanager
+    async def fake_db_session():
+        yield mock_db
+
+    return (
+        patch("src.services.pipeline_service.db_session", fake_db_session),
+        patch("src.services.pipeline_service.create_product_service", return_value=product_svc),
+        patch("src.services.pipeline_service.PolicyDocumentPipeline", return_value=fake_pipeline),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_no_wall_clock_cap_by_default(mock_db, monkeypatch):
+    """With the cap disabled (default), the core is never wrapped in a wall-clock wait_for.
+
+    A legitimately long crawl (e.g. a multi-jurisdiction site running for hours) must not be
+    guillotined; liveness is the stall guard + max_pages, not total runtime.
+    """
+    monkeypatch.setattr(ps, "MAX_PIPELINE_DURATION_SECONDS", 0.0)
+
+    job = PipelineJob(
+        id="job-long",
+        product_slug="test-product",
+        product_name="Test Product",
+        url="https://test.com",
+        status="pending",
+    )
+    repo = MagicMock(spec=PipelineRepository)
+    repo.find_by_id = AsyncMock(return_value=job)
+    repo.update = AsyncMock()
+    repo.update_fields = AsyncMock()
+    service = PipelineService(pipeline_repo=repo)
+
+    product = SimpleNamespace(slug="test-product", name="Test Product")
+    product_svc = MagicMock()
+    product_svc.get_product_by_slug = AsyncMock(return_value=product)
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=0,
+        policy_documents_stored=0,
+        crawl_errors=[],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    wait_for_calls: list[float | None] = []
+    real_wait_for = asyncio.wait_for
+
+    async def recording_wait_for(awaitable, timeout):
+        wait_for_calls.append(timeout)
+        return await real_wait_for(awaitable, timeout)
+
+    patches = _pipeline_run_patches(mock_db, fake_pipeline, product_svc)
+    with patches[0], patches[1], patches[2]:
+        monkeypatch.setattr(ps.asyncio, "wait_for", recording_wait_for)
+        await service.run_pipeline("job-long")
+
+    # The stall guard was awaited directly — no finite wall-clock timeout wrapped the core.
+    assert not wait_for_calls
+    assert job.error != PipelineErrorCode.timed_out
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_opt_in_cap_marks_timed_out(mock_db, monkeypatch):
+    """When PIPELINE_MAX_DURATION_SECONDS is set > 0, the wall-clock backstop still fires."""
+    monkeypatch.setattr(ps, "MAX_PIPELINE_DURATION_SECONDS", 0.05)
+
+    job = PipelineJob(
+        id="job-capped",
+        product_slug="test-product",
+        product_name="Test Product",
+        url="https://test.com",
+        status="pending",
+    )
+    repo = MagicMock(spec=PipelineRepository)
+    repo.find_by_id = AsyncMock(return_value=job)
+    repo.update = AsyncMock()
+    repo.update_fields = AsyncMock()
+    service = PipelineService(pipeline_repo=repo)
+
+    product = SimpleNamespace(slug="test-product", name="Test Product")
+    product_svc = MagicMock()
+    product_svc.get_product_by_slug = AsyncMock(return_value=product)
+
+    # A crawl that outlives the opt-in cap (but is making progress, so the stall guard wouldn't
+    # touch it) must still be aborted by the wall-clock backstop.
+    async def slow_run(*args, **kwargs):
+        await asyncio.sleep(5)
+        return SimpleNamespace(
+            total_documents_found=0,
+            policy_documents_stored=0,
+            crawl_errors=[],
+            crawl_skip_reasons=[],
+        )
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(side_effect=slow_run)
+
+    patches = _pipeline_run_patches(mock_db, fake_pipeline, product_svc)
+    with patches[0], patches[1], patches[2]:
+        await service.run_pipeline("job-capped")
+
+    assert job.error == PipelineErrorCode.timed_out
+    assert job.status == "failed"


### PR DESCRIPTION
## What changes for the operator

The pipeline no longer aborts at a fixed 2-hour wall-clock ceiling. Legitimately long crawls — e.g. a multi-jurisdiction site like shein that takes ~4h across many country policy pages — now run to completion instead of being killed with a `timed_out` error mid-crawl.

Liveness is now provided by two mechanisms that are already reliable:
- **Stall guard** (`STALL_TIMEOUT_SECONDS`, default 15min): aborts a job that makes *no forward progress*. Since the per-page heartbeat work merged (#80), the job's `updated_at`/`last_heartbeat` is bumped every ~10 pages, so a wedged job still frees its worker slot fast.
- **`max_pages`**: the crawler bounds total work independently.

The absolute wall-clock cap is now an **opt-in backstop**, off by default.

## Before / after

| | Before | After |
|---|---|---|
| Total-runtime cap | Hard 7200s (2h), always on | Off by default; opt-in via `PIPELINE_MAX_DURATION_SECONDS` |
| Long healthy crawl | Killed at 2h (`timed_out`) | Runs to completion |
| Wedged job | Killed by stall guard OR 2h cap | Killed by stall guard (unchanged) |

## How the opt-in cap is wired

`MAX_PIPELINE_DURATION_SECONDS` is now read from `PIPELINE_MAX_DURATION_SECONDS` and defaults to `0` (disabled). In `run_pipeline`, the core is wrapped in `asyncio.wait_for(..., timeout=cap)` **only when the cap is > 0**; otherwise `_await_with_stall_guard` is awaited directly. The existing `TimeoutError` -> `_mark_aborted(..., timed_out, ...)` path is preserved and reachable only when the opt-in cap is set. `_PipelineStalled` handling is unchanged. No change to `STALL_TIMEOUT_SECONDS`, the stall-guard logic, the crawler, or `max_pages`.

## Tests

Added to `tests/unit/pipeline_service_test.py` (driving the real `run_pipeline` harness):
- `test_run_pipeline_no_wall_clock_cap_by_default` — with the cap disabled (default), the core is never wrapped in a finite `asyncio.wait_for`, so a long crawl is not guillotined.
- `test_run_pipeline_opt_in_cap_marks_timed_out` — with `PIPELINE_MAX_DURATION_SECONDS` > 0, a crawl that outlives the cap is aborted and marked `timed_out`.

The existing `pipeline_stall_watchdog_test.py` already asserts the stall guard cancels a no-progress job past `STALL_TIMEOUT_SECONDS` and lets a progressing one finish — both still pass.

Verification (from `packages/backend`):
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean
- `uv run ty check .` — clean
- `uv run pytest tests/unit -q` — 590 passed

## Follow-up: stall-guard coverage during overview synthesis (not fixed here, by design)

With the 2h cap gone, the stall guard (900s no-progress) is the sole liveness bound. The crawl and summarize stages bump `updated_at` continuously (per-page heartbeat; per-document `_on_summarize_progress` callback), so they are well covered.

**Step 3 (generating_overview) is a potential false-kill risk.** It marks the step `running` once, then makes sequential LLM-bound calls — `generate_product_overview`, then best-effort `generate_product_consumer_explainer` and `generate_product_compliance` — with **no intermediate `updated_at` bump**. `generate_product_overview` takes no `progress_callback`. If that single synthesis call (multi-doc, through the model cascade with retries/backoff) exceeds 900s with no write, the stall guard would now cancel a healthy job. Per-call LLM timeouts bound each model invocation, so this is unlikely but not impossible on a large core-doc set. Suggested follow-up: thread a progress/heartbeat callback through `generate_product_overview` (and bump `updated_at` between the three Step-3 calls), or use a longer stall window for the overview stage. Deliberately out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)