### PR TITLE
fix(crawler): extract real policy body, not the consent widget

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -271,6 +271,27 @@ async def _block_heavy_assets(page: Page) -> None:
     await page.route(_BLOCKED_ASSETS_RE, _abort)
 
 
+# Consent / cookie-management widgets (OneTrust, TrustArc, Cookiebot, Osano, Usercentrics,
+# Didomi, and Shein's own cmp_/_shein_privacy) embed a hidden block whose class often contains
+# "privacy", so a "[class*=privacy]" selector latches onto the 2-3k-char consent widget instead
+# of the real policy body. Excluded from content selection — but only when the text is actually
+# consent UI (≥2 markers), so a genuine Cookie Policy page is never dropped.
+_CONSENT_CONTAINER_RE = re.compile(
+    r"(onetrust|ot-sdk|ot-pc|truste|trustarc|cookiebot|osano|usercentrics|didomi|klaro|"
+    r"cookie-?consent|consent-?(?:banner|manager|preference)|privacy-?(?:preference|settings)|"
+    r"cmp[-_]|_shein_privacy)",
+    re.IGNORECASE,
+)
+_CONSENT_TEXT_MARKERS = (
+    "manage consent",
+    "strictly necessary cookies",
+    "reject all",
+    "confirm my choices",
+    "privacy settings center",
+    "privacy preference center",
+    "store or retrieve information on your browser",
+)
+
 # Non-production mirror subdomains (docs-internal, staging., preview.) serve near-identical
 # copies of prod pages — crawling them just duplicates documents. Matched on the subdomain only.
 # The trailing boundary is "." or end-of-label, NOT "-": a hyphen there over-matches legit
@@ -2488,6 +2509,7 @@ class ClauseaCrawler:
         best_text_len = 0
         for selector in selectors:
             matches = self._top_level_elements(soup.select(selector))
+            matches = [el for el in matches if not self._is_consent_container(el)]
             if not matches:
                 continue
             combined_text_len = sum(len(el.get_text(" ", strip=True)) for el in matches)
@@ -2516,6 +2538,13 @@ class ClauseaCrawler:
             ["nav", "header", "footer", "aside", "form", "button", "input", "select", "textarea"]
         ):
             tag.decompose()
