### PR TITLE
fix: address Gemini review on classifier + markdown parsing (#91/#92 follow-up)

### DIFF
--- a/packages/backend/src/analyzers/document_classifier.py
+++ b/packages/backend/src/analyzers/document_classifier.py
@@ -242,6 +242,12 @@ class DocumentClassifier(LLMUsageTrackingMixin):
         self.nav_indicators = ["home", "about", "contact", "menu", "navigation", "search"]
 
     @staticmethod
+    def _meta_has_keyword(meta_text: str, keyword: str) -> bool:
+        """Whole-word/phrase match so short tokens ('tos', 'dpa', 'gdpr') don't match
+        substrings ('photos', 'grandpa', 'sandpaper')."""
+        return re.search(rf"\b{re.escape(keyword)}\b", meta_text) is not None
+
+    @staticmethod
     def _content_supports_substantive_policy_claim(text: str) -> bool:
         """True if the body matches the same keyword model used for non-LLM content routing.
 
@@ -418,6 +424,7 @@ class DocumentClassifier(LLMUsageTrackingMixin):
                     "user agreement",
                     "service agreement",
                     "terms & conditions",
+                    "tos",
                     "conditions of use",
                     "nutzungsbedingungen",  # German
                     "conditions d'utilisation",  # French
@@ -501,7 +508,7 @@ class DocumentClassifier(LLMUsageTrackingMixin):
             }
 
             for doc_type, keywords in meta_keywords.items():
-                if any(keyword in combined_meta for keyword in keywords):
+                if any(self._meta_has_keyword(combined_meta, kw) for kw in keywords):
                     # Check if content is substantial (not just a navigation page)
                     if len(text) > 300:
                         logger.debug(f"found metadata keyword matches: classified as {doc_type}")

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -2057,7 +2057,9 @@ class ClauseaCrawler:
             status_code=raw.status_code,
         )
 
-    _MD_INLINE_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+[\"'][^\"']*[\"'])?\s*\)")
+    _MD_INLINE_LINK_RE = re.compile(
+        r"""\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+(?:"[^"]*"|'[^']*'))?\s*\)"""
+    )
     _MD_AUTOLINK_RE = re.compile(r"<(https?://[^>\s]+)>")
 
     def _resolve_md_link(self, base_url: str, href: str) -> str | None:

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -2013,7 +2013,7 @@ class ClauseaCrawler:
             return await self._extract_binary_content(raw, url)
 
         if "markdown" in ct:
-            return self._extract_markdown_content(raw, url)
+            return await asyncio.to_thread(self._extract_markdown_content, raw, url)
         if "text/html" in ct:
             # BeautifulSoup parsing + markdownify conversion are CPU-bound and can
             # block the event loop for hundreds of ms on large pages.  Offload to a
@@ -2057,7 +2057,7 @@ class ClauseaCrawler:
             status_code=raw.status_code,
         )
 
-    _MD_INLINE_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+\"[^\"]*\")?\s*\)")
+    _MD_INLINE_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+[\"'][^\"']*[\"'])?\s*\)")
     _MD_AUTOLINK_RE = re.compile(r"<(https?://[^>\s]+)>")
 
     def _resolve_md_link(self, base_url: str, href: str) -> str | None:
@@ -2097,9 +2097,13 @@ class ClauseaCrawler:
                 discovered_links.append({"url": resolved, "text": ""})
 
         title = ""
+        in_fence = False
         for line in body.splitlines():
             stripped = line.strip()
-            if stripped.startswith("#"):
+            if stripped.startswith(("```", "~~~")):
+                in_fence = not in_fence
+                continue
+            if not in_fence and stripped.startswith("#"):
                 title = stripped.lstrip("#").strip()
                 break
         if not title:

--- a/packages/backend/tests/unit/analyzers/document_classifier_test.py
+++ b/packages/backend/tests/unit/analyzers/document_classifier_test.py
@@ -247,6 +247,35 @@ class TestMetadataClassification:
             metadata={"title": "Signal >> Blog >> Research on your terms"},
         )
         assert result["classification"] != "terms_of_service"
