### PR TITLE
fix(crawler): stop scoring auth/redirect URLs as policy pages

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -46,6 +46,30 @@ _TLD_EXTRACT = tldextract.TLDExtract(suffix_list_urls=())
 _LOCALE_QUERY_KEYS = frozenset(
     {"l", "lang", "hl", "locale", "lr", "language", "setlang", "uselang", "ui_locale"}
 )
+# Redirect-target params (post-auth destination), excluded from URL scoring so a login
+# wall doesn't inherit the relevance of the policy URL embedded in its return_to.
+_REDIRECT_QUERY_KEYS = frozenset(
+    {
+        "return_to",
+        "returnto",
+        "return",
+        "redirect",
+        "redirect_to",
+        "redirect_uri",
+        "redir",
+        "next",
+        "url",
+        "continue",
+        "dest",
+        "destination",
+        "goto",
+        "go",
+        "ref_url",
+        "callback",
+        "came_from",
+        "origin",
+    }
+)
 # Bare ISO 639-1 language codes (no region) used as path segments or query values.
 # "hr" (Croatian) and "uk" (Ukrainian) are deliberately excluded: as path segments they
 # collide with /hr/ (HR/employee policies) and /uk/ (UK-GDPR region), both legally
@@ -534,6 +558,12 @@ class URLScorer:
             r"^/(?:templates?|universe|marketplace|gallery|showcase|examples?)(?:/|$)",
             re.IGNORECASE,
         )
+        # Auth/account flows never host policy text; hard-excluded from scoring.
+        self._auth_path_re = re.compile(
+            r"(?:^|/)(?:log[-_]?in|log[-_]?out|sign[-_]?in|sign[-_]?out|sign[-_]?up|"
+            r"signon|register|oauth2?|openid|sso|saml|authorize|authentication)(?:/|$)",
+            re.IGNORECASE,
+        )
 
         self.legal_keywords = {
             # Generic legal terms
@@ -609,11 +639,21 @@ class URLScorer:
         parsed = urlparse(url_lower)
         path = parsed.path
 
+        if self._auth_path_re.search(path):
+            return 0.0
+
+        scoring_query = " ".join(
+            f"{key} {value}"
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+            if key not in _REDIRECT_QUERY_KEYS
+        )
+        scoring_url = f"{path} {scoring_query}".strip()
+
         score = 0.0
 
         # Check high-value patterns in URL using compiled regex
         for pattern, weight in self.compiled_high_value_patterns.items():
-            if pattern.search(url_lower):
+            if pattern.search(scoring_url):
                 score += weight
 
         # Score based on anchor text if provided.
@@ -639,9 +679,8 @@ class URLScorer:
             if pattern.search(path):
                 score += weight
 
-        # Score based on keywords in URL
         url_text = (
-            f"{path} {parsed.query} {parsed.fragment}".replace("/", " ")
+            f"{path} {scoring_query} {parsed.fragment}".replace("/", " ")
             .replace("-", " ")
             .replace("_", " ")
         )

--- a/packages/backend/tests/unit/crawler/url_scorer_test.py
+++ b/packages/backend/tests/unit/crawler/url_scorer_test.py
@@ -305,3 +305,48 @@ class TestMinLegalScoreFilter:
         assert len(crawler.url_priority_queue) == 1, (
             "URL with legal anchor text should pass min_legal_score filter"
         )
+
+
+class TestURLScorerAuthAndRedirectParams:
+    """Login walls fronting policy URLs must not inherit the policy's relevance."""
+
+    def test_login_with_policy_return_to_scores_zero(self) -> None:
+        scorer = URLScorer()
+        # Real case from the github crawl: a login wall whose return_to embeds the policy
+        # URL must not score as if it were the policy (it would burn a browser render).
+        url = (
+            "https://github.com/login?return_to=https://github.com/github/docs/blob/"
+            "main/content/site-policy/github-terms/github-terms-of-service.md"
+        )
+        assert scorer.score_url(url) == 0.0
+
+    def test_bare_auth_paths_score_zero(self) -> None:
+        scorer = URLScorer()
+        for url in (
+            "https://example.com/login",
+            "https://example.com/sign-in",
+            "https://example.com/account/signup",
+            "https://example.com/logout",
+            "https://example.com/oauth/authorize",
+            "https://example.com/sso",
+        ):
+            assert scorer.score_url(url) == 0.0, url
+
+    def test_redirect_param_does_not_inflate_non_auth_page(self) -> None:
+        scorer = URLScorer()
+        # A non-auth page carrying a policy URL in a redirect param should be scored on
+        # its own path, not on the redirect target.
+        with_param = scorer.score_url("https://example.com/home?next=/privacy-policy")
+        bare = scorer.score_url("https://example.com/home")
+        assert with_param == bare
+
+    def test_real_policy_pages_still_score_high(self) -> None:
+        scorer = URLScorer()
+        # Regression guard: the fix must not depress genuine policy URLs.
+        assert scorer.score_url("https://example.com/privacy-policy") >= 5.0
+        assert (
+            scorer.score_url(
+                "https://docs.github.com/en/site-policy/github-terms/github-terms-of-service"
+            )
+            >= 5.0
+        )


### PR DESCRIPTION
## Problem
A login wall whose `return_to` embeds a policy URL — e.g. `github.com/login?return_to=…/github-terms-of-service` — scored as if it *were* the policy, because `score_url` keyword-matched the query string. The crawl then burned its scarce browser-render budget on login walls that time out (20s) and yield nothing.

Diagnosed by probing the github `site-policy` seed: recall was fine (~25 policy URLs found) but the crawl wandered — 86 visited / 17 fetched in 240s, slots lost to `/login` and the docs source repo.

## Fix (generic, no vendor-specific blocklist)
- Exclude redirect-target params (`return_to`, `next`, `url`, `continue`, …) from URL scoring — they describe where you go after the page, not what the page is.
- Hard-zero auth/account paths (`login`, `signin`, `oauth`, `sso`, …) — they never host policy text.

## Measured impact (github site-policy seed, 240s, best_first, identical config)
| | before | after |
|---|---|---|
| `/login` walls crawled | 4 | 0 |
| `/github` source-repo links | 32 | 5 |
| policy URLs found | 25 | 25 |

Recall preserved, wander cut; the render budget now goes to real policy docs.

## Not addressed here
github remains render-throughput-bound (heavy JS docs pages, ~20s each). That's a separate known bottleneck; this PR stops *wasting* renders, it doesn't speed them up.

Tests: 4 added to `url_scorer_test.py` (login+return_to → 0, bare auth paths → 0, redirect param doesn't inflate a non-auth page, real policy URLs still ≥5). Full scorer suite 28/28.