### PR TITLE
fix(classifier): drop bare 'terms'/'tos' metadata tokens (false ToS)

### DIFF
--- a/packages/backend/src/analyzers/document_classifier.py
+++ b/packages/backend/src/analyzers/document_classifier.py
@@ -418,8 +418,6 @@ class DocumentClassifier(LLMUsageTrackingMixin):
                     "user agreement",
                     "service agreement",
                     "terms & conditions",
-                    "tos",
-                    "terms",
                     "conditions of use",
                     "nutzungsbedingungen",  # German
                     "conditions d'utilisation",  # French

--- a/packages/backend/tests/unit/analyzers/document_classifier_test.py
+++ b/packages/backend/tests/unit/analyzers/document_classifier_test.py
@@ -227,6 +227,28 @@ class TestMetadataClassification:
         assert result["classification"] == "cookie_policy"
 
     @pytest.mark.asyncio
+    async def test_blog_titled_on_your_terms_not_classified_as_terms(
+        self, classifier: DocumentClassifier
+    ) -> None:
+        """A blog whose title merely contains the word "terms" must not become a ToS.
+
+        Regression: signal.org/blog/signal-research ("Research on your terms") was
+        classified as terms_of_service because the bare token "terms" was a metadata
+        keyword. Text kept short with a nav word so it resolves statically (no LLM).
+        """
+        result = await classifier.classify_document(
+            url="https://signal.org/blog/signal-research",
+            text=(
+                "Home About Blog. Signal has always benefitted from our engagement with "
+                "the research community. This post describes our research program and how "
+                "academics can collaborate with us on privacy-preserving technologies. "
+            )
+            * 2,
+            metadata={"title": "Signal >> Blog >> Research on your terms"},
+        )
+        assert result["classification"] != "terms_of_service"
+
+    @pytest.mark.asyncio
     async def test_metadata_short_content_rejected(self, classifier: DocumentClassifier) -> None:
         """Metadata match should be rejected if content is < 300 chars."""
         result = await classifier.classify_document(


### PR DESCRIPTION
## Bug
A page whose title merely contains the word "terms" was classified as `terms_of_service` via the metadata keyword step. Real case: `signal.org/blog/signal-research` (title *"Research on your terms"*) was stored in Signal's legal bundle as the ToS — a blog post masquerading as terms. `"tos"` is the same hazard (substring of "pho**tos**", "kra**tos**", …).

## Fix
Remove the bare `"terms"` and `"tos"` tokens from the `terms_of_service` metadata keyword list. Genuine ToS pages are still caught by:
- the `/terms`, `/tos`, `/legal/terms` URL patterns (step 1),
- the specific metadata phrases that remain (`"terms of service"`, `"terms and conditions"`, `"terms of use"`, `"terms & conditions"`, `"user terms"`, `"service terms"`, `"conditions of use"`),
- the content-keyword heuristics (step 3).

None of those trip on a non-legal title like "Research on your terms".

## Test
Regression test added: the signal blog title no longer classifies as ToS (crafted to resolve statically, no LLM call). Classifier suite 30/30.