### PR TITLE
fix(crawler): mirror-subdomain regex dropped legit hyphenated subdomains

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -273,7 +273,10 @@ async def _block_heavy_assets(page: Page) -> None:
 
 # Non-production mirror subdomains (docs-internal, staging., preview.) serve near-identical
 # copies of prod pages — crawling them just duplicates documents. Matched on the subdomain only.
-_MIRROR_SUBDOMAIN_RE = re.compile(r"(?:^|[.-])(?:internal|staging|preview)(?:$|[.-])")
+# The trailing boundary is "." or end-of-label, NOT "-": a hyphen there over-matches legit
+# subdomains that merely start with the token (preview-blog, staging-guide, my-internal-tool),
+# silently dropping real pages — recall loss we won't trade for dedup.
+_MIRROR_SUBDOMAIN_RE = re.compile(r"(?:^|[.-])(?:internal|staging|preview)(?:$|\.)")
 
 # Hard cap on a Camoufox launch. The launch (__aenter__ spawns Firefox) has no internal
 # timeout, so a stuck launch — common when two instances start at once in a constrained

--- a/packages/backend/tests/unit/crawler/url_scorer_test.py
+++ b/packages/backend/tests/unit/crawler/url_scorer_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.crawler import ClauseaCrawler, URLScorer
+from src.crawler import _MIRROR_SUBDOMAIN_RE, ClauseaCrawler, URLScorer
 
 
 class TestURLScorerGlossaryGuard:
@@ -377,3 +377,20 @@ class TestMirrorSubdomainExclusion:
             "https://docs.github.com/en/site-policy",
             1,
         )
+
+    def test_regex_catches_real_mirrors(self) -> None:
+        for subdomain in ("docs-internal", "staging", "preview", "preview.staging"):
+            assert _MIRROR_SUBDOMAIN_RE.search(subdomain), subdomain
+
+    def test_regex_spares_legit_subdomains_with_token_prefix(self) -> None:
+        # Hyphenated subdomains that merely start with a trigger token are legitimate, not
+        # mirrors — rejecting them silently drops real pages.
+        for subdomain in (
+            "preview-blog",
+            "staging-guide",
+            "my-internal-tool",
+            "internal-docs",
+            "international",
+            "www",
+        ):
+            assert not _MIRROR_SUBDOMAIN_RE.search(subdomain), subdomain


### PR DESCRIPTION
## Problem (recall regression)

#95 added `_MIRROR_SUBDOMAIN_RE` to skip non-prod mirror subdomains (`docs-internal`, `staging.`, `preview.`). It runs — not a no-op — but its **trailing boundary** `[.-]` treats a hyphen as a label break, so any subdomain *starting* with a trigger token then a hyphen is matched and rejected **before any content check**, logged only at debug:

| subdomain | #95 | should be |
|---|---|---|
| `docs-internal` | rejected | rejected ✓ |
| `staging` / `preview` | rejected | rejected ✓ |
| `my-internal-tool` | **rejected** | allowed |
| `staging-guide` | **rejected** | allowed |
| `preview-blog` | **rejected** | allowed |
| `internal-docs` | **rejected** | allowed |

Silently dropping real pages is exactly the recall-over-speed trade we don't make.

## Fix

Trailing boundary → `.` or end-of-label only (`(?:$|\.)`). The discriminator is that real mirror tokens sit at the *end* of the label (`docs-internal`, `staging`), while false positives are `token-something`. Real mirrors still match; token-prefixed legit subdomains are spared.

## Test

Strengthened to assert the **sparing** (`preview-blog`, `my-internal-tool`, `internal-docs`, `international` …) and that real mirrors still match — a behavior assertion that would have failed on the old regex, not just "the regex exists."

## How it was found

Behavioral audit of the fast-merged crawler batch (#90/#91/#92/#93/#95) after #97 — proving each change *actually fires* on real input rather than passing a registration-only test. The other four checked out (markdown routing, auth/redirect scoring, word-boundary ToS keywords all genuinely correct); this was the one real defect.

`ruff` + `ty` clean, 32 url_scorer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)