### PR TITLE
fix(analysis): distinguish absent from vague in overview synthesis

### DIFF
--- a/packages/backend/src/prompts/analysis_prompts.py
+++ b/packages/backend/src/prompts/analysis_prompts.py
@@ -214,6 +214,7 @@ Explicitly surface, when the inputs support it: children's or teens' data, sale 
 - When documents conflict, report the conflict in `contradictions` and use the more conservative interpretation for factual claims — not for tone (stay measured, not alarmist).
 - If a field cannot be filled from the evidence, use "Not specified in documents" — never invent.
 - Be honest: if the company collects a lot of data, do not soften it; but do not invent or exaggerate risks beyond what the documents support.
+- Distinguish *absent* from *vague*. "Mentioned but unspecified" and "not mentioned at all" are different findings — never collapse the former into the latter. If a document addresses a topic only with boilerplate or without naming a concrete mechanism (e.g. "we apply appropriate safeguards" for international transfers, with no Standard Contractual Clauses / adequacy decision / BCRs named), describe it as **vague or unspecified** (e.g. "transfer safeguards are claimed but unspecified — no mechanism named"), not as missing or non-existent. Flagging vague boilerplate as a weakness is correct; stating that none exists when the document claims otherwise is not.
 
 ## SUMMARY
 1. Up to 5 sentences: who this company is, what data they collect overall, the most important privacy risk, and the most important protection (if any). Start directly with the company or service name.


### PR DESCRIPTION
## Problem
clausea.co's overview summary claimed international transfers have "no legal safeguards (such as Standard Contractual Clauses) are specified" — but the privacy policy states *"We ensure appropriate safeguards are in place to protect your information"* (`privacy/page.tsx:298`). Reads as *absent* when the document claims vague safeguards *exist*.

## Root cause (verified — not missing data)
The stored privacy doc (6,384 chars) contains the full text including "International Data Transfers" and "appropriate safeguards" — confirmed by DB inspection. The model saw the sentence.

Per-document extraction enforces faithfulness (`analyser.py:647` "Not specified in document"; verbatim-quote validation in `_validate_consumer_explainer_quotes`). The **product-level overview summary synthesis** (`PRODUCT_OVERVIEW_PROMPT`) paraphrases freely and had no equivalent *absent-vs-vague* rule, so "vague boilerplate safeguards" collapsed into "no safeguards specified".

## Fix
Add a non-negotiable rule to `PRODUCT_OVERVIEW_PROMPT`: treat "mentioned but unspecified" and "not mentioned at all" as distinct findings; flag vague boilerplate (e.g. unnamed transfer mechanism) as a weakness **without** claiming it is absent.

## Validation
Verified against clausea.co end-to-end: 5 of 6 summary claims were already verbatim-accurate (data collected, govt-disclosure clause, immediate deletion, no-sale); only the transfer-safeguards claim was overstated. This narrows the prompt without softening genuine risk-flagging.

Closes #85