### PR TITLE
feat(crawler): resume retried crawls — skip re-fetching recently stored docs

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -1427,6 +1427,10 @@ class ClauseaCrawler:
         # failure). Lets callers stream each page to classification/storage as it is
         # produced instead of batching at the end of a multi-hour crawl.
         result_callback: Callable[[CrawlResult], Awaitable[None]] | None = None,
+        # URLs of docs stored within the resume freshness window. Skipped during
+        # should_crawl_url so a retried long crawl resumes (keeps already-stored
+        # pages) instead of re-fetching and re-rendering them from scratch.
+        recently_stored_urls: list[str] | set[str] | None = None,
     ):
         """
         Initialize the ClauseaCrawler.
@@ -1511,6 +1515,13 @@ class ClauseaCrawler:
         self.visited_urls: set[str] = set()
         self.failed_urls: set[str] = set()
         self.queued_urls: set[str] = set()  # Prevents duplicate queue entries
+        # Docs stored within the resume freshness window; skip re-fetching them so a
+        # retried long crawl resumes instead of re-rendering. Normalized with the same
+        # normalize_url used on crawled URLs so the membership test in should_crawl_url
+        # matches. Persists across all seeds in crawl_multiple (never reset per-seed).
+        self._recently_stored_urls: set[str] = {
+            self.normalize_url(url) for url in (recently_stored_urls or [])
+        }
         # Maps a language-stripped "canonical key" to the variant we kept, so pure
         # translation duplicates of an already-seen document are skipped while
         # region-qualified locales (jurisdiction-distinct) are always preserved.
@@ -2803,6 +2814,10 @@ class ClauseaCrawler:
             logger.debug(f"❌ URL {url} rejected: already visited, failed, or queued")
             return False
 
+        if self.normalize_url(url) in self._recently_stored_urls:
+            logger.debug(f"❌ URL {url} skipped: already stored recently (resume)")
+            return False
+
         # Parse URL once and reuse for multiple checks
         parsed_url = self._parse_url(url)
 
@@ -4057,6 +4072,8 @@ class ClauseaCrawler:
                 self._policy_pages_found = 0
                 self._crawls_since_new_lead = 0
                 self.results.clear()
+                # NB: _recently_stored_urls is intentionally NOT reset here — the resume
+                # skip-set spans every seed in the batch, not just the first.
                 # Clear caches between different base URLs
                 if self.robots_checker:
                     self.robots_checker.clear_cache()

--- a/packages/backend/src/models/document.py
+++ b/packages/backend/src/models/document.py
@@ -1468,6 +1468,10 @@ class Document(BaseModel):
     regions: list[Region] = Field(default_factory=list)
     effective_date: datetime | None = None
     created_at: datetime = Field(default_factory=datetime.now)
+    # Last time this document row was written (stored or updated). Drives crawl
+    # resume: a retried crawl skips re-fetching docs written within the resume
+    # freshness window, while older docs are still re-fetched for change detection.
+    updated_at: datetime = Field(default_factory=datetime.now)
     tier_relevance: TierRelevance = "extended"
 
 

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -46,11 +46,12 @@ Usage:
 import asyncio
 import hashlib
 import json
+import os
 import re
 import time
 import tracemalloc
 from collections.abc import Awaitable, Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import urlparse
 
@@ -85,6 +86,13 @@ logger_storage = get_logger(__name__, component="pipeline:storage")
 
 # Minimum normalized legal_score (0.0–1.0) to accept a crawled page into analysis.
 MIN_LEGAL_SCORE_THRESHOLD = 0.2
+
+# Resume freshness window (hours). A retried crawl skips re-fetching docs stored
+# within this window so it resumes instead of re-rendering hours of work. Stored
+# older than this -> still re-fetched, so scheduled monitoring re-crawls days later
+# continue to detect policy changes. Recency is the signal that tells a retry
+# (minutes/hours later) apart from a monitoring run (days later).
+RESUME_FRESH_HOURS = float(os.getenv("PIPELINE_RESUME_FRESH_HOURS", "24"))
 
 
 def _content_fingerprint(text: str) -> str:
@@ -805,6 +813,27 @@ class PolicyDocumentPipeline:
             self.fallback_strategy,
         )
 
+    async def _get_recently_stored_urls(self, product: Product) -> list[str]:
+        """URLs of this product's docs stored within the resume freshness window.
+
+        Drives crawl resume: passed to the crawler so a retried long crawl skips
+        re-fetching pages it already stored minutes/hours ago. Docs older than
+        ``RESUME_FRESH_HOURS`` are excluded, so a scheduled monitoring re-crawl days
+        later still re-fetches them and detects policy changes. One query per crawl.
+        Failures are non-fatal — the crawl simply runs without the skip-set.
+        """
+        cutoff = datetime.now() - timedelta(hours=RESUME_FRESH_HOURS)
+        try:
+            async with db_session() as db:
+                document_service = create_document_service()
+                return await document_service.get_recent_document_urls(db, product.id, cutoff)
+        except Exception as error:
+            logger.warning(
+                f"Could not load recently stored URLs for {product.name} "
+                f"(resume skip disabled this run): {error}"
+            )
+            return []
+
     def _create_crawler_for_product(
         self,
         product: Product,
@@ -815,6 +844,7 @@ class PolicyDocumentPipeline:
         strategy: str | None = None,
         progress_phase: str | None = None,
         result_callback: Callable[[CrawlResult], Awaitable[None]] | None = None,
+        recently_stored_urls: list[str] | None = None,
     ) -> ClauseaCrawler:
         """Create a configured crawler instance for a specific product."""
         from datetime import datetime
@@ -862,6 +892,7 @@ class PolicyDocumentPipeline:
             denied_paths=product.crawl_denied_paths,
             progress_callback=progress_callback,
             result_callback=result_callback,
+            recently_stored_urls=recently_stored_urls,
         )
 
     async def _store_documents(self, documents: list[Document]) -> int:
@@ -1373,6 +1404,18 @@ class PolicyDocumentPipeline:
                     self.stats.policy_documents_stored += stored
                     processed_documents.extend(docs)
 
+            # Docs stored within the resume freshness window. A retried crawl skips
+            # re-fetching these so it resumes instead of re-rendering hours of work;
+            # docs older than the window are still re-fetched so scheduled monitoring
+            # re-crawls days later keep detecting policy changes. One query per crawl.
+            recently_stored_urls = await self._get_recently_stored_urls(product)
+            if recently_stored_urls:
+                logger.info(
+                    f"♻️ Resume: skipping re-fetch of {len(recently_stored_urls)} "
+                    f"recently stored docs for {product.name} "
+                    f"(within {RESUME_FRESH_HOURS}h window)"
+                )
+
             # ----------------------------------------------------------
             # Stage 1: Crawl (streams classify + store per page)
             # ----------------------------------------------------------
@@ -1389,6 +1432,7 @@ class PolicyDocumentPipeline:
                 strategy=self.discovery_strategy,
                 progress_phase="discovery",
                 result_callback=result_callback,
+                recently_stored_urls=recently_stored_urls,
             )
             discovery_results = await self._crawl_base_urls(discovery_crawler, crawl_urls)
             logger_discovery.info(
@@ -1410,6 +1454,7 @@ class PolicyDocumentPipeline:
                     strategy=self.fallback_strategy,
                     progress_phase="fallback",
                     result_callback=result_callback,
+                    recently_stored_urls=recently_stored_urls,
                 )
                 fallback_results = await self._crawl_base_urls(fallback_crawler, crawl_urls)
                 logger_discovery.info(

--- a/packages/backend/src/repositories/document_repository.py
+++ b/packages/backend/src/repositories/document_repository.py
@@ -231,6 +231,29 @@ class DocumentRepository(BaseRepository):
         documents: list[dict[str, Any]] = await db.documents.find(query).to_list(length=None)
         return [Document(**_normalize_document_record(document)) for document in documents]
 
+    async def find_recent_urls_by_product(
+        self, db: AgnosticDatabase, product_id: str, cutoff: datetime
+    ) -> list[str]:
+        """Return URLs of a product's documents written at or after ``cutoff``.
+
+        Backs crawl resume: a retried crawl skips re-fetching docs stored within the
+        freshness window. Matches on ``updated_at`` (stamped on every store/update) and
+        falls back to ``created_at`` so legacy rows written before ``updated_at`` existed
+        are still recognised. Projects only the URL so this stays a cheap, one-per-crawl
+        query rather than streaming full document bodies.
+        """
+        query: dict[str, Any] = {
+            "product_id": product_id,
+            "$or": [
+                {"updated_at": {"$gte": cutoff}},
+                {"created_at": {"$gte": cutoff}},
+            ],
+        }
+        rows: list[dict[str, Any]] = await db.documents.find(query, {"_id": 0, "url": 1}).to_list(
+            length=None
+        )
+        return [row["url"] for row in rows if row.get("url")]
+
     # ============================================================================
     # Document Persistence Operations
     # ============================================================================

--- a/packages/backend/src/services/document_service.py
+++ b/packages/backend/src/services/document_service.py
@@ -7,6 +7,8 @@ accepts database instances as parameters.
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from motor.core import AgnosticDatabase
 
 from src.core.logging import get_logger
@@ -130,6 +132,19 @@ class DocumentService:
         documents: list[Document] = await self._document_repo.find_with_analysis(db, product_id)
         return documents
 
+    async def get_recent_document_urls(
+        self, db: AgnosticDatabase, product_id: str, cutoff: datetime
+    ) -> list[str]:
+        """Return URLs of a product's documents written at or after ``cutoff``.
+
+        Used by the pipeline to tell the crawler which freshly stored docs to skip
+        re-fetching when resuming a retried crawl.
+        """
+        urls: list[str] = await self._document_repo.find_recent_urls_by_product(
+            db, product_id, cutoff
+        )
+        return urls
+
     # ============================================================================
     # Document Persistence Operations (with cache invalidation)
     # ============================================================================
@@ -151,6 +166,9 @@ class DocumentService:
         """
         try:
             self._assign_tier_relevance(document)
