### PR TITLE
feat(pipeline): heartbeat during overview synthesis to close stall-guard false-kill

### DIFF
--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -104,6 +104,10 @@ def _analysis_validator(content: str) -> bool:
 
 ProgressCallback = Callable[[int, int, Document], Awaitable[None] | None]
 
+# A no-argument liveness ping fired at sub-step boundaries during long synthesis so the
+# pipeline can bump the job heartbeat. Carries no payload — its only job is "still alive".
+HeartbeatCallback = Callable[[], Awaitable[None] | None]
+
 
 async def _maybe_await(result: Awaitable[None] | None) -> None:
     if asyncio.iscoroutine(result):
@@ -1311,6 +1315,7 @@ async def generate_product_overview(
     product_svc: ProductService | None = None,
     document_svc: DocumentService | None = None,
     cancellation_token: CancellationToken | None = None,
+    on_progress: HeartbeatCallback | None = None,
 ) -> MetaSummary:
     """
     Generate a cached product overview from analyzed core policy documents.
@@ -1330,6 +1335,9 @@ async def generate_product_overview(
         product_svc: Optional ProductService instance (for dependency injection)
         document_svc: Optional DocumentService instance (for dependency injection)
         cancellation_token: Optional cancellation token for interrupting the operation
+        on_progress: Optional liveness ping fired before each long sub-step (aggregation
+            rebuild, LLM synthesis) so a caller can keep the job heartbeat fresh. A None
+            callback is a no-op, leaving behaviour outside the pipeline unchanged.
 
     Returns:
         MetaSummary: The generated overview payload
@@ -1370,6 +1378,8 @@ async def generate_product_overview(
     logger.info(f"Generating new product overview for {product_slug}")
 
     await token.check_cancellation()
+    if on_progress is not None:
+        await _maybe_await(on_progress())
     aggregation_service = AggregationService(
         DocumentRepository(), FindingRepository(), AggregationRepository()
     )
@@ -1509,6 +1519,8 @@ Per-document analyses and extractions:
 
     # Check for cancellation before making LLM call
     await token.check_cancellation()
+    if on_progress is not None:
+        await _maybe_await(on_progress())
 
     try:
         async with usage_tracking(tracker_callback):

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -628,12 +628,27 @@ class PipelineService:
 
                     product_svc_for_overview = create_product_service()
                     doc_svc_for_overview = create_document_service()
+
+                    # Overview synthesis runs several long LLM/aggregation sub-steps with no
+                    # DB write of its own. On a large core-doc set it can outlast the stall
+                    # window, so bump the job heartbeat at each sub-step boundary the same way
+                    # the summarize stage does — keeping a healthy synthesis from being killed
+                    # at the finish line while a truly wedged one still trips the guard.
+                    async def _on_overview_progress() -> None:
+                        await self._update_step_progress(
+                            db,
+                            job,
+                            "generating_overview",
+                            message="Generating privacy overview...",
+                        )
+
                     await generate_product_overview(
                         db,
                         job.product_slug,
                         force_regenerate=True,
                         product_svc=product_svc_for_overview,
                         document_svc=doc_svc_for_overview,
+                        on_progress=_on_overview_progress,
                     )
 
                     # Verify the overview actually persisted — same truthfulness lesson as
@@ -664,6 +679,7 @@ class PipelineService:
                     # Best-effort: a failure here must NOT fail a job whose overview already
                     # succeeded — the product page degrades gracefully when it is absent.
                     try:
+                        await _on_overview_progress()
                         explainer = await generate_product_consumer_explainer(
                             db,
                             job.product_slug,
@@ -697,6 +713,7 @@ class PipelineService:
                     # Justified compliance assessment (per-regime score + strengths/gaps).
                     # Also best-effort — secondary to the consumer-facing outputs above.
                     try:
+                        await _on_overview_progress()
                         compliance = await generate_product_compliance(
                             db,
                             job.product_slug,

--- a/packages/backend/tests/unit/overview_heartbeat_test.py
+++ b/packages/backend/tests/unit/overview_heartbeat_test.py
@@ -1,0 +1,141 @@
+"""The overview synthesis fires its liveness ping at each long sub-step boundary.
+
+`generate_product_overview` runs a findings rebuild + aggregation and an LLM synthesis with
+no DB write of its own. On a large core-doc set that span can outlast the pipeline stall
+window, so it accepts an `on_progress` callback fired before each long sub-step. The pipeline
+wires that to its job-heartbeat write; outside the pipeline a None callback must be a no-op.
+
+The LLM, aggregation engine, and services are all mocked — no real network or DB calls.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from litellm import ModelResponse
+
+from src.analyser import generate_product_overview
+from src.models.document import Document, DocumentAnalysis, DocumentAnalysisScores
+
+
+def _core_doc() -> Document:
+    analysis = DocumentAnalysis(
+        summary="x",
+        scores={
+            "transparency": DocumentAnalysisScores(score=5, justification=""),
+            "data_collection_scope": DocumentAnalysisScores(score=5, justification=""),
+            "user_control": DocumentAnalysisScores(score=5, justification=""),
+            "third_party_sharing": DocumentAnalysisScores(score=5, justification=""),
+            "data_retention_score": DocumentAnalysisScores(score=5, justification=""),
+            "security_score": DocumentAnalysisScores(score=5, justification=""),
+        },
+        risk_score=5,
+        verdict="moderate",
+        keypoints=[],
+        critical_clauses=[],
+    )
+    return Document(
+        url="https://example.com/privacy",
+        product_id="p1",
+        doc_type="privacy_policy",  # type: ignore[arg-type]
+        markdown="",
+        text="",
+        analysis=analysis,
+    )
+
+
+def _overview_response() -> ModelResponse:
+    payload = {
+        "summary": "ok",
+        "scores": {
+            "transparency": {"score": 5, "justification": ""},
+            "data_collection_scope": {"score": 5, "justification": ""},
+            "user_control": {"score": 5, "justification": ""},
+            "third_party_sharing": {"score": 5, "justification": ""},
+        },
+        "risk_score": 5,
+        "verdict": "moderate",
+    }
+    response = MagicMock(spec=ModelResponse)
+    response.model = "test-model"
+    message = MagicMock()
+    message.content = json.dumps(payload)
+    choice = MagicMock()
+    choice.message = message
+    response.choices = [choice]
+    return response
+
+
+def _services() -> tuple[MagicMock, MagicMock]:
+    product = MagicMock()
+    product.id = "p1"
+    product.name = "Example"
+    product_svc = MagicMock()
+    product_svc.get_product_by_slug = AsyncMock(return_value=product)
+    product_svc.save_product_overview = AsyncMock(return_value=True)
+    document_svc = MagicMock()
+    document_svc.get_product_documents_by_slug = AsyncMock(return_value=[_core_doc()])
+    return product_svc, document_svc
+
+
+def _patch_aggregation_and_llm():
+    aggregation = MagicMock()
+    aggregation.conflicts = []
+    aggregation.coverage = []
+    aggregation_service = MagicMock()
+    aggregation_service.rebuild_findings_for_product = AsyncMock(return_value=None)
+    aggregation_service.build_product_aggregation = AsyncMock(return_value=aggregation)
+    return (
+        patch("src.analyser.AggregationService", return_value=aggregation_service),
+        patch(
+            "src.analyser.acompletion_with_fallback",
+            AsyncMock(return_value=_overview_response()),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_overview_fires_heartbeat_at_each_sub_step():
+    product_svc, document_svc = _services()
+    pings = 0
+
+    async def on_progress() -> None:
+        nonlocal pings
+        pings += 1
+
+    agg_patch, llm_patch = _patch_aggregation_and_llm()
+    with agg_patch, llm_patch:
+        await generate_product_overview(
+            MagicMock(),
+            "example",
+            force_regenerate=True,
+            product_svc=product_svc,
+            document_svc=document_svc,
+            on_progress=on_progress,
+        )
+
+    # One ping before the aggregation rebuild and one before the LLM synthesis — the two
+    # spans that can each run long enough to stall an otherwise-healthy job.
+    assert pings == 2
+
+
+@pytest.mark.asyncio
+async def test_overview_none_callback_is_noop():
+    """A None callback leaves generate_product_overview behaving exactly as before."""
+    product_svc, document_svc = _services()
+
+    agg_patch, llm_patch = _patch_aggregation_and_llm()
+    with agg_patch, llm_patch:
+        result = await generate_product_overview(
+            MagicMock(),
+            "example",
+            force_regenerate=True,
+            product_svc=product_svc,
+            document_svc=document_svc,
+            on_progress=None,
+        )
+
+    assert result.verdict == "moderate"
+    product_svc.save_product_overview.assert_awaited_once()

--- a/packages/backend/tests/unit/pipeline_service_test.py
+++ b/packages/backend/tests/unit/pipeline_service_test.py
@@ -392,3 +392,91 @@ async def test_run_pipeline_opt_in_cap_marks_timed_out(mock_db, monkeypatch):
 
     assert job.error == PipelineErrorCode.timed_out
     assert job.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_overview_stage_heartbeats_during_synthesis(mock_db):
+    """The overview stage bumps the job heartbeat at each synthesis sub-step.
+
+    Overview synthesis (aggregation rebuild + LLM calls + explainer + compliance) does no DB
+    write of its own and can outlast the stall window on a large core-doc set. The stage must
+    thread a heartbeat callback into generate_product_overview so updated_at/last_heartbeat are
+    refreshed before a healthy-but-slow synthesis trips the no-progress stall guard.
+    """
+    job = PipelineJob(
+        id="job-overview",
+        product_slug="test-product",
+        product_name="Test Product",
+        url="https://test.com",
+        status="pending",
+    )
+
+    repo = MagicMock(spec=PipelineRepository)
+    repo.find_by_id = AsyncMock(return_value=job)
+    repo.update = AsyncMock()
+    repo.update_fields = AsyncMock()
+    service = PipelineService(pipeline_repo=repo)
+
+    product = SimpleNamespace(slug="test-product", name="Test Product")
+    product_svc = MagicMock()
+    product_svc.get_product_by_slug = AsyncMock(return_value=product)
+    product_svc.get_product_overview_data = AsyncMock(return_value={"overview": {"summary": "ok"}})
+    product_svc.save_product_explainer = AsyncMock(return_value=True)
+    product_svc.save_product_compliance = AsyncMock(return_value=True)
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=1,
+        policy_documents_stored=1,
+        crawl_errors=[],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    analysed_docs = [SimpleNamespace(analysis=object(), doc_type="privacy_policy")]
+    analyse_mock = AsyncMock(return_value=analysed_docs)
+
+    # Stand in for the real generator: fire the threaded heartbeat callback the same number of
+    # times the real one does (once per long sub-step) so the assertion exercises the wiring.
+    async def fake_generate_overview(*_args, on_progress=None, **_kwargs):
+        assert on_progress is not None, "overview stage must thread a heartbeat callback"
+        await on_progress()
+        await on_progress()
+
+    overview_mock = AsyncMock(side_effect=fake_generate_overview)
+
+    @asynccontextmanager
+    async def fake_db_session():
+        yield mock_db
+
+    with (
+        patch("src.services.pipeline_service.db_session", fake_db_session),
+        patch("src.services.pipeline_service.create_product_service", return_value=product_svc),
+        patch("src.services.pipeline_service.create_document_service", return_value=MagicMock()),
+        patch("src.services.pipeline_service.PolicyDocumentPipeline", return_value=fake_pipeline),
+        patch("src.services.pipeline_service.analyse_product_documents", analyse_mock),
+        patch("src.services.pipeline_service.generate_product_overview", overview_mock),
+        patch(
+            "src.services.pipeline_service.generate_product_consumer_explainer",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "src.services.pipeline_service.generate_product_compliance",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await service.run_pipeline("job-overview")
+
+    assert job.status == "completed"
+
+    # The generating_overview step is index 2 in the default step list. Find every progress
+    # write the stage emitted for it and confirm each carried the liveness heartbeat — both the
+    # in-synthesis pings and the pre-explainer / pre-compliance pings.
+    overview_heartbeats = [
+        call.args[2]
+        for call in repo.update_fields.await_args_list
+        if "steps.2.message" in call.args[2] and "last_heartbeat" in call.args[2]
+    ]
+    # 2 in-synthesis pings + 1 before explainer + 1 before compliance.
+    assert len(overview_heartbeats) >= 4
+    assert all(fields["last_heartbeat"] is not None for fields in overview_heartbeats)


### PR DESCRIPTION
## What changes for the running system

The pipeline's liveness bound is now a **no-progress stall guard** (`_await_with_stall_guard`): it cancels a job whose `updated_at` isn't bumped for `STALL_TIMEOUT_SECONDS` (900s). The crawl stage heartbeats per ~10 pages and the summarize stage heartbeats per document, so both stay fresh. But the **`generating_overview`** stage marked its step `running` once and then ran `generate_product_overview` (findings rebuild + aggregation + LLM synthesis) plus best-effort explainer/compliance LLM calls with **no intermediate write**.

On a large core-document set that synthesis can plausibly exceed 900s with zero forward write, so the stall guard would cancel a **healthy** job at the finish line. Now that the 2h wall-clock cap is gone (#81) and long high-recall crawls produce bigger doc sets → longer synthesis, this gap needed sealing.

After this change a legitimately long synthesis keeps the job alive; a genuinely wedged one still trips the guard.

## How

- `generate_product_overview` gains an optional `on_progress: HeartbeatCallback | None` (a no-arg `Awaitable`-or-`None` liveness ping). It is fired at the two long sub-step boundaries inside synthesis: **before the aggregation rebuild** and **before the LLM call**. A `None` callback is a no-op — the generator behaves exactly as before outside the pipeline.
- `pipeline_service` defines `_on_overview_progress`, which routes through the **existing** `_update_step_progress` (the same write the crawl/summarize stages use — it bumps both `updated_at` via `update_fields` and `last_heartbeat`). No parallel heartbeat path. It is threaded into `generate_product_overview` and also fired **before the explainer** and **before the compliance** calls (the other two long LLM sub-steps).

`STALL_TIMEOUT_SECONDS` is untouched and no stage-specific window was added — this matches the crawl/summarize heartbeat approach.

## Where the heartbeat now fires within overview generation

1. Before `AggregationService.rebuild_findings_for_product` / `build_product_aggregation` (inside `generate_product_overview`)
2. Before the overview LLM call (inside `generate_product_overview`)
3. Before `generate_product_consumer_explainer` (in `pipeline_service`)
4. Before `generate_product_compliance` (in `pipeline_service`)

## Tests

- `tests/unit/overview_heartbeat_test.py`: `generate_product_overview` fires `on_progress` once per long sub-step (2 pings) with the LLM/aggregation/services mocked; a `None` callback is a no-op and the function returns identically.
- `tests/unit/pipeline_service_test.py::test_overview_stage_heartbeats_during_synthesis`: drives `run_pipeline` through the overview stage and asserts every progress write for the `generating_overview` step carried `last_heartbeat` (≥4: 2 in-synthesis + pre-explainer + pre-compliance).

## Verify (from `packages/backend`)

`uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run pytest tests/unit -q` — all clean; 593 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)