### PR TITLE
fix(crawler): parse text/markdown responses instead of discarding them

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -1919,6 +1919,8 @@ class ClauseaCrawler:
                 ct in content_type
                 for ct in (
                     "text/html",
+                    "text/markdown",
+                    "text/x-markdown",
                     "text/plain",
                     "text/xml",
                     "application/xml",
@@ -1998,6 +2000,8 @@ class ClauseaCrawler:
             t in ct
             for t in (
                 "text/html",
+                "text/markdown",
+                "text/x-markdown",
                 "text/plain",
                 "text/xml",
                 "application/xml",
@@ -2008,6 +2012,8 @@ class ClauseaCrawler:
         if not is_text_type:
             return await self._extract_binary_content(raw, url)
 
+        if "markdown" in ct:
+            return self._extract_markdown_content(raw, url)
         if "text/html" in ct:
             # BeautifulSoup parsing + markdownify conversion are CPU-bound and can
             # block the event loop for hundreds of ms on large pages.  Offload to a
@@ -2047,6 +2053,63 @@ class ClauseaCrawler:
             markdown=markdown_content,
             title=title,
             metadata=metadata,
+            discovered_links=discovered_links,
+            status_code=raw.status_code,
+        )
+
+    _MD_INLINE_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+\"[^\"]*\")?\s*\)")
+    _MD_AUTOLINK_RE = re.compile(r"<(https?://[^>\s]+)>")
+
+    def _resolve_md_link(self, base_url: str, href: str) -> str | None:
+        href = href.strip()
+        if not href or href.startswith(("#", "mailto:", "tel:", "javascript:", "data:")):
+            return None
+        resolved = urljoin(base_url, href)
+        if not resolved.startswith(("http://", "https://")):
+            return None
+        return self.normalize_url(resolved)
+
+    @staticmethod
+    def _markdown_to_text(md: str) -> str:
+        """Render markdown to readable plain text for length/classification gates."""
+        text = re.sub(r"<!--.*?-->", " ", md, flags=re.DOTALL)
+        text = re.sub(r"!\[[^\]]*\]\([^)]*\)", " ", text)
+        text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+        text = re.sub(r"`{1,3}[^`]*`{1,3}", " ", text)
+        text = re.sub(r"^\s{0,3}[>#\-\*\+]+\s*", "", text, flags=re.MULTILINE)
+        text = re.sub(r"[*_~]{1,3}", "", text)
+        text = re.sub(r"<[^>]+>", " ", text)
+        return re.sub(r"\n{3,}", "\n\n", text).strip()
+
+    def _extract_markdown_content(self, raw: StaticFetchResult, url: str) -> PageContent:
+        """Handle servers that honour ``Accept: text/markdown`` (e.g. GitHub Docs).
+
+        The body is already clean markdown — keep it verbatim, derive plain text for the
+        gates, and pull links so discovery can follow the policy index.
+        """
+        body = raw.body or ""
+        discovered_links: list[dict[str, str]] = []
+        seen: set[str] = set()
+        for href in self._MD_INLINE_LINK_RE.findall(body) + self._MD_AUTOLINK_RE.findall(body):
+            resolved = self._resolve_md_link(url, href)
+            if resolved and resolved not in seen:
+                seen.add(resolved)
+                discovered_links.append({"url": resolved, "text": ""})
+
+        title = ""
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                title = stripped.lstrip("#").strip()
+                break
+        if not title:
+            title = url.rstrip("/").split("/")[-1].replace("-", " ").replace("_", " ").title()
+
+        return PageContent(
+            text=self._markdown_to_text(body),
+            markdown=body,
+            title=title,
+            metadata={"content-type": raw.content_type, "estimated_title": title},
             discovered_links=discovered_links,
             status_code=raw.status_code,
         )

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -552,3 +552,37 @@ async def test_all_children_followed_when_under_cap_no_truncation_log(caplog):
     for child in children:
         assert child in session.fetched
     assert not any("children; following the first" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_extract_markdown_content_type_kept_and_links_followed():
+    """Servers honouring Accept: text/markdown (e.g. GitHub Docs) must be parsed as
+    text, not discarded as binary — the prior bug forced a wasted browser render."""
+    from src.crawler import StaticFetchResult
+
+    crawler = ClauseaCrawler(allowed_domains=["docs.github.com"])
+    body = (
+        "# GitHub Terms of Service\n\n"
+        "Please read this Terms of Service agreement carefully. By using GitHub you agree "
+        "to these terms, including limitation of liability and governing law.\n\n"
+        "See also [Privacy Statement](/en/site-policy/privacy-policies/github-privacy-statement) "
+        "and <https://docs.github.com/en/site-policy/github-terms/github-corporate-terms-of-service>.\n"
+    ) * 8
+    raw = StaticFetchResult(
+        url="https://docs.github.com/en/site-policy/github-terms/github-terms-of-service",
+        status_code=200,
+        content_type="text/markdown; charset=utf-8",
+        body=body,
+    )
+    page = await crawler._extract_page_content(
+        raw, "https://docs.github.com/en/site-policy/github-terms/github-terms-of-service"
+    )
+    assert page is not None
+    assert page.markdown == body  # clean markdown kept verbatim
+    assert "terms of service" in page.text.lower()
+    assert crawler._content_is_sufficient(
+        page, "https://docs.github.com/en/site-policy/github-terms/github-terms-of-service"
+    )
+    urls = {link["url"] for link in page.discovered_links}
+    assert any("github-privacy-statement" in u for u in urls)  # relative link resolved
+    assert any("github-corporate-terms-of-service" in u for u in urls)  # autolink captured


### PR DESCRIPTION
## Bug (catalog-wide recall + throughput)
We send `Accept: text/markdown` first. Servers honouring content negotiation (GitHub Docs, others) reply `Content-Type: text/markdown`. But `_static_fetch`'s `is_text` check and `_extract_page_content` only recognized `text/html|plain|xml` — so markdown was routed to the **binary** path, the body dropped (`body_len=0`), the page judged content-insufficient, and the crawler escalated to a **20s browser render that times out**.

Net effect: github (and any markdown-negotiating site) stored **zero docs / `no_documents`** despite serving the full policy text over plain HTTP — and burned the scarce browser-render budget doing it (the render bottleneck).

## Fix
- Recognize `text/markdown` / `text/x-markdown` as text in both `_static_fetch` and `_extract_page_content`.
- Add `_extract_markdown_content`: keep the clean markdown verbatim (better analysis input than HTML→markdownify), derive plain text for the length/classification gates, and extract inline `[..](url)` + `<autolink>` URLs so discovery follows the policy index.

## Verified
On `docs.github.com/en/site-policy`: static fetch now `sufficient=True` (no browser render); the ToS page yields 49K text / 52K markdown; the index discovers **63 links incl. every policy doc** (ToS, privacy statement, acceptable-use, …).

Tests: regression added to `extraction_and_sitemap_test.py` (markdown kept, content sufficient, relative link + autolink resolved). Crawler suite 169→170 green.