### PR TITLE
fix(seo): give cookie-policy its own canonical URL

### DIFF
--- a/packages/frontend/app/(site)/cookie-policy/layout.tsx
+++ b/packages/frontend/app/(site)/cookie-policy/layout.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+
+const siteUrl = (
+  process.env.NEXT_PUBLIC_APP_URL || "https://clausea.co"
+).replace(/\/$/, "");
+
+export const metadata: Metadata = {
+  title: "Cookie Policy | Clausea AI",
+  description:
+    "Read Clausea AI's Cookie Policy to understand how we use cookies and similar technologies, and how you can control them.",
+  robots: {
+    index: true,
+    follow: true,
+  },
+  openGraph: {
+    title: "Cookie Policy | Clausea AI",
+    description:
+      "Read Clausea AI's Cookie Policy to understand how we use cookies and similar technologies.",
+    url: `${siteUrl}/cookie-policy`,
+    siteName: "Clausea AI",
+    images: [
+      {
+        url: `${siteUrl}/og`,
+        width: 1200,
+        height: 630,
+        alt: "Clausea AI Cookie Policy",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  alternates: {
+    canonical: `${siteUrl}/cookie-policy`,
+  },
+};
+
+export default function CookiePolicyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/packages/frontend/app/(site)/cookie-policy/page.tsx
+++ b/packages/frontend/app/(site)/cookie-policy/page.tsx
@@ -1,13 +1,5 @@
-import type { Metadata } from "next";
-
 import { Header } from "@/components/clausea/Header";
 import { Footer } from "@/components/clausea/PricingAndFooter";
-
-export const metadata: Metadata = {
-  title: "Cookie Policy | Clausea AI",
-  description:
-    "How Clausea AI uses cookies and similar technologies, and how you can control them.",
-};
 
 export default function CookiePolicyPage() {
   return (


### PR DESCRIPTION
## Problem
The `cookie_policy` document crawled from clausea.co was stored with `url = https://clausea.co` (site root) instead of `https://clausea.co/cookie-policy`. Content was correct; only the source URL was wrong. Privacy and terms were fine.

## Root cause
`app/(site)/cookie-policy/` had **no `layout.tsx`**, so it inherited the root `app/layout.tsx` metadata — `alternates.canonical = siteUrl` (root) and `openGraph.url = siteUrl`. `privacy/layout.tsx` and `terms/layout.tsx` each declare their own per-path canonical; cookie-policy didn't.

A crawler that honors `rel=canonical` (standard SEO behavior — `_choose_effective_url` in the backend does this) therefore recorded the canonical/root URL as the document's source.

## Fix
Add `cookie-policy/layout.tsx` mirroring privacy/terms, declaring `canonical` and `openGraph.url` = `${siteUrl}/cookie-policy`.

## Scope note (the crawler side, intentionally not changed)
The crawler honoring `rel=canonical` is **correct** behavior — when a page declares a canonical URL, that *is* its authoritative URL. The bug here was clausea.co misdeclaring its own canonical, which this PR fixes at the source. A defensive crawler guard (don't let a canonical collapse a distinct policy page onto another page's URL, for misconfigured vendor sites) is a separate, debatable change tracked in #86 — not bundled here to avoid overriding legitimate vendor canonicals.

Closes #86