+        assert result["is_policy_document"] is False
+
+    @pytest.mark.asyncio
+    async def test_tos_token_still_matches_as_whole_word(
+        self, classifier: DocumentClassifier
+    ) -> None:
+        """Word-boundary matching keeps 'ToS' working for genuine terms pages."""
+        result = await classifier.classify_document(
+            url="https://example.com/legal/doc789",
+            text="By using our services you agree to these terms. " * 20,
+            metadata={"title": "ToS"},
+        )
+        assert result["classification"] == "terms_of_service"
+
+    @pytest.mark.asyncio
+    async def test_short_tokens_do_not_substring_match(
+        self, classifier: DocumentClassifier
+    ) -> None:
+        """'photos' must not match 'tos'; 'grandpa' must not match 'dpa'."""
+        for title in ("My Photos Gallery", "Grandpa's recipes"):
+            result = await classifier.classify_document(
+                url="https://example.com/gallery/page",
+                text="Home About menu. A collection of nice things to look at. " * 4,
+                metadata={"title": title},
+            )
+            assert result["classification"] not in (
+                "terms_of_service",
+                "data_processing_agreement",
+            ), title
 
     @pytest.mark.asyncio
     async def test_metadata_short_content_rejected(self, classifier: DocumentClassifier) -> None:

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -586,3 +586,28 @@ async def test_extract_markdown_content_type_kept_and_links_followed():
     urls = {link["url"] for link in page.discovered_links}
     assert any("github-privacy-statement" in u for u in urls)  # relative link resolved
     assert any("github-corporate-terms-of-service" in u for u in urls)  # autolink captured
+
+
+@pytest.mark.asyncio
+async def test_markdown_title_skips_code_fence_and_single_quoted_link():
+    from src.crawler import StaticFetchResult
+
+    crawler = ClauseaCrawler(allowed_domains=["example.com"])
+    body = (
+        "```bash\n# this is a shell comment, not the title\n```\n\n"
+        "# Real Privacy Policy\n\n"
+        "We collect personal data and respect your rights. "
+        * 10
+        + "See [details](https://example.com/legal/data 'Data details').\n"
+    )
+    raw = StaticFetchResult(
+        url="https://example.com/legal/privacy",
+        status_code=200,
+        content_type="text/markdown",
+        body=body,
+    )
+    page = await crawler._extract_page_content(raw, "https://example.com/legal/privacy")
+    assert page is not None
+    assert page.title == "Real Privacy Policy"  # not the code-fence comment
+    urls = {link["url"] for link in page.discovered_links}
+    assert any(u.endswith("/legal/data") for u in urls)  # single-quoted title parsed


### PR DESCRIPTION
Follow-up addressing the Gemini code-assist reviews on #91 and #92 (which were merged before the reviews landed).

## Classifier (#91 review)
- **Word-boundary metadata matching** instead of removing tokens. Short tokens were substring-vulnerable: `dpa`→"gran**dpa**"/"san**dpa**per", `tos`→"pho**tos**". `_meta_has_keyword` now matches whole words (`\b…\b`), so `tos` is **restored** safely and `dpa`/`gdpr`/`coppa` stop false-matching.
- Bare `terms` stays removed — word boundaries don't fix the idiom "on your **terms**" (it's a whole word there).
- Tests: assert `is_policy_document is False` for the blog; add `tos`-still-matches and `photos`/`grandpa`-don't-match cases.

## Markdown (#92 review)
- `_extract_markdown_content` now runs via `asyncio.to_thread` (CPU-bound regex shouldn't block the event loop — matches the HTML path).
- Inline-link regex accepts **single-quoted** link titles `[t](url 'title')`.
- Title extraction **skips `#` lines inside fenced code blocks** (``` / ~~~).
- Test: fenced-code comment is not picked as title; single-quoted link is parsed.

Suites: classifier + crawler 202→ all green (added regressions).