### PR TITLE
fix(worker): cap concurrency to memory-safe ceiling + bounded shutdown (OOM stabilization)

### DIFF
--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -23,9 +23,17 @@ from src.services.service_factory import create_pipeline_service
 
 logger = get_logger(__name__)
 
-_CONCURRENCY = max(1, int(os.getenv("PIPELINE_WORKER_CONCURRENCY", "3")))
+# One replica shares a single Camoufox/Firefox; each concurrent crawl can render heavy
+# SPA DOMs into memory. Above a handful of concurrent jobs the container OOM-kills (it died
+# at ~13). Cap the effective concurrency to a memory-safe ceiling regardless of the env so a
+# too-high setting can't crashloop the worker. Raise only with more RAM or more replicas.
+_SAFE_CONCURRENCY_CEILING = 4
+_CONCURRENCY = max(
+    1, min(int(os.getenv("PIPELINE_WORKER_CONCURRENCY", "3")), _SAFE_CONCURRENCY_CEILING)
+)
 _POLL_SECONDS = float(os.getenv("PIPELINE_WORKER_POLL_SECONDS", "3"))
 _STALE_SWEEP_SECONDS = float(os.getenv("PIPELINE_WORKER_STALE_SWEEP_SECONDS", "300"))
+_SHUTDOWN_GRACE_SECONDS = float(os.getenv("PIPELINE_WORKER_SHUTDOWN_GRACE", "20"))
 
 
 async def _sweep_stale(repo: PipelineRepository) -> None:
@@ -104,8 +112,23 @@ async def main() -> None:
         task.add_done_callback(running.discard)
 
     if running:
-        logger.info("Shutdown: waiting for %d in-flight job(s) to finish", len(running))
-        await asyncio.gather(*running, return_exceptions=True)
+        logger.info(
+            "Shutdown: waiting up to %.0fs for %d in-flight job(s) to finish",
+            _SHUTDOWN_GRACE_SECONDS,
+            len(running),
+        )
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*running, return_exceptions=True),
+                timeout=_SHUTDOWN_GRACE_SECONDS,
+            )
+        except TimeoutError:
+            # Don't get SIGKILLed mid-crawl (which leaks the browser and leaves zombie
+            # `crawling` jobs). Cancel now; the stale-sweep reclaims them on next boot.
+            logger.warning("Shutdown grace exceeded; cancelling %d in-flight job(s)", len(running))
+            for task in running:
+                task.cancel()
+            await asyncio.gather(*running, return_exceptions=True)
     close_motor_client()
     logger.info("Pipeline worker stopped")
 


### PR DESCRIPTION
## Incident
The Railway worker went **down ~90 minutes** tonight — no doc writes, no job claims; 15 jobs stuck zombie-`crawling` (heartbeats 2h+ stale, `attempts` up to 6) on render-heavy SPA sites (shein, notion, doordash, airbnb). The catalog fully stalled.

## Root cause (challenger-team reliability + crawler review)
Single Railway replica ran **~13 concurrent jobs**, all feeding **one shared Camoufox/Firefox** heavy SPA DOMs (`page.content()` materializes the full rendered DOM repeatedly). The container **OOM-killed (SIGKILL)** — which took the **in-process self-heal** (stale-sweep + stall guard) down with it, so nothing reaped the zombies. Unlimited retries then re-claimed the same memory-heavy jobs on each boot → crashloop (the climbing `attempts`).

## Fix (stop the bleeding; deployable in code — can't touch Railway env)
- **Cap effective concurrency** to `_SAFE_CONCURRENCY_CEILING=4` regardless of `PIPELINE_WORKER_CONCURRENCY`, so a too-high env can't OOM-crashloop a single replica. Survival over throughput (we're recall-over-speed anyway).
- **Bounded graceful shutdown**: drain in-flight jobs up to 20s, then cancel — so a deploy SIGTERM stops cleanly instead of being SIGKILLed mid-crawl (the zombie-`crawling` + leaked-browser signature).

Merging this redeploys the worker, whose boot-sweep reaps the current zombies and resumes draining the 100+ backlog **at a survivable concurrency**.

## Deliberately NOT changed (honoring prior product decisions)
- No wall-clock ceiling — the stall guard (900s no-progress) stays the liveness signal (you rejected an arbitrary ceiling).
- Retries stay unlimited — OOM was the cause, not the retry policy.

## Follow-ups (separate PRs, per the review)
1. Move stale-sweep to an **external reaper** (lease / visibility-timeout) so recovery survives worker death.
2. **Tear down the browser on cancel** (reclaim memory; today cancel only closes the page).
3. **Reduce render reliance** — block/status-aware render gating + "static-was-complete" escape hatch (renders are the OOM source *and* the throughput bottleneck).
4. **Worker observability** — `/healthz` + metrics so a death is visible in minutes, not 90.

Verify-premise note: OOM is inferred from code shape + symptoms; confirm via Railway OOMKilled exit codes for the window. Both fixes help whether it was OOM or deploy-orphan.