+            # Stamp the write time so a retried crawl can recognise freshly stored
+            # docs and skip re-fetching them (see Document.updated_at).
+            document.updated_at = datetime.now()
             result = await self._document_repo.save(db, document)
 
             # Business logic: Invalidate product overview cache for this product
@@ -200,6 +218,7 @@ class DocumentService:
         """
         try:
             self._assign_tier_relevance(document)
+            document.updated_at = datetime.now()
             success = await self._document_repo.update(db, document)
 
             if success and invalidate_product_overview:

--- a/packages/backend/tests/unit/crawler/state_test.py
+++ b/packages/backend/tests/unit/crawler/state_test.py
@@ -143,3 +143,79 @@ class TestCrawlerState:
         crawler = ClauseaCrawler(strategy="best_first")
         heapq.heappush(crawler.url_priority_queue, (-5.0, "https://example.com/a", 1, 5.0))
         assert crawler._get_pending_url_count() == 1
+
+
+class TestResumeSkipSet:
+    """A retried crawl skips re-fetching docs stored within the resume freshness
+    window (recently_stored_urls), while leaving every other crawl decision intact."""
+
+    def test_recently_stored_url_is_rejected(self) -> None:
+        crawler = ClauseaCrawler(recently_stored_urls=["https://anthropic.com/privacy"])
+        assert (
+            crawler.should_crawl_url("https://anthropic.com/privacy", "https://anthropic.com", 1)
+            is False
+        )
+
+    def test_skip_matches_after_normalization(self) -> None:
+        # Stored without trailing slash; crawled with one — normalize_url collapses both,
+        # so the membership test still matches. A mismatch here would silently disable
+        # the skip, so this guards normalization parity between stored and crawled URLs.
+        crawler = ClauseaCrawler(recently_stored_urls=["https://anthropic.com/legal"])
+        assert (
+            crawler.should_crawl_url("https://anthropic.com/legal/", "https://anthropic.com", 1)
+            is False
+        )
+
+    def test_skip_matches_when_crawled_url_carries_tracking_params(self) -> None:
+        # normalize_url strips trackers on both sides, so a tracked crawl URL still
+        # resolves to the stored canonical URL and is skipped.
+        crawler = ClauseaCrawler(recently_stored_urls=["https://anthropic.com/privacy"])
+        assert (
+            crawler.should_crawl_url(
+                "https://anthropic.com/privacy?utm_source=email",
+                "https://anthropic.com",
+                1,
+            )
+            is False
+        )
+
+    def test_non_stored_url_is_not_skipped(self) -> None:
+        crawler = ClauseaCrawler(recently_stored_urls=["https://anthropic.com/privacy"])
+        assert (
+            crawler.should_crawl_url("https://anthropic.com/terms", "https://anthropic.com", 1)
+            is True
+        )
+
+    def test_empty_set_causes_no_skips(self) -> None:
+        crawler = ClauseaCrawler(recently_stored_urls=[])
+        assert (
+            crawler.should_crawl_url("https://anthropic.com/privacy", "https://anthropic.com", 1)
+            is True
+        )
+
+    def test_none_causes_no_skips(self) -> None:
+        crawler = ClauseaCrawler(recently_stored_urls=None)
+        assert (
+            crawler.should_crawl_url("https://anthropic.com/privacy", "https://anthropic.com", 1)
+            is True
+        )
+
+    def test_skip_set_survives_per_seed_reset(self) -> None:
+        # crawl_multiple clears per-seed state (visited/queued/etc.) between base URLs,
+        # but the resume skip-set must span every seed in the batch — otherwise the 2nd
+        # seed would re-fetch docs already stored. Assert it still skips after a reset.
+        crawler = ClauseaCrawler(recently_stored_urls=["https://anthropic.com/privacy"])
+
+        # Simulate the per-seed reset block in crawl_multiple.
+        crawler.visited_urls.clear()
+        crawler.failed_urls.clear()
+        crawler.queued_urls.clear()
+        crawler._locale_seen_keys.clear()
+        crawler._sitemap_seeded = False
+        crawler.url_queue.clear()
+
+        assert crawler._recently_stored_urls == {"https://anthropic.com/privacy"}
+        assert (
+            crawler.should_crawl_url("https://anthropic.com/privacy", "https://anthropic.com", 1)
+            is False
+        )

--- a/packages/backend/tests/unit/document_repository_recent_urls_test.py
+++ b/packages/backend/tests/unit/document_repository_recent_urls_test.py
@@ -1,0 +1,121 @@
+"""find_recent_urls_by_product returns only docs written within the freshness window.
+
+Backs crawl resume: a retried crawl skips re-fetching docs stored recently, while
+docs older than the cutoff are still re-fetched so scheduled monitoring detects
+policy changes. The recency filter lives in the Mongo query ($gte on updated_at,
+falling back to created_at), so this test drives a small in-memory collection that
+applies that query and asserts the cutoff is honoured.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, cast
+
+import pytest
+from motor.core import AgnosticDatabase
+
+from src.repositories.document_repository import DocumentRepository
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    async def to_list(self, length: int | None = None) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+
+class _FakeDocuments:
+    """Minimal stand-in for db.documents that understands the recent-urls query."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self._rows = rows
+
+    def find(self, query: dict[str, Any], projection: dict[str, Any]) -> _FakeCursor:
+        product_id = query["product_id"]
+        or_clauses = query["$or"]
+        updated_cutoff = or_clauses[0]["updated_at"]["$gte"]
+        created_cutoff = or_clauses[1]["created_at"]["$gte"]
+
+        matched: list[dict[str, Any]] = []
+        for row in self._rows:
+            if row.get("product_id") != product_id:
+                continue
+            recent = (row.get("updated_at") and row["updated_at"] >= updated_cutoff) or (
+                row.get("created_at") and row["created_at"] >= created_cutoff
+            )
+            if recent:
+                # Honour the {"_id": 0, "url": 1} projection.
+                matched.append({"url": row.get("url")})
+        return _FakeCursor(matched)
+
+
+class _FakeDb:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.documents = _FakeDocuments(rows)
+
+
+@pytest.mark.asyncio
+async def test_returns_recent_excludes_stale() -> None:
+    now = datetime.now()
+    cutoff = now - timedelta(hours=24)
+    rows = [
+        {
+            "product_id": "prod-1",
+            "url": "https://acme.com/fresh",
+            "updated_at": now - timedelta(hours=1),
+        },
+        {
+            "product_id": "prod-1",
+            "url": "https://acme.com/stale",
+            "updated_at": now - timedelta(days=10),
+        },
+    ]
+    repo = DocumentRepository()
+    urls = await repo.find_recent_urls_by_product(
+        cast(AgnosticDatabase, _FakeDb(rows)), "prod-1", cutoff
+    )
+    assert urls == ["https://acme.com/fresh"]
+
+
+@pytest.mark.asyncio
+async def test_created_at_fallback_for_docs_without_updated_at() -> None:
+    # Legacy rows written before updated_at existed are still recognised via created_at.
+    now = datetime.now()
+    cutoff = now - timedelta(hours=24)
+    rows = [
+        {
+            "product_id": "prod-1",
+            "url": "https://acme.com/legacy-fresh",
+            "created_at": now - timedelta(hours=2),
+        },
+    ]
+    repo = DocumentRepository()
+    urls = await repo.find_recent_urls_by_product(
+        cast(AgnosticDatabase, _FakeDb(rows)), "prod-1", cutoff
+    )
+    assert urls == ["https://acme.com/legacy-fresh"]
+
+
+@pytest.mark.asyncio
+async def test_scopes_to_product() -> None:
+    now = datetime.now()
+    cutoff = now - timedelta(hours=24)
+    rows = [
+        {
+            "product_id": "prod-1",
+            "url": "https://acme.com/mine",
+            "updated_at": now,
+        },
+        {
+            "product_id": "prod-2",
+            "url": "https://other.com/theirs",
+            "updated_at": now,
+        },
+    ]
+    repo = DocumentRepository()
+    urls = await repo.find_recent_urls_by_product(
+        cast(AgnosticDatabase, _FakeDb(rows)), "prod-1", cutoff
+    )
+    assert urls == ["https://acme.com/mine"]

--- a/packages/backend/tests/unit/pipeline_resume_skip_test.py
+++ b/packages/backend/tests/unit/pipeline_resume_skip_test.py
@@ -1,0 +1,157 @@
+"""_process_product wires recently stored URLs into the crawler for resume.
+
+A crawl interrupted and retried minutes/hours later must skip re-fetching the docs it
+already stored, instead of re-rendering hours of work. _process_product queries the
+product's recently stored docs (within RESUME_FRESH_HOURS) and passes their URLs to
+every crawler it creates via recently_stored_urls. Docs stored long ago are excluded by
+the cutoff, so scheduled monitoring re-crawls days later still re-fetch and detect change.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src import pipeline as pipeline_module
+from src.crawler import CrawlResult
+from src.models.document import DocType, Document
+from src.models.product import Product
+from src.pipeline import PolicyDocumentPipeline
+
+
+def _result(url: str) -> CrawlResult:
+    return CrawlResult(
+        url=url,
+        title="",
+        content=f"unique content for {url} " * 30,
+        markdown="x",
+        metadata={},
+        status_code=200,
+        success=True,
+    )
+
+
+def _doc(url: str, doc_type: DocType) -> Document:
+    return Document(
+        id=url,
+        url=url,
+        product_id="prod-1",
+        doc_type=doc_type,
+        title="T",
+        text="t" * 400,
+        markdown="t",
+    )
+
+
+class _FakeCrawler:
+    def __init__(self, results, result_callback) -> None:
+        self._results = results
+        self._result_callback = result_callback
+
+    async def crawl_multiple(self, _urls):
+        for result in self._results:
+            if self._result_callback is not None:
+                await self._result_callback(result)
+        return list(self._results)
+
+
+def _make_product() -> Product:
+    return Product(
+        id="prod-1",
+        name="Acme",
+        slug="acme",
+        domains=["acme.com"],
+        crawl_base_urls=["https://acme.com/"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_recent_urls_passed_to_crawler_as_skips(monkeypatch):
+    product = _make_product()
+    discovery = [_result("https://acme.com/privacy"), _result("https://acme.com/terms")]
+
+    async def fake_process_crawl_result(result: CrawlResult, _product):
+        doc_type = "privacy_policy" if "privacy" in result.url else "terms_of_service"
+        return _doc(result.url, doc_type)
+
+    pipeline = PolicyDocumentPipeline(
+        min_docs_before_fallback=1,
+        required_doc_types=["privacy_policy", "terms_of_service"],
+    )
+
+    monkeypatch.setattr(pipeline, "_process_crawl_result", fake_process_crawl_result)
+    monkeypatch.setattr(pipeline, "_store_documents", AsyncMock(side_effect=lambda docs: len(docs)))
+    monkeypatch.setattr(pipeline, "_start_crawl_session", AsyncMock(return_value=None))
+    monkeypatch.setattr(pipeline, "_finish_crawl_session", AsyncMock(return_value=None))
+
+    # Stand in for the DB query: only the recent doc's URL is returned (stale ones are
+    # already excluded by the repository's cutoff query, tested separately).
+    recent_urls = ["https://acme.com/privacy"]
+    monkeypatch.setattr(
+        pipeline,
+        "_get_recently_stored_urls",
+        AsyncMock(return_value=recent_urls),
+    )
+
+    captured_skips: list[list[str] | None] = []
+
+    def fake_create_crawler(_product, **kwargs):
+        captured_skips.append(kwargs.get("recently_stored_urls"))
+        return _FakeCrawler(discovery, kwargs.get("result_callback"))
+
+    monkeypatch.setattr(pipeline, "_create_crawler_for_product", fake_create_crawler)
+
+    await pipeline._process_product(product)
+
+    # The discovery crawler received exactly the recent URLs as its resume skip-set.
+    assert captured_skips
+    assert captured_skips[0] == recent_urls
+
+
+@pytest.mark.asyncio
+async def test_get_recently_stored_urls_queries_with_freshness_cutoff(monkeypatch):
+    product = _make_product()
+    pipeline = PolicyDocumentPipeline()
+
+    captured_product_id: list[str] = []
+    captured_cutoff: list[datetime] = []
+
+    class _FakeService:
+        async def get_recent_document_urls(self, _db, product_id: str, cutoff: datetime):
+            captured_product_id.append(product_id)
+            captured_cutoff.append(cutoff)
+            # Service returns only docs already filtered to the recent window.
+            return ["https://acme.com/privacy"]
+
+    class _FakeDbCtx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(pipeline_module, "db_session", lambda: _FakeDbCtx())
+    monkeypatch.setattr(pipeline_module, "create_document_service", lambda: _FakeService())
+
+    before = datetime.now() - timedelta(hours=pipeline_module.RESUME_FRESH_HOURS)
+    urls = await pipeline._get_recently_stored_urls(product)
+    after = datetime.now() - timedelta(hours=pipeline_module.RESUME_FRESH_HOURS)
+
+    assert urls == ["https://acme.com/privacy"]
+    assert captured_product_id == ["prod-1"]
+    # Cutoff is "now minus the freshness window", so it falls between the two samples.
+    assert before <= captured_cutoff[0] <= after
+
+
+@pytest.mark.asyncio
+async def test_query_failure_disables_skip_but_does_not_crash(monkeypatch):
+    product = _make_product()
+    pipeline = PolicyDocumentPipeline()
+
+    def _boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(pipeline_module, "db_session", lambda: _boom())
+
+    urls = await pipeline._get_recently_stored_urls(product)
+    assert urls == []


### PR DESCRIPTION
## What changes

Makes Clausea crawls **resumable**. Since incremental storage (#80), an interrupted long crawl keeps the docs it already stored — but on retry the pipeline re-crawled every seed from scratch and re-rendered those same pages, repeating hours of expensive browser work. This change lets a retry **skip re-fetching docs it stored very recently**, while preserving change-monitoring.

### For the operator
- A retried/re-claimed job now resumes instead of redoing work: docs written within a **freshness window** (default **24h**, env `PIPELINE_RESUME_FRESH_HOURS`) are skipped at `should_crawl_url`.
- A scheduled monitoring re-crawl days later still re-fetches everything (docs are now stale) → policy-change detection is unaffected.
- One extra cheap query per product at crawl start; an info log shows how many URLs are being skipped (`♻️ Resume: skipping re-fetch of N recently stored docs`).

### The recency signal
A retry happens minutes/hours after the docs were stored; a monitor runs days later. So freshness — not URL identity — is what distinguishes the two. Stored-recently → skip; stale → re-fetch.

## How it works

- **`ClauseaCrawler`** gains `recently_stored_urls`. It is normalized with the crawler's own `normalize_url` and compared against `normalize_url(url)` in `should_crawl_url`, so the membership test matches regardless of trailing-slash / tracking-param variants. The skip-set **persists across all seeds** in `crawl_multiple` (it is deliberately excluded from the per-seed state reset).
- **`Document.updated_at`** is added and stamped on every `store_document` / `update_document`. The model previously had no `updated_at` field, so freshly stored docs (via `save`) carried none — the recency query would have silently matched nothing. Now `updated_at` is a reliable "last written" timestamp.
- **`DocumentRepository.find_recent_urls_by_product`** — a cheap URL-only projection querying `updated_at >= cutoff`, with a `created_at` fallback so legacy rows written before `updated_at` existed are still recognised.
- **Pipeline** wires the recent URLs into both the discovery and fallback crawlers via a new `recently_stored_urls` param on `_create_crawler_for_product`. The query is wrapped so a DB failure is non-fatal (the crawl just runs without the skip-set).

Out of scope (unchanged): storage, dedup, stall guard, `max_pages`. A `None`/empty skip-set is a no-op. Seed/base URLs bypass `should_crawl_url`, so an already-stored seed may still be re-crawled — that is cheap and intentional.

## Normalization parity
Stored document URLs come from `CrawlResult.url`, which the crawler already produced via `normalize_url`. The skip-set re-runs the same `normalize_url` on both sides, so the comparison is symmetric by construction. A test asserts trailing-slash and tracking-param variants still match.

## Tests
- Crawler (`state_test.py::TestResumeSkipSet`): stored URL rejected; normalization parity (trailing slash + trackers); non-stored not skipped; empty/None = no skips; skip-set survives the `crawl_multiple` per-seed reset.
- Repository (`document_repository_recent_urls_test.py`): recent included, stale excluded, `created_at` fallback, product scoping.
- Pipeline (`pipeline_resume_skip_test.py`): recent URLs forwarded to the crawler as skips; cutoff computed as now − window; query failure → empty list, no crash.

Verification (from `packages/backend`): `ruff check`, `ruff format --check`, `ty check`, and `pytest tests/unit` (**609 passed**) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)