### PR TITLE
fix(worker): remove pipeline retry cap — retries are unlimited

### DIFF
--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -181,17 +181,20 @@ class PipelineRepository(BaseRepository):
         )
         logger.debug(f"Partially updated pipeline job {job_id}: {list(fields.keys())}")
 
-    async def requeue_failed_jobs(self, db: AgnosticDatabase, max_attempts: int) -> int:
-        """Re-queue failed jobs for another attempt, bounded by max_attempts.
+    async def requeue_failed_jobs(self, db: AgnosticDatabase) -> int:
+        """Re-queue every failed job for another attempt — retries are unlimited.
 
         Makes the worker self-healing: orphaned jobs (failed by mark_stale_as_failed) and
         transient failures retry. ``no_documents`` is terminal and deliberately not retried.
+        There is no attempt ceiling: a job mostly accrues attempts from redeploys orphaning
+        long in-flight crawls, not from real defects, so capping it would permanently kill
+        legitimate work. The 5-minute stale-sweep cadence is the natural backoff between
+        retries, so a genuinely poison job retries slowly rather than tight-looping.
 
         At most one active job per product (enforced by the uniq_active_job_per_product
         partial index): products that already have an active job are skipped, and only one
         failed job per remaining product is revived — reactivating a second would raise a
-        DuplicateKeyError. A missing "attempts" field doesn't match ``$lt`` in MongoDB, so
-        pre-existing jobs are matched via ``$exists`` and get attempts=1 on the next claim.
+        DuplicateKeyError.
         """
         fresh_steps = [
             {
@@ -210,14 +213,7 @@ class PipelineRepository(BaseRepository):
             await db[self.COLLECTION].distinct("product_slug", {"active": True})
         )
         candidates: list[dict[str, Any]] = (
-            await db[self.COLLECTION]
-            .find(
-                {
-                    "status": "failed",
-                    "$or": [{"attempts": {"$lt": max_attempts}}, {"attempts": {"$exists": False}}],
-                }
-            )
-            .to_list(length=None)
+            await db[self.COLLECTION].find({"status": "failed"}).to_list(length=None)
         )
 
         count = 0
@@ -244,9 +240,7 @@ class PipelineRepository(BaseRepository):
             )
             count += 1
         if count:
-            logger.info(
-                "Re-queued %d failed job(s) for retry (max_attempts=%d)", count, max_attempts
-            )
+            logger.info("Re-queued %d failed job(s) for retry", count)
         return count
 
     async def mark_stale_as_failed(

--- a/packages/backend/tests/unit/pipeline_stale_jobs_test.py
+++ b/packages/backend/tests/unit/pipeline_stale_jobs_test.py
@@ -40,26 +40,33 @@ def _failed_jobs_collection(active_slugs, candidates):
 
 
 @pytest.mark.asyncio
-async def test_requeue_failed_only_retries_under_attempt_cap():
+async def test_requeue_failed_retries_unlimited_regardless_of_attempts():
+    # Retries are unlimited: a job mostly accrues attempts from redeploys orphaning long
+    # crawls, not real defects, so there is no attempt ceiling. Even a high-attempt job
+    # must be requeued.
     collection = _failed_jobs_collection(
         active_slugs=[],
-        candidates=[{"id": "a", "product_slug": "alpha"}, {"id": "b", "product_slug": "beta"}],
+        candidates=[
+            {"id": "a", "product_slug": "alpha", "attempts": 1},
+            {"id": "b", "product_slug": "beta", "attempts": 99},
+        ],
     )
     db = MagicMock()
     db.__getitem__.return_value = collection
 
-    requeued = await PipelineRepository().requeue_failed_jobs(db, max_attempts=4)
+    requeued = await PipelineRepository().requeue_failed_jobs(db)
 
     query = collection.find.call_args.args[0]
     # Only failed jobs are retried; no_documents stays terminal.
     assert query["status"] == "failed"
-    # Under the cap OR missing the field (pre-existing jobs) — $lt alone skips missing fields.
-    assert {"attempts": {"$lt": 4}} in query["$or"]
-    assert {"attempts": {"$exists": False}} in query["$or"]
+    # No attempt cap: the query must not filter on attempts at all.
+    assert "$or" not in query
+    assert "attempts" not in query
     update = collection.update_one.call_args.args[1]
     assert update["$set"]["status"] == "pending"
     # Steps reset so a retry doesn't carry stale terminal step state.
     assert all(s["status"] == "pending" for s in update["$set"]["steps"])
+    # The 99-attempt job is requeued too.
     assert requeued == 2
 
 
@@ -80,7 +87,7 @@ async def test_requeue_never_creates_second_active_job_per_product():
     db = MagicMock()
     db.__getitem__.return_value = collection
 
-    requeued = await PipelineRepository().requeue_failed_jobs(db, max_attempts=4)
+    requeued = await PipelineRepository().requeue_failed_jobs(db)
 
     assert requeued == 2
     revived_ids = {call.args[0]["id"] for call in collection.update_one.call_args_list}

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -8,7 +8,6 @@ Concurrency and poll interval are env-tunable:
   PIPELINE_WORKER_CONCURRENCY         (default 3)    max jobs running at once
   PIPELINE_WORKER_POLL_SECONDS        (default 3)    idle poll interval
   PIPELINE_WORKER_STALE_SWEEP_SECONDS (default 300)  how often to reap orphaned jobs
-  PIPELINE_MAX_ATTEMPTS               (default 4)    max claims before a job stays failed
 """
 
 from __future__ import annotations
