### PR TITLE
fix(pipeline): union crawl-seed domains into allowed_domains

### DIFF
--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -64,7 +64,7 @@ from src.analyzers.locale_analyzer import LocaleAnalyzer
 from src.analyzers.region_detector import RegionDetector
 from src.core.database import db_session
 from src.core.logging import get_logger
-from src.crawler import ClauseaCrawler, CrawlResult
+from src.crawler import _TLD_EXTRACT, ClauseaCrawler, CrawlResult
 from src.llm import SupportedModel, acompletion_with_fallback
 from src.models.crawl import CrawlSession
 from src.models.document import Document, coerce_doc_type_from_classifier
@@ -834,6 +834,23 @@ class PolicyDocumentPipeline:
             )
             return []
 
+    @staticmethod
+    def _allowed_domains_for_product(product: Product) -> list[str]:
+        """Product domains unioned with the registered domain of every crawl seed.
+
+        A seed on a different registered domain (e.g. www.sheingroup.com seeded for a product
+        whose domain is shein.com) is otherwise rejected by the domain gate, dropping a whole
+        policy source. Deduped by registered-domain name, matching is_allowed_domain.
+        """
+        domains = list(product.domains or [])
+        seen = {_TLD_EXTRACT(d).domain for d in domains}
+        for seed in product.crawl_base_urls or []:
+            ext = _TLD_EXTRACT(seed)
+            if ext.domain and ext.domain not in seen:
+                seen.add(ext.domain)
+                domains.append(f"{ext.domain}.{ext.suffix}" if ext.suffix else ext.domain)
+        return domains
+
     def _create_crawler_for_product(
         self,
         product: Product,
@@ -878,7 +895,7 @@ class PolicyDocumentPipeline:
             delay_between_requests=self.delay_between_requests,
             delay_jitter=config.crawler.rate_limit_jitter,
             timeout=self.timeout,
-            allowed_domains=product.domains,
+            allowed_domains=self._allowed_domains_for_product(product),
             respect_robots_txt=self.respect_robots_txt,
             user_agent=self.user_agent,
             follow_external_links=False,

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -55,6 +55,7 @@ from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import urlparse
 
+import tldextract
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 
@@ -64,7 +65,7 @@ from src.analyzers.locale_analyzer import LocaleAnalyzer
 from src.analyzers.region_detector import RegionDetector
 from src.core.database import db_session
 from src.core.logging import get_logger
-from src.crawler import _TLD_EXTRACT, ClauseaCrawler, CrawlResult
+from src.crawler import ClauseaCrawler, CrawlResult
 from src.llm import SupportedModel, acompletion_with_fallback
 from src.models.crawl import CrawlSession
 from src.models.document import Document, coerce_doc_type_from_classifier
@@ -80,6 +81,10 @@ from src.utils.perf import log_memory_usage, memory_monitor_task
 load_dotenv()
 
 logger = get_logger(__name__)
+
+# Offline extractor (no live suffix-list fetch), matching the crawler's domain matching.
+_TLD_EXTRACT = tldextract.TLDExtract(suffix_list_urls=())
+
 logger_discovery = get_logger(__name__, component="pipeline:discovery")
 logger_analysis = get_logger(__name__, component="pipeline:analysis")
 logger_storage = get_logger(__name__, component="pipeline:storage")

--- a/packages/backend/tests/unit/pipeline/allowed_domains_test.py
+++ b/packages/backend/tests/unit/pipeline/allowed_domains_test.py
@@ -19,9 +19,7 @@ def test_seed_on_other_registered_domain_is_unioned() -> None:
         ],
     )
     allowed = _fn(product)
-    domains = {d.lower() for d in allowed}
-    assert "shein.com" in domains
-    assert any("sheingroup" in d for d in domains)
+    assert set(allowed) == {"shein.com", "sheingroup.com"}
 
 
 def test_same_domain_seeds_do_not_duplicate() -> None:
@@ -33,7 +31,7 @@ def test_same_domain_seeds_do_not_duplicate() -> None:
         crawl_base_urls=["https://m.shein.com/a", "https://us.shein.com/b"],
     )
     allowed = _fn(product)
-    assert sum("shein" in d for d in allowed) == 1
+    assert allowed == ["shein.com"]
 
 
 def test_empty_seeds_returns_product_domains() -> None:

--- a/packages/backend/tests/unit/pipeline/allowed_domains_test.py
+++ b/packages/backend/tests/unit/pipeline/allowed_domains_test.py
@@ -1,0 +1,41 @@
+"""A crawl seed on a different registered domain must be added to allowed_domains, or the
+domain gate rejects it and a whole policy source (e.g. shein's corporate site) is dropped."""
+
+from src.models.product import Product
+from src.pipeline import PolicyDocumentPipeline
+
+_fn = PolicyDocumentPipeline._allowed_domains_for_product
+
+
+def test_seed_on_other_registered_domain_is_unioned() -> None:
+    product = Product(
+        id="p1",
+        slug="shein",
+        name="Shein",
+        domains=["shein.com"],
+        crawl_base_urls=[
+            "https://m.shein.com/us/PRIVACY-POLICY-a-1061.html",
+            "https://www.sheingroup.com/privacy-policy",
+        ],
+    )
+    allowed = _fn(product)
+    domains = {d.lower() for d in allowed}
+    assert "shein.com" in domains
+    assert any("sheingroup" in d for d in domains)
+
+
+def test_same_domain_seeds_do_not_duplicate() -> None:
+    product = Product(
+        id="p2",
+        slug="x",
+        name="X",
+        domains=["shein.com"],
+        crawl_base_urls=["https://m.shein.com/a", "https://us.shein.com/b"],
+    )
+    allowed = _fn(product)
+    assert sum("shein" in d for d in allowed) == 1
+
+
+def test_empty_seeds_returns_product_domains() -> None:
+    product = Product(id="p3", slug="x", name="X", domains=["acme.com"], crawl_base_urls=[])
+    assert _fn(product) == ["acme.com"]


### PR DESCRIPTION
## Problem

`allowed_domains` was just `product.domains`. When a product's `crawl_base_urls` includes a seed on a *different registered domain* — e.g. `www.sheingroup.com/privacy-policy` seeded for shein (domain `shein.com`) — `is_allowed_domain` rejects it (`shein` ≠ `sheingroup`), so the seed page **and every link off it** are dropped. A whole policy source (corporate privacy, subprocessor lists) is silently lost.

One of the shein 3→~14 recall fixes (extraction landed in #100; convergence + non-English land separately).

## Fix

Union each crawl-seed's registered domain into `allowed_domains`, deduped by registered-domain name (matching `is_allowed_domain`'s comparison). Strictly *widens* scope, and only to domains we already explicitly seed — `follow_external_links` stays off, so it can't wander.

Pure helper `_allowed_domains_for_product`, unit-tested: seed on another registered domain is added, same-domain seeds don't duplicate, no seeds → product domains unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)