+
+        # Drop consent/cookie-management widgets the boilerplate pattern below misses (vendor
+        # classes like _shein_privacy / cmp_). Done before that pass so the legal-container
+        # guard can't preserve them.
+        for tag in list(cleaned.find_all(True)):
+            if tag.attrs is not None and self._is_consent_container(tag):
+                tag.decompose()
 
         # Remove common boilerplate containers (cookie banners, menus, popups, etc.).
         boilerplate_pattern = re.compile(
@@ -2548,6 +2577,21 @@ class ClauseaCrawler:
                 tag.decompose()
 
         return cleaned
+
+    @classmethod
+    def _is_consent_container(cls, element: Any) -> bool:
+        """True when an element is a cookie/consent widget (vendor class + ≥2 consent markers).
+
+        The text corroboration keeps a genuine Cookie Policy page (prose, no widget controls)
+        from being mistaken for the consent UI.
+        """
+        if getattr(element, "attrs", None) is None:
+            return False
+        attrs = " ".join(str(v) for v in (element.get("id", ""), element.get("class", "")))
+        if not _CONSENT_CONTAINER_RE.search(attrs):
+            return False
+        text_lower = element.get_text(" ", strip=True).lower()
+        return sum(marker in text_lower for marker in _CONSENT_TEXT_MARKERS) >= 2
 
     @staticmethod
     def _is_substantive_legal_policy_container(attrs: str, text: str) -> bool:

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -2543,6 +2543,8 @@ class ClauseaCrawler:
         # classes like _shein_privacy / cmp_). Done before that pass so the legal-container
         # guard can't preserve them.
         for tag in list(cleaned.find_all(True)):
+            if tag.parent is None:  # already removed with a decomposed ancestor
+                continue
             if tag.attrs is not None and self._is_consent_container(tag):
                 tag.decompose()
 
@@ -2587,7 +2589,12 @@ class ClauseaCrawler:
         """
         if getattr(element, "attrs", None) is None:
             return False
-        attrs = " ".join(str(v) for v in (element.get("id", ""), element.get("class", "")))
+        class_value = element.get("class")
+        if isinstance(class_value, list):
+            class_str = " ".join(str(cls) for cls in class_value)
+        else:
+            class_str = str(class_value or "")
+        attrs = f"{element.get('id') or ''} {class_str}"
         if not _CONSENT_CONTAINER_RE.search(attrs):
             return False
         text_lower = element.get_text(" ", strip=True).lower()

--- a/packages/backend/tests/unit/crawler/consent_extraction_test.py
+++ b/packages/backend/tests/unit/crawler/consent_extraction_test.py
@@ -1,0 +1,65 @@
+"""Guards content extraction against consent/cookie widgets winning over the real body.
+
+A consent widget's class often contains "privacy", so a `[class*=privacy]` selector latched
+onto a ~2.8k-char OneTrust/Shein consent block and discarded the ~48k real policy. These tests
+assert the real body wins, clean pages are unchanged, and a genuine Cookie Policy is preserved.
+"""
+
+from bs4 import BeautifulSoup
+
+from src.crawler import ClauseaCrawler
+
+REAL_POLICY = (
+    "Privacy Policy. We collect personal data including your name and email. "
+    "The information we collect is used to provide the service. We share information with "
+    "third parties. You have rights to access and delete your data. Retention periods apply. "
+) * 6
+
+CONSENT_WIDGET = (
+    "Privacy settings center. Manage Consent Preferences. Strictly Necessary Cookies. "
+    "Reject All. Confirm My Choices. Store or retrieve information on your browser."
+)
+
+
+def _text(html: str) -> str:
+    crawler = ClauseaCrawler()
+    return (
+        crawler._extract_main_content_soup(BeautifulSoup(html, "html.parser"))
+        .get_text(" ", strip=True)
+        .lower()
+    )
+
+
+def test_real_body_wins_over_consent_widget() -> None:
+    # Consent block carries a privacy-ish class; real body sits in a plain #app with no
+    # recognized content class — exactly the Shein shape that returned only the widget.
+    html = f"""
+    <html><body>
+      <div class="_shein_privacy_preference cmp_c_1200">{CONSENT_WIDGET}</div>
+      <div id="app"><div id="in-app">{REAL_POLICY}</div></div>
+    </body></html>
+    """
+    text = _text(html)
+    assert "we collect personal data" in text
+    assert "reject all" not in text
+    assert "strictly necessary cookies" not in text
+
+
+def test_clean_page_without_consent_is_unchanged() -> None:
+    html = f"<html><body><main>{REAL_POLICY}</main></body></html>"
+    text = _text(html)
+    assert "we collect personal data" in text
+    assert "your data" in text
+
+
+def test_consent_class_with_real_prose_is_preserved() -> None:
+    # Class matches the consent-vendor regex (privacy-settings) but the text is real policy
+    # prose with no widget controls (<2 markers) — the text corroboration must keep it.
+    prose = (
+        "This page explains how we use cookies and similar technologies to recognise you. "
+        "We collect personal data via cookies. You have rights regarding this information "
+        "and its retention. We share information with third parties. "
+    ) * 5
+    html = f'<html><body><div class="privacy-settings-doc">{prose}</div></body></html>'
+    text = _text(html)
+    assert "we collect personal data via cookies" in text


### PR DESCRIPTION
## Problem

Content extraction was discarding real policy bodies in favor of a hidden cookie-consent widget. A consent block's class often contains `privacy`, so the `[class*=privacy]` content selector latched onto a ~2.8k-char OneTrust/Shein consent widget ("Strictly Necessary Cookies / Reject All / Confirm My Choices") while the **~48k-char real policy body** — in a plain `#app` with no recognized content class — matched no selector and was thrown away. shein's privacy policy was being stored as 2 867 chars of consent UI.

Found while auditing why shein yields only ~3 documents; this is one of several fixes (discovery/dedup/domain-scoping land separately).

## Fix

`_extract_main_content_soup`: exclude **text-corroborated** consent widgets from candidate selection and strip them from the body fallback. A container counts as a consent widget only if its id/class matches a vendor pattern (OneTrust/TrustArc/Cookiebot/Osano/Usercentrics/Didomi/Klaro + Shein `cmp_`/`_shein_privacy`) **and** its text has ≥2 consent-UI markers — so a genuine Cookie Policy page (prose, no widget controls) is never dropped.

## Validation (local render+extract basket — behavior, not assertion)

| page | before | after |
|---|---|---|
| shein privacy | 2 867 (consent shell) | **47 841 (real policy)** |
| shein terms | 15 523 (+embedded consent) | 12 655 (consent stripped, terms intact) |
| notion privacy | 34 827 | 34 827 (unchanged) |
| doordash privacy | 46 675 | 46 675 (unchanged) |
| clausea privacy | 6 357 | 6 357 (unchanged) |

Clean (`consent=0`) pages are byte-identical — the fix only fires on real consent widgets. New unit tests assert the real body wins, clean pages are unchanged, and a consent-class element with real prose is preserved. 194 crawler tests + ruff + ty pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)