@@ -27,12 +26,11 @@ logger = get_logger(__name__)
 _CONCURRENCY = max(1, int(os.getenv("PIPELINE_WORKER_CONCURRENCY", "3")))
 _POLL_SECONDS = float(os.getenv("PIPELINE_WORKER_POLL_SECONDS", "3"))
 _STALE_SWEEP_SECONDS = float(os.getenv("PIPELINE_WORKER_STALE_SWEEP_SECONDS", "300"))
-_MAX_ATTEMPTS = max(1, int(os.getenv("PIPELINE_MAX_ATTEMPTS", "4")))
 
 
 async def _sweep_stale(repo: PipelineRepository) -> None:
     """Self-heal the queue (boot + periodic): reap crash-orphaned in-progress jobs, then
-    re-queue failed ones (orphans + transient failures) up to _MAX_ATTEMPTS.
+    re-queue failed ones (orphans + transient failures) — retries are unlimited.
 
     Best-effort: a sweep error must never stop the worker from claiming jobs (a single
     failure here previously crashlooped the whole worker), so failures are logged, not raised.
@@ -40,7 +38,7 @@ async def _sweep_stale(repo: PipelineRepository) -> None:
     try:
         async with db_session() as db:
             reaped = await repo.mark_stale_as_failed(db)
-            requeued = await repo.requeue_failed_jobs(db, _MAX_ATTEMPTS)
+            requeued = await repo.requeue_failed_jobs(db)
         if reaped:
             logger.info("Reaped %d stale job(s) as failed", reaped)
         if requeued:


### PR DESCRIPTION
## Why
`PIPELINE_MAX_ATTEMPTS` (default 4) capped how many times a failed job could be requeued. But a job accrues attempts mostly from **redeploys orphaning long in-flight crawls**, not from real defects — so the cap permanently failed legitimate work. During today's testing, `notion` and `doordash` hit `att=4` purely from deploy churn while crawling large sites.

The cap was an artifact of heavy dev/redeploy churn, not a day-to-day production need. A pipeline should always be retryable.

## Change
- `requeue_failed_jobs(db)` — drop the `max_attempts` parameter and the `attempts` filter; revive **every** failed job regardless of attempt count.
- `worker.py` — remove `PIPELINE_MAX_ATTEMPTS` env var, `_MAX_ATTEMPTS`, and the doc line.
- Tests updated: a 99-attempt failed job is now requeued; the query carries no attempt filter.

## Safety
- The 5-minute stale-sweep cadence remains the natural backoff, so a genuinely poison job retries slowly (every ~5 min) rather than tight-looping a worker slot.
- `no_documents` stays terminal (not retried).
- The one-active-job-per-product guard (`uniq_active_job_per_product`) is unchanged — still ≤1 revival per product per sweep.
- `attempts` is still tracked on claim for observability; it just no longer gates retries.