### PR TITLE
Crawler discovery recall overhaul + bounded retry/cancellation + probes

### DIFF
--- a/packages/backend/scripts/content_probe.py
+++ b/packages/backend/scripts/content_probe.py
@@ -1,0 +1,64 @@
+"""Fetch each URL as a single page (no link-following) and report extracted content size.
+
+Used to verify recall-neutrality of browser-fetch changes: run on baseline, run again on a
+branch, diff the content lengths per URL. A change is recall-safe only if policy pages keep
+(roughly) the same extracted text. Read-only; no DB, no LLM.
+
+Usage:
+    uv run python scripts/content_probe.py <url> [<url> ...]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+from urllib.parse import urlparse
+
+from src.core.logging import setup_logging
+from src.crawler import ClauseaCrawler
+
+
+async def fetch_one(url: str) -> dict:
+    domain = urlparse(url).netloc
+    crawler = ClauseaCrawler(
+        max_depth=0,  # seed only, no link-following
+        max_pages=1,
+        allowed_domains=[domain],
+        respect_robots_txt=True,
+        follow_external_links=False,
+        min_legal_score=0,
+        strategy="best_first",
+        use_browser=True,
+        browser_concurrency=1,
+    )
+    start = time.perf_counter()
+    try:
+        results = await crawler.crawl(url)
+    except Exception as exc:  # noqa: BLE001 - probe must report, not crash
+        return {"url": url, "ok": False, "error": repr(exc)}
+    elapsed = time.perf_counter() - start
+    if not results:
+        return {"url": url, "ok": False, "elapsed_s": round(elapsed, 1), "text_len": 0}
+    r = results[0]
+    return {
+        "url": url,
+        "ok": r.success,
+        "elapsed_s": round(elapsed, 1),
+        "status": r.status_code,
+        "title": (r.title or "")[:80],
+        "text_len": len(r.content or ""),
+        "markdown_len": len(r.markdown or ""),
+    }
+
+
+async def main() -> None:
+    setup_logging()
+    for url in sys.argv[1:]:
+        result = await fetch_one(url)
+        print("CONTENT_PROBE " + json.dumps(result))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/backend/scripts/crawl_probe.py
+++ b/packages/backend/scripts/crawl_probe.py
@@ -17,6 +17,7 @@ import sys
 import time
 from collections import Counter
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from src.core.logging import setup_logging
@@ -67,21 +68,18 @@ def _policy_page_details(results: list[CrawlResult]) -> list[dict[str, object]]:
     return details
 
 
-def _compare_probe_runs(current: dict[str, object], baseline_path: str) -> dict[str, object]:
-    baseline = json.loads(Path(baseline_path).read_text())
+def _len_map(details: Any) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for item in details or []:
+        if isinstance(item, dict) and item.get("url"):
+            out[str(item["url"])] = int(item.get("content_length", 0))
+    return out
 
-    current_details = current.get("policy_page_details", [])
-    baseline_details = baseline.get("policy_page_details", [])
-    current_map = {
-        str(item["url"]): int(item.get("content_length", 0))
-        for item in current_details
-        if isinstance(item, dict) and item.get("url")
-    }
-    baseline_map = {
-        str(item["url"]): int(item.get("content_length", 0))
-        for item in baseline_details
-        if isinstance(item, dict) and item.get("url")
-    }
+
+def _compare_probe_runs(current: dict[str, Any], baseline_path: str) -> dict[str, object]:
+    baseline = json.loads(Path(baseline_path).read_text())
+    current_map = _len_map(current.get("policy_page_details"))
+    baseline_map = _len_map(baseline.get("policy_page_details"))
 
     current_urls = set(current_map)
     baseline_urls = set(baseline_map)
@@ -203,8 +201,8 @@ async def main() -> None:
     if write_path:
         Path(write_path).write_text(json.dumps(summary, indent=2) + "\n")
     print("PROBE_RESULT " + json.dumps(summary))
-    if compare_path and isinstance(summary.get("comparison"), dict):
-        comparison = summary["comparison"]
+    comparison = summary.get("comparison")
+    if compare_path and isinstance(comparison, dict):
         if not comparison.get("verification_gate_passed", False):
             raise SystemExit(2)
 

--- a/packages/backend/scripts/crawl_probe.py
+++ b/packages/backend/scripts/crawl_probe.py
@@ -1,0 +1,213 @@
+"""Measure real crawl behavior for one seed URL + strategy. Read-only; no DB, no LLM.
+
+Answers the only question that matters before touching the crawler: left to its own
+devices, does a crawl terminate quickly (converged / frontier exhausted) or does it keep
+climbing until it hits the page cap (wander)? Runs the actual ClauseaCrawler with the same
+knobs the pipeline uses, under a hard wall-clock timeout, and prints a JSON summary.
+
+Usage:
+    uv run python scripts/crawl_probe.py <seed_url> <strategy> <min_legal_score> <max_depth> <max_pages> <timeout_s> [browser_concurrency] [--write <result_json>] [--compare <baseline_json>]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from urllib.parse import urlparse
+
+from src.core.logging import setup_logging
+from src.crawler import ClauseaCrawler, CrawlResult
+
+
+def _parse_optional_args(argv: list[str]) -> tuple[int, str | None, str | None]:
+    browser_concurrency = 4
+    write_path: str | None = None
+    compare_path: str | None = None
+    idx = 0
+    while idx < len(argv):
+        token = argv[idx]
+        if token == "--write" and idx + 1 < len(argv):
+            write_path = argv[idx + 1]
+            idx += 2
+            continue
+        if token == "--compare" and idx + 1 < len(argv):
+            compare_path = argv[idx + 1]
+            idx += 2
+            continue
+        # Backward compatible optional positional browser_concurrency.
+        if idx == 0:
+            browser_concurrency = int(token)
+            idx += 1
+            continue
+        raise ValueError(f"Unknown argument: {token}")
+    return browser_concurrency, write_path, compare_path
+
+
+def _policy_page_details(results: list[CrawlResult]) -> list[dict[str, object]]:
+    details: list[dict[str, object]] = []
+    for result in results:
+        if not result.success:
+            continue
+        legal_score = float(result.legal_score or 0.0)
+        if legal_score < 0.2:
+            continue
+        details.append(
+            {
+                "url": result.url,
+                "legal_score": round(legal_score, 3),
+                "content_length": len(result.content or ""),
+                "title": result.title or "",
+            }
+        )
+    details.sort(key=lambda item: (-float(item["legal_score"]), -int(item["content_length"])))
+    return details
+
+
+def _compare_probe_runs(current: dict[str, object], baseline_path: str) -> dict[str, object]:
+    baseline = json.loads(Path(baseline_path).read_text())
+
+    current_details = current.get("policy_page_details", [])
+    baseline_details = baseline.get("policy_page_details", [])
+    current_map = {
+        str(item["url"]): int(item.get("content_length", 0))
+        for item in current_details
+        if isinstance(item, dict) and item.get("url")
+    }
+    baseline_map = {
+        str(item["url"]): int(item.get("content_length", 0))
+        for item in baseline_details
+        if isinstance(item, dict) and item.get("url")
+    }
+
+    current_urls = set(current_map)
+    baseline_urls = set(baseline_map)
+    missing_policy_urls = sorted(baseline_urls - current_urls)
+    new_policy_urls = sorted(current_urls - baseline_urls)
+
+    # Flag major content truncation for URLs present in both runs.
+    # 0.7 keeps mild extraction variance out of the alert channel.
+    regressions: list[dict[str, object]] = []
+    for url in sorted(current_urls & baseline_urls):
+        base_len = baseline_map[url]
+        curr_len = current_map[url]
+        if base_len >= 200 and curr_len < int(base_len * 0.7):
+            regressions.append(
+                {
+                    "url": url,
+                    "baseline_length": base_len,
+                    "current_length": curr_len,
+                    "ratio": round(curr_len / base_len, 3) if base_len else 1.0,
+                }
+            )
+
+    gate_passed = not missing_policy_urls and not regressions
+    return {
+        "baseline_path": baseline_path,
+        "baseline_policy_pages": len(baseline_urls),
+        "current_policy_pages": len(current_urls),
+        "missing_policy_urls": missing_policy_urls,
+        "new_policy_urls": new_policy_urls,
+        "content_length_regressions": regressions,
+        "verification_gate_passed": gate_passed,
+    }
+
+
+async def main() -> None:
+    if len(sys.argv) < 7:
+        raise SystemExit(
+            "Usage: uv run python scripts/crawl_probe.py "
+            "<seed_url> <strategy> <min_legal_score> <max_depth> <max_pages> <timeout_s> "
+            "[browser_concurrency] [--write <result_json>] [--compare <baseline_json>]"
+        )
+    seed, strategy = sys.argv[1], sys.argv[2]
+    min_legal_score = float(sys.argv[3])
+    max_depth, max_pages = int(sys.argv[4]), int(sys.argv[5])
+    timeout_s = float(sys.argv[6])
+    browser_concurrency, write_path, compare_path = _parse_optional_args(sys.argv[7:])
+
+    setup_logging()
+    domain = urlparse(seed).netloc
+    crawler = ClauseaCrawler(
+        max_depth=max_depth,
+        max_pages=max_pages,
+        max_concurrent=20,
+        delay_between_requests=1.0,
+        timeout=30,
+        allowed_domains=[domain],
+        respect_robots_txt=True,
+        follow_external_links=False,
+        min_legal_score=min_legal_score,
+        strategy=strategy,
+        use_browser=True,
+        browser_concurrency=browser_concurrency,
+    )
+
+    start = time.perf_counter()
+    timed_out = False
+    try:
+        results = await asyncio.wait_for(crawler.crawl(seed), timeout=timeout_s)
+    except TimeoutError:
+        timed_out = True
+        results = []
+    elapsed = time.perf_counter() - start
+
+    crawled = crawler.stats.crawled_urls
+    visited = len(crawler.visited_urls)
+    # Path-prefix histogram of what actually got fetched — reveals wander into
+    # non-policy areas (/blog, /help, /careers) vs staying on policy paths.
+    prefixes = Counter(
+        ("/" + (urlparse(u).path.lstrip("/").split("/", 1)[0] or "<root>"))
+        for u in crawler.visited_urls
+    )
+    policy_pages = (
+        sum(1 for r in results if (r.legal_score or 0) >= 0.2 and r.success) if results else None
+    )
+    # Did we actually reach policy pages? Surfaces opaque-URL discovery (Amazon-style)
+    # and lets us eyeball whether non-standard labels (Conditions of Use) were followed.
+    policy_tokens = ("privacy", "conditions", "legal", "cookie", "terms", "notice", "gdpr")
+    policy_like = sorted(
+        u for u in crawler.visited_urls if any(t in u.lower() for t in policy_tokens)
+    )[:25]
+    policy_page_details = _policy_page_details(results)
+
+    hit_cap = visited >= max_pages
+    summary = {
+        "seed": seed,
+        "strategy": strategy,
+        "min_legal_score": min_legal_score,
+        "max_depth": max_depth,
+        "max_pages": max_pages,
+        "browser_concurrency": browser_concurrency,
+        "elapsed_s": round(elapsed, 1),
+        "timed_out_at_s": timeout_s if timed_out else None,
+        "visited": visited,
+        "crawled_ok": crawled,
+        "policy_pages_ge_0.2": policy_pages,
+        "hit_page_cap": hit_cap,
+        # The verdict: terminated early (good) vs hit cap / timed out (wander signal).
+        "verdict": (
+            "WANDER (hit cap)" if hit_cap
+            else "WANDER (timed out, still going)" if timed_out
+            else "CONVERGED/EXHAUSTED early"
+        ),
+        "top_path_prefixes": prefixes.most_common(12),
+        "policy_like_urls": policy_like,
+        "policy_page_details": policy_page_details,
+    }
+    if compare_path:
+        summary["comparison"] = _compare_probe_runs(summary, compare_path)
+    if write_path:
+        Path(write_path).write_text(json.dumps(summary, indent=2) + "\n")
+    print("PROBE_RESULT " + json.dumps(summary))
+    if compare_path and isinstance(summary.get("comparison"), dict):
+        comparison = summary["comparison"]
+        if not comparison.get("verification_gate_passed", False):
+            raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/backend/scripts/queue_status.py
+++ b/packages/backend/scripts/queue_status.py
@@ -1,0 +1,53 @@
+"""Read-only snapshot of the pipeline_jobs queue. Usage: uv run python scripts/queue_status.py
+
+Aggregates job counts by status and lists currently-crawling products and recent
+failures. Connects to PRODUCTION_MONGO_URI when set, else MONGO_URI. Never writes.
+"""
+
+import asyncio
+import os
+
+from motor.motor_asyncio import AsyncIOMotorClient
+
+
+async def main() -> None:
+    uri = os.getenv("PRODUCTION_MONGO_URI") or os.getenv("MONGO_URI")
+    if not uri:
+        raise SystemExit("No PRODUCTION_MONGO_URI or MONGO_URI set")
+    db_name = os.getenv("MONGODB_DATABASE", "clausea")
+    client = AsyncIOMotorClient(uri)
+    db = client[db_name]
+
+    by_status: dict[str, int] = {}
+    async for row in db.pipeline_jobs.aggregate(
+        [{"$group": {"_id": "$status", "n": {"$sum": 1}}}]
+    ):
+        by_status[row["_id"]] = row["n"]
+
+    overviews = await db.product_overviews.count_documents({})
+    total = sum(by_status.values())
+
+    order = ["pending", "crawling", "summarizing", "generating_overview", "completed",
+             "no_documents", "failed"]
+    parts = [f"{s}={by_status.get(s, 0)}" for s in order if s in by_status]
+    extra = [f"{s}={n}" for s, n in by_status.items() if s not in order]
+    print(f"jobs={total} " + " ".join(parts + extra) + f" overviews={overviews}")
+
+    crawling = await db.pipeline_jobs.find(
+        {"status": {"$in": ["crawling", "summarizing", "generating_overview"]}}
+    ).to_list(length=20)
+    if crawling:
+        active = [f"{j['product_slug']}({j['status']},att={j.get('attempts', 0)})" for j in crawling]
+        print("in-progress: " + ", ".join(active))
+
+    failed = await db.pipeline_jobs.find({"status": "failed"}).sort("updated_at", -1).to_list(20)
+    if failed:
+        print(f"failed (top {min(len(failed), 20)} by recency):")
+        for j in failed:
+            print(f"  {j['product_slug']:24} att={j.get('attempts', 0)} err={j.get('error')}")
+
+    client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/backend/src/core/config.py
+++ b/packages/backend/src/core/config.py
@@ -152,7 +152,7 @@ class CrawlerConfig:
 
         # --- Concurrency & politeness ---
         self.concurrent_limit: int = int(os.getenv("CRAWLER_CONCURRENT_LIMIT", "20"))
-        self.browser_concurrency: int = int(os.getenv("CRAWLER_BROWSER_CONCURRENCY", "2"))
+        self.browser_concurrency: int = int(os.getenv("CRAWLER_BROWSER_CONCURRENCY", "4"))
         self.delay_between_requests: float = float(
             os.getenv("CRAWLER_DELAY_BETWEEN_REQUESTS", "1.0")
         )

--- a/packages/backend/src/core/db_indexes.py
+++ b/packages/backend/src/core/db_indexes.py
@@ -122,7 +122,6 @@ async def ensure_document_indexes(db: AgnosticDatabase) -> None:
         else:
             logger.warning(f"Could not create index on documents.url: {e}")
 
-    # Resume helper query: find_recent_urls_by_product(product_id + recency window).
     try:
         await collection.create_index(
             [("product_id", 1), ("updated_at", -1), ("created_at", -1)],

--- a/packages/backend/src/core/db_indexes.py
+++ b/packages/backend/src/core/db_indexes.py
@@ -122,6 +122,23 @@ async def ensure_document_indexes(db: AgnosticDatabase) -> None:
         else:
             logger.warning(f"Could not create index on documents.url: {e}")
 
+    # Resume helper query: find_recent_urls_by_product(product_id + recency window).
+    try:
+        await collection.create_index(
+            [("product_id", 1), ("updated_at", -1), ("created_at", -1)],
+            name="idx_document_recent_by_product",
+            background=True,
+        )
+        logger.info("Created index on documents.(product_id,updated_at,created_at)")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "already exists" in error_msg:
+            logger.debug("Index on documents.(product_id,updated_at,created_at) already exists")
+        else:
+            logger.warning(
+                "Could not create index on documents.(product_id,updated_at,created_at): %s", e
+            )
+
 
 async def ensure_user_indexes(db: AgnosticDatabase) -> None:
     """Ensure indexes exist on the users collection."""
@@ -265,6 +282,23 @@ async def ensure_pipeline_indexes(db: AgnosticDatabase) -> None:
             logger.debug("Index on pipeline_jobs.product_slug already exists")
         else:
             logger.warning(f"Could not create index on pipeline_jobs.product_slug: {e}")
+
+    # Worker stale/requeue sweeps scan by status/active and order by updated_at.
+    try:
+        await db.pipeline_jobs.create_index(
+            [("status", 1), ("active", 1), ("updated_at", 1)],
+            name="idx_pipeline_job_requeue_scan",
+            background=True,
+        )
+        logger.info("Created index on pipeline_jobs.(status,active,updated_at)")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "already exists" in error_msg:
+            logger.debug("Index on pipeline_jobs.(status,active,updated_at) already exists")
+        else:
+            logger.warning(
+                "Could not create index on pipeline_jobs.(status,active,updated_at): %s", e
+            )
 
     # indexation_subscriptions
     try:

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 from urllib.parse import ParseResult, parse_qsl, urlencode, urljoin, urlparse, urlunparse
 
 import aiohttp
@@ -152,6 +152,14 @@ _LANGUAGE_NAMES = frozenset(
 _ENGLISH_TOKENS = frozenset({"en", "english"})
 
 
+def _english_locale_variant(token: str) -> str | None:
+    """Bare English marker (en/english) — safe to collapse. Region-qualified en-XX (en-us vs
+    en-gb = CCPA vs GDPR) are jurisdiction-distinct and returned as None so they aren't merged."""
+    if token.lower().strip() in ("en", "english"):
+        return "en"
+    return None
+
+
 def _is_bare_language(token: str) -> bool:
     """True if ``token`` names a language with no region qualifier.
 
@@ -200,6 +208,38 @@ def locale_canonical_key(parsed: ParseResult) -> tuple[str, bool, bool]:
     return canonical, had_signal, is_english
 
 
+def english_locale_canonical_key(parsed: ParseResult) -> tuple[str, str | None]:
+    """Canonical key for English locale variants of one document.
+
+    Strips English locale markers from path segments and locale query params, returning
+    the canonical URL plus the normalized English variant token (``en``, ``en-us``,
+    ``en-gb``, etc.) when one was present.
+    """
+    segments = [seg for seg in parsed.path.split("/") if seg]
+    kept_segments: list[str] = []
+    english_variant: str | None = None
+    for seg in segments:
+        variant = _english_locale_variant(seg)
+        if variant is not None:
+            english_variant = english_variant or variant
+            continue
+        kept_segments.append(seg)
+
+    kept_query: list[tuple[str, str]] = []
+    for key, value in parse_qsl(parsed.query, keep_blank_values=True):
+        variant = _english_locale_variant(value) if key.lower() in _LOCALE_QUERY_KEYS else None
+        if variant is not None:
+            english_variant = english_variant or variant
+            continue
+        kept_query.append((key, value))
+
+    canonical_path = "/" + "/".join(kept_segments)
+    canonical = urlunparse(
+        (parsed.scheme, parsed.netloc, canonical_path, "", urlencode(kept_query), "")
+    )
+    return canonical, english_variant
+
+
 # Standard user agent string following RFC 7231 format
 DEFAULT_USER_AGENT = (
     "Mozilla/5.0 (compatible; ClauseaBot/2.0; +https://www.clausea.co/bot.html; lvndry@proton.me)"
@@ -221,6 +261,10 @@ CONVERGENCE_LEGAL_SCORE = 0.2
 # Boost-only pages to keep crawling after the own-score frontier empties, in case one links a
 # policy reachable no other way. A new real lead resets it. See _relevance_exhausted.
 CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
+# Cap per-document English locale variants (e.g. en-us/en-gb) to reduce duplicate crawls.
+MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC = int(
+    os.getenv("CRAWLER_MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC", "2")
+)
 
 # Minimum extracted body text length to treat static fetch as sufficient (low URL score) and
 # to skip SPA hydration waits in the browser fetch path.
@@ -243,12 +287,9 @@ MAX_HEADER_BYTES = 65_536
 # use, so it gets a tight cap: a page that hasn't reached domcontentloaded in this long is
 # almost always hung or bot-walled, not a slow policy page. Bounded by the static timeout.
 BROWSER_NAV_TIMEOUT_MS = 20_000
-# Per load-state settle wait after navigation. We do NOT wait for "networkidle": SPA/marketing
-# sites (analytics, websockets, long-polling) rarely reach it, so waiting just burns the budget
-# on a state that never fires. domcontentloaded + a short "load" settle is enough; late-hydrating
-# content is still captured by the SPA_HYDRATION_RETRIES polling below.
-BROWSER_LOAD_STATE_TIMEOUT_MS = 5_000
-
+# Short "load" settle; partial-SSR pages inject their body at load. Kept low so SPAs that never
+# fire it don't burn the budget.
+BROWSER_LOAD_STATE_TIMEOUT_MS = int(os.getenv("CRAWLER_BROWSER_LOAD_STATE_MS", "2000"))
 # Heavy assets aborted during render to cap renderer memory. A regex route — Playwright matches
 # only these URLs, so document/CSS/JS/XHR navigate untouched with no event-loop overhead. NOT a
 # catch-all "**/*" (a blanket route that continue_()s every request stalls SPA navigation under
@@ -1502,7 +1543,7 @@ class ClauseaCrawler:
         max_retries: int = 3,  # Maximum retry attempts for transient errors
         log_file_path: str | None = None,  # Optional path to log file for crawl session
         use_browser: bool = False,  # Whether to use a headless browser for dynamic rendering
-        browser_concurrency: int = 2,  # Max concurrent browser renders (shared browser instance)
+        browser_concurrency: int = 4,  # Max concurrent browser renders (shared browser instance)
         proxy: str | None = None,  # Optional proxy URL (e.g., "http://user:pass@host:port")
         allowed_paths: list[str] | None = None,  # Optional list of allowed path regexes
         denied_paths: list[str] | None = None,  # Optional list of denied path regexes
@@ -1516,6 +1557,9 @@ class ClauseaCrawler:
         # failure). Lets callers stream each page to classification/storage as it is
         # produced instead of batching at the end of a multi-hour crawl.
         result_callback: Callable[[CrawlResult], Awaitable[None]] | None = None,
+        # Optional early-stop hook checked after each processed result. Return True to
+        # stop the crawl once caller-specific coverage criteria are met.
+        stop_callback: Callable[[], bool] | Callable[[], Awaitable[bool]] | None = None,
         # URLs of docs stored within the resume freshness window. Skipped during
         # should_crawl_url so a retried long crawl resumes (keeps already-stored
         # pages) instead of re-fetching and re-rendering them from scratch.
@@ -1576,6 +1620,7 @@ class ClauseaCrawler:
         # Progress callback for external monitoring
         self.progress_callback = progress_callback
         self.result_callback = result_callback
+        self.stop_callback = stop_callback
         # Number of processed URLs at the last progress report (for cadence).
         self._last_progress_report = 0
 
@@ -1615,6 +1660,10 @@ class ClauseaCrawler:
         # translation duplicates of an already-seen document are skipped while
         # region-qualified locales (jurisdiction-distinct) are always preserved.
         self._locale_seen_keys: set[str] = set()
+        # Canonical English-locale key -> variants admitted for this document. Caps
+        # duplicate en-* policy crawls while retaining representative coverage.
+        self.max_english_locale_variants = max(1, MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC)
+        self._english_locale_seen: dict[str, set[str]] = {}
         self.url_queue: deque[tuple[str, int]] = deque()  # For BFS
         self.url_stack: list[tuple[str, int]] = []  # For DFS
         # best-first frontier: (-score, url, depth, base_score). base_score excludes parent boost.
@@ -2333,26 +2382,11 @@ class ClauseaCrawler:
                 logger.warning(f"❌ Browser fetch failed to initiate for {url}")
                 return None
 
-            # Short load-state settle after navigation. We deliberately do NOT wait for
-            # "networkidle" — SPA/marketing sites rarely reach it, so it just times out and
-            # wastes the budget. Late-hydrating content is recovered by the SPA-hydration
-            # polling below, so dropping networkidle is recall-neutral.
-            wait_states: list[Literal["domcontentloaded", "load"]] = [
-                "domcontentloaded",
-                "load",
-            ]
-            state_timeout = BROWSER_LOAD_STATE_TIMEOUT_MS
-
-            for state in wait_states:
-                try:
-                    logger.debug(f"⏳ Waiting for {state} state for {url}")
-                    await page.wait_for_load_state(state, timeout=state_timeout)
-                    logger.debug(f"✅ Reached {state} state for {url}")
-                except Exception as e:
-                    logger.debug(f"⚠️ Wait for {state} timed out for {url} (continuing): {e}")
-                    # If we reached domcontentloaded, we can try to extract content even if others fail.
-                    # We continue the loop to try the next state if time remains.
-                    continue
+            # Short "load" settle so partial-SSR bodies aren't truncated; swallow if it never fires.
+            try:
+                await page.wait_for_load_state("load", timeout=BROWSER_LOAD_STATE_TIMEOUT_MS)
+            except Exception:
+                pass
 
             title = await page.title()
             content = await page.content()
@@ -3062,14 +3096,32 @@ class ClauseaCrawler:
                 logger.debug(f"❌ URL {url} rejected: matches skip pattern {pattern.pattern}")
                 return False
 
+        normalized_parsed = self._parse_url(self.normalize_url(url))
+
+        # Cap English locale variants per canonical document path (e.g. /en-us, /en-gb)
+        # so the crawl keeps representative coverage without exploding on en-* mirrors.
+        english_key, english_variant = english_locale_canonical_key(normalized_parsed)
+        if english_variant is not None:
+            seen_variants = self._english_locale_seen.setdefault(english_key, set())
+            if english_variant in seen_variants:
+                logger.debug(
+                    f"❌ URL {url} rejected: duplicate English locale variant "
+                    f"'{english_variant}' for {english_key}"
+                )
+                return False
+            if len(seen_variants) >= self.max_english_locale_variants:
+                logger.debug(
+                    f"❌ URL {url} rejected: English locale variant cap reached for {english_key} "
+                    f"(cap={self.max_english_locale_variants})"
+                )
+                return False
+            seen_variants.add(english_variant)
+
         # Skip pure-translation duplicates of a document we've already admitted. The
-        # canonical key strips only bare-language markers, so region-qualified locales
-        # (jurisdiction-distinct, e.g. en-GB vs en-US, /eu vs /us) keep separate keys
-        # and are always crawled. We keep the language-less or English variant when one
-        # exists; otherwise the first translation seen.
-        canonical_key, had_language_signal, is_english = locale_canonical_key(
-            self._parse_url(self.normalize_url(url))
-        )
+        # canonical key strips only bare-language markers, so jurisdictional region
+        # paths (/eu vs /us) keep separate keys. English region variants are handled
+        # by the cap above; non-English translations collapse to one representative.
+        canonical_key, had_language_signal, is_english = locale_canonical_key(normalized_parsed)
         if had_language_signal and not is_english and canonical_key in self._locale_seen_keys:
             logger.debug(f"❌ URL {url} rejected: translation duplicate of {canonical_key}")
             return False
@@ -3425,6 +3477,8 @@ class ClauseaCrawler:
                         status_code=(browser_page.status_code if browser_page else raw.status_code),
                         success=False,
                         error_message="Static content unusable and browser rendering failed",
+                        # Keep links: a thin app shell still footers to the real policy pages.
+                        discovered_links=(browser_page.discovered_links if browser_page else []),
                     )
                 if page is not None:
                     # Not policy-relevant but we parsed something — keep the static content
@@ -3754,12 +3808,25 @@ class ClauseaCrawler:
             self._frontier_real_leads += 1
             self._crawls_since_new_lead = 0
 
+    def _frontier_top_base_score(self) -> float | None:
+        """Best remaining own-score in the frontier (ignores parent-page boost)."""
+        if self.strategy != "best_first" or not self.url_priority_queue:
+            return None
+        return max(base_score for _, _, _, base_score in self.url_priority_queue)
+
     def _relevance_exhausted(self) -> bool:
-        """True once policy content is found and only boost-only links remain past the grace window."""
+        """True once only low-own-score URLs remain after policy has been found.
+
+        For discovery we care about *own* legal relevance, not parent-page boost.
+        When the frontier's best own-score falls below ``min_legal_score`` (and
+        stays there for the grace budget), everything left is tail noise.
+        """
+        top_base_score = self._frontier_top_base_score()
         return (
             self.strategy == "best_first"
             and self._policy_pages_found >= 1
-            and self._frontier_real_leads <= 0
+            and top_base_score is not None
+            and top_base_score < self.min_legal_score
             and self._crawls_since_new_lead >= CRAWL_EXHAUSTION_GRACE
         )
 
@@ -3951,6 +4018,15 @@ class ClauseaCrawler:
         if self.result_callback is not None:
             await self.result_callback(result)
 
+    async def _should_stop_early(self) -> bool:
+        """Return True when caller-provided stop callback asks to end the crawl."""
+        if self.stop_callback is None:
+            return False
+        decision = self.stop_callback()
+        if isinstance(decision, Awaitable):
+            decision = await decision
+        return bool(decision)
+
     async def _drain_render_retries(self, session: aiohttp.ClientSession) -> None:
         """Serially re-attempt renders that failed during the concurrent crawl.
 
@@ -4028,6 +4104,7 @@ class ClauseaCrawler:
             self._frontier_real_leads = 0
             self._policy_pages_found = 0
             self._crawls_since_new_lead = 0
+            self._english_locale_seen.clear()
 
             # Add base URL to queue. Base URLs are explicit seeds (crawl_base_urls) and
             # are always crawled regardless of score; record a generous score so the
@@ -4106,6 +4183,7 @@ class ClauseaCrawler:
                 # policy content once we've found some, to stop wandering the marketing site.
                 pages_since_policy_hit = 0
                 found_policy = False
+                stop_requested = False
                 while len(self.visited_urls) < self.max_pages:
                     # Get batch of URLs to process
                     batch = []
@@ -4148,14 +4226,6 @@ class ClauseaCrawler:
                             else:
                                 pages_since_policy_hit += 1
 
-                            # Add discovered URLs to queue
-                            if depth < self.max_depth:
-                                self.add_urls_to_queue(
-                                    result.discovered_links,
-                                    base_url,
-                                    depth,
-                                    page_metadata=result.metadata,
-                                )
                             logger.info(
                                 f"✅ [{self.stats.crawled_urls}/{self.max_pages}] "
                                 f"{url} — {len(result.discovered_links)} links"
@@ -4171,14 +4241,32 @@ class ClauseaCrawler:
                             if result.blocked_by_robots_txt:
                                 self.results.append(result)
 
+                        # Follow links even from failed results: a thin page is a vital nav source.
+                        if depth < self.max_depth and result.discovered_links:
+                            self.add_urls_to_queue(
+                                result.discovered_links,
+                                base_url,
+                                depth,
+                                page_metadata=result.metadata,
+                            )
+
                         # Stream every processed result (success and failure) so the
                         # pipeline can classify+store as pages arrive and keep the job
                         # heartbeat fresh during long crawls.
                         await self._emit_result(result)
+                        if await self._should_stop_early():
+                            stop_requested = True
+                            logger.info(
+                                "🧭 Crawl stopped early: caller coverage criteria satisfied."
+                            )
+                            break
 
                     # Progress update — emitted on a threshold crossing so it
                     # survives batched jumps in total_urls (see helper docstring).
                     self._report_crawl_progress()
+
+                    if stop_requested:
+                        break
 
                     if self._has_converged(found_policy, pages_since_policy_hit):
                         logger.info(
@@ -4202,7 +4290,8 @@ class ClauseaCrawler:
                 self._report_crawl_progress(force=True)
 
                 # Recover any policy-relevant pages whose render failed under load.
-                await self._drain_render_retries(session)
+                if not stop_requested:
+                    await self._drain_render_retries(session)
 
             # Render instrumentation — data for future concurrency/pooling decisions.
             if self._render_attempts:
@@ -4235,6 +4324,12 @@ class ClauseaCrawler:
 
         try:
             for i, url in enumerate(urls, 1):
+                if await self._should_stop_early():
+                    logger.info(
+                        f"🧭 Stopping remaining seeds early after {i - 1}/{len(urls)} seed(s): "
+                        "coverage criteria already met."
+                    )
+                    break
                 logger.info(f"🔄 Processing URL {i}/{len(urls)}: {url}")
                 results = await self.crawl(url, cleanup=False)
                 all_results.extend(results)
@@ -4249,6 +4344,7 @@ class ClauseaCrawler:
                 self.failed_urls.clear()
                 self.queued_urls.clear()
                 self._locale_seen_keys.clear()
+                self._english_locale_seen.clear()
                 self._sitemap_seeded = False
                 self.url_queue.clear()
                 self.url_stack.clear()

--- a/packages/backend/src/models/pipeline_job.py
+++ b/packages/backend/src/models/pipeline_job.py
@@ -43,8 +43,8 @@ PipelineJobStatus = Literal[
 #   - completed:    ran to the end, overview generated
 #   - no_documents: crawl ran to completion but found 0 policy documents (a valid,
 #                   deterministic result — retrying yields the same outcome)
-#   - failed:       interrupted (orphaned/timeout) or errored — eligible for a
-#                   user-initiated retry, but never auto-retriggered
+#   - failed:       interrupted or errored. Auto-retry may re-queue some failed
+#                   jobs (transient/retryable) within a bounded attempt budget.
 TERMINAL_PIPELINE_STATUSES: tuple[PipelineJobStatus, ...] = (
     "completed",
     "failed",
@@ -157,6 +157,9 @@ class PipelineJob(BaseModel):
     last_heartbeat: datetime | None = None
 
     attempts: int = 0  # claims so far; bounds auto-retry of failed/orphaned jobs
+    # Sticky auto-retry guard: when true, stale sweeps won't re-queue this failed job.
+    auto_retry_disabled: bool = False
+    auto_retry_disabled_reason: str | None = None
 
     # Stats from the crawl phase
     documents_found: int = 0

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -866,6 +866,7 @@ class PolicyDocumentPipeline:
         strategy: str | None = None,
         progress_phase: str | None = None,
         result_callback: Callable[[CrawlResult], Awaitable[None]] | None = None,
+        stop_callback: Callable[[], bool] | Callable[[], Awaitable[bool]] | None = None,
         recently_stored_urls: list[str] | None = None,
     ) -> ClauseaCrawler:
         """Create a configured crawler instance for a specific product."""
@@ -914,6 +915,7 @@ class PolicyDocumentPipeline:
             denied_paths=product.crawl_denied_paths,
             progress_callback=progress_callback,
             result_callback=result_callback,
+            stop_callback=stop_callback,
             recently_stored_urls=recently_stored_urls,
         )
 
@@ -1248,9 +1250,26 @@ class PolicyDocumentPipeline:
         # Prepend https://
         return f"https://{url_or_domain}"
 
+    def _seed_dedupe_key(self, normalized_url: str) -> tuple[str, str, str, str]:
+        """Stable dedupe key for crawl seeds.
+
+        Treat root variants as equivalent (``https://x.com`` == ``https://x.com/``)
+        while preserving deeper paths and query-bearing override seeds.
+        """
+        parsed = urlparse(normalized_url)
+        path = parsed.path
+        if path in ("", "/"):
+            path = ""
+        return (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            path,
+            parsed.query,
+        )
+
     def _get_crawl_urls(self, product: Product) -> list[str]:
         """
-        Get crawl URLs for a product, falling back to domains if crawl_base_urls is empty.
+        Get crawl URLs for a product with domain roots as primary seeds.
 
         Args:
             product: Product to get URLs for
@@ -1258,22 +1277,28 @@ class PolicyDocumentPipeline:
         Returns:
             List of URLs to crawl (all normalized with https:// protocol)
         """
-        if product.crawl_base_urls:
-            # Normalize crawl_base_urls to ensure they have https:// protocol
-            return [self._normalize_url(url) for url in product.crawl_base_urls if url.strip()]
-
-        # Fallback to domains if crawl_base_urls is empty
-        if not product.domains:
-            return []
-
-        # Convert domains to URLs (prepend https:// if not already present)
-        urls = []
+        # Domain roots are the backbone (always crawl homepage + sitemap discovery).
+        candidates: list[str] = []
         for domain in product.domains:
             normalized = self._normalize_url(domain)
             if normalized:
-                urls.append(normalized)
+                candidates.append(normalized)
 
-        return urls
+        # crawl_base_urls are optional overrides for odd sites, not the primary source.
+        for seed in product.crawl_base_urls or []:
+            normalized = self._normalize_url(seed)
+            if normalized:
+                candidates.append(normalized)
+
+        deduped: list[str] = []
+        seen: set[tuple[str, str, str, str]] = set()
+        for candidate in candidates:
+            key = self._seed_dedupe_key(candidate)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(candidate)
+        return deduped
 
     async def _start_crawl_session(self, product: Product, crawl_urls: list[str]) -> CrawlSession:
         session = CrawlSession(
@@ -1381,7 +1406,7 @@ class PolicyDocumentPipeline:
         product_start_time = time.time()
         log_memory_usage(f"Starting {product.name}")
 
-        # Get crawl URLs (from crawl_base_urls or fallback to domains)
+        # Get crawl URLs (domain roots primary, crawl_base_urls as optional overrides).
         crawl_urls = self._get_crawl_urls(product)
 
         if not crawl_urls:
@@ -1393,9 +1418,14 @@ class PolicyDocumentPipeline:
             self.stats.failed_product_slugs.append(product.slug)
             return []
 
-        # Log whether we're using crawl_base_urls or domains
-        using_domains = not product.crawl_base_urls
-        source = "domains" if using_domains else "crawl_base_urls"
+        has_domains = bool(product.domains)
+        has_overrides = bool(product.crawl_base_urls)
+        if has_domains and has_overrides:
+            source = "domains+overrides"
+        elif has_domains:
+            source = "domains"
+        else:
+            source = "crawl_base_urls_override"
         crawl_session: CrawlSession | None = None
         try:
             logger.info(
@@ -1410,6 +1440,8 @@ class PolicyDocumentPipeline:
             seen_fingerprints: set[str] = set()
             total_results = 0
             processed_documents: list[Document] = []
+            discovered_doc_types: set[str] = set()
+            discovery_coverage_met = False
 
             # Stream each crawled result through classification + storage as it is
             # produced, so a crawl killed at the time ceiling or by a stall keeps the
@@ -1418,6 +1450,7 @@ class PolicyDocumentPipeline:
             # per-result calls exactly as the old batch call did. _store_documents is
             # idempotent (dedupes by URL/fingerprint), so re-arrivals are safe.
             async def result_callback(result: CrawlResult) -> None:
+                nonlocal discovery_coverage_met
                 docs = await self._classify_results(
                     [result], product, processed_urls, seen_fingerprints
                 )
@@ -1425,6 +1458,16 @@ class PolicyDocumentPipeline:
                     stored = await self._store_documents(docs)
                     self.stats.policy_documents_stored += stored
                     processed_documents.extend(docs)
+                    discovered_doc_types.update(
+                        str(doc.doc_type) for doc in docs if getattr(doc, "doc_type", None)
+                    )
+                    if len(processed_documents) >= self.min_docs_before_fallback and all(
+                        req in discovered_doc_types for req in self.required_doc_types
+                    ):
+                        discovery_coverage_met = True
+
+            def stop_discovery_callback() -> bool:
+                return discovery_coverage_met
 
             # Docs stored within the resume freshness window. A retried crawl skips
             # re-fetching these so it resumes instead of re-rendering hours of work;
@@ -1454,12 +1497,19 @@ class PolicyDocumentPipeline:
                 strategy=self.discovery_strategy,
                 progress_phase="discovery",
                 result_callback=result_callback,
+                stop_callback=stop_discovery_callback,
                 recently_stored_urls=recently_stored_urls,
             )
             discovery_results = await self._crawl_base_urls(discovery_crawler, crawl_urls)
             logger_discovery.info(
                 f"discovery pass complete for '{product.name}': found {len(discovery_results)} pages"
             )
+            if discovery_coverage_met:
+                logger_discovery.info(
+                    f"discovery coverage target met for '{product.name}' "
+                    f"(required types: {', '.join(self.required_doc_types)}); "
+                    "stopped discovery early"
+                )
             total_results += len(discovery_results)
 
             # Fallback deep crawl (recall-first) if coverage is low. The decision runs

--- a/packages/backend/src/repositories/document_repository.py
+++ b/packages/backend/src/repositories/document_repository.py
@@ -267,8 +267,10 @@ class DocumentRepository(BaseRepository):
                 {"created_at": {"$gte": cutoff}},
             ],
         }
-        rows: list[dict[str, Any]] = await db.documents.find(query, {"_id": 0, "url": 1}).to_list(
-            length=MAX_RECENT_URLS_PER_RESUME
+        rows: list[dict[str, Any]] = (
+            await db.documents.find(query, {"_id": 0, "url": 1})
+            .sort([("updated_at", -1), ("created_at", -1)])
+            .to_list(length=MAX_RECENT_URLS_PER_RESUME)
         )
         if len(rows) == MAX_RECENT_URLS_PER_RESUME:
             logger.warning(

--- a/packages/backend/src/repositories/document_repository.py
+++ b/packages/backend/src/repositories/document_repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime
 from typing import Any
 
@@ -18,6 +19,23 @@ from src.models.document import (
 from src.repositories.base_repository import BaseRepository
 
 logger = get_logger(__name__)
+_DEFAULT_MAX_RESUME_URLS = 5000
+
+
+def _read_positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logger.warning("Invalid %s=%r (must be int), using default=%d", name, raw, default)
+        return default
+
+
+MAX_RECENT_URLS_PER_RESUME = _read_positive_int_env(
+    "PIPELINE_RESUME_MAX_RECENT_URLS", _DEFAULT_MAX_RESUME_URLS
+)
 
 
 def _normalize_document_record(document: dict[str, Any]) -> dict[str, Any]:
@@ -250,8 +268,15 @@ class DocumentRepository(BaseRepository):
             ],
         }
         rows: list[dict[str, Any]] = await db.documents.find(query, {"_id": 0, "url": 1}).to_list(
-            length=None
+            length=MAX_RECENT_URLS_PER_RESUME
         )
+        if len(rows) == MAX_RECENT_URLS_PER_RESUME:
+            logger.warning(
+                "Resume URL cap reached for product_id=%s (cap=%d). "
+                "Older recent URLs were truncated this run.",
+                product_id,
+                MAX_RECENT_URLS_PER_RESUME,
+            )
         return [row["url"] for row in rows if row.get("url")]
 
     # ============================================================================

--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from typing import Any
 
@@ -10,7 +11,7 @@ from pymongo import ReturnDocument
 from pymongo.errors import DuplicateKeyError
 
 from src.core.logging import get_logger
-from src.models.pipeline_job import TERMINAL_PIPELINE_STATUSES, PipelineJob
+from src.models.pipeline_job import TERMINAL_PIPELINE_STATUSES, PipelineErrorCode, PipelineJob
 from src.repositories.base_repository import BaseRepository
 
 _TERMINAL_STATUSES = list(TERMINAL_PIPELINE_STATUSES)
@@ -21,6 +22,68 @@ _TERMINAL_STATUSES = list(TERMINAL_PIPELINE_STATUSES)
 _ORPHANABLE_STATUSES = ["crawling", "summarizing", "generating_overview"]
 
 logger = get_logger(__name__)
+
+_RETRYABLE_PIPELINE_ERRORS = {
+    PipelineErrorCode.crawl_failed.value,
+    PipelineErrorCode.all_analysis_failed.value,
+    PipelineErrorCode.core_docs_unanalyzed.value,
+    PipelineErrorCode.overview_not_persisted.value,
+    PipelineErrorCode.internal_error.value,
+    PipelineErrorCode.timed_out.value,
+    PipelineErrorCode.stalled.value,
+}
+_NON_RETRYABLE_PIPELINE_ERRORS = {
+    PipelineErrorCode.product_not_found.value,
+    PipelineErrorCode.crawl_robots_blocked.value,
+    PipelineErrorCode.no_documents_found.value,
+}
+
+
+def _read_positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logger.warning("Invalid %s=%r (must be int), using default=%d", name, raw, default)
+        return default
+
+
+# Recall-first default: allow enough auto-retry headroom to recover from transient
+# crawler/render/LLM failures before quarantining a job as poison.
+MAX_AUTO_RETRY_ATTEMPTS = _read_positive_int_env("PIPELINE_MAX_AUTO_RETRY_ATTEMPTS", 12)
+MAX_REQUEUE_BATCH_SIZE = _read_positive_int_env("PIPELINE_REQUEUE_BATCH_SIZE", 200)
+
+
+def _is_auto_retryable_failure(error_code: Any) -> bool:
+    """Best-effort retryability classifier for failed jobs.
+
+    We keep this forgiving for backward compatibility with historical rows that
+    store free-form strings in ``error``.
+    """
+    code = (str(error_code).strip().lower() if error_code is not None else "")
+    if not code:
+        return True
+    if code in _NON_RETRYABLE_PIPELINE_ERRORS:
+        return False
+    if code in _RETRYABLE_PIPELINE_ERRORS:
+        return True
+    # Legacy rows may store free-text values.
+    if code in {"cancelled", "canceled", "cancelled by user", "canceled by user"}:
+        return False
+    if "orphaned" in code:
+        return True
+    return True
+
+
+def _retry_block_reason(job: dict[str, Any]) -> str | None:
+    attempts = int(job.get("attempts") or 0)
+    if attempts >= MAX_AUTO_RETRY_ATTEMPTS:
+        return f"attempt limit reached ({attempts}/{MAX_AUTO_RETRY_ATTEMPTS})"
+    if not _is_auto_retryable_failure(job.get("error")):
+        return f"non-retryable failure ({job.get('error') or 'unknown'})"
+    return None
 
 
 class PipelineRepository(BaseRepository):
@@ -98,7 +161,7 @@ class PipelineRepository(BaseRepository):
         data: dict[str, Any] | None = await db[self.COLLECTION].find_one_and_update(
             {"status": "pending"},
             {
-                "$set": {"status": "crawling", "started_at": datetime.now()},
+                "$set": {"status": "crawling", "started_at": datetime.now(), "active": True},
                 "$inc": {"attempts": 1},
             },
             sort=[("created_at", 1)],
@@ -174,6 +237,10 @@ class PipelineRepository(BaseRepository):
             job_id: Job ID
             fields: Dictionary of fields to update (supports dot notation)
         """
+        status = fields.get("status")
+        if isinstance(status, str):
+            # Keep the active-index discriminator consistent whenever status is patched.
+            fields["active"] = status not in _TERMINAL_STATUSES
         fields["updated_at"] = datetime.now()
         await db[self.COLLECTION].update_one(
             {"id": job_id},
@@ -182,14 +249,12 @@ class PipelineRepository(BaseRepository):
         logger.debug(f"Partially updated pipeline job {job_id}: {list(fields.keys())}")
 
     async def requeue_failed_jobs(self, db: AgnosticDatabase) -> int:
-        """Re-queue every failed job for another attempt — retries are unlimited.
+        """Re-queue retryable failed jobs for another attempt.
 
         Makes the worker self-healing: orphaned jobs (failed by mark_stale_as_failed) and
-        transient failures retry. ``no_documents`` is terminal and deliberately not retried.
-        There is no attempt ceiling: a job mostly accrues attempts from redeploys orphaning
-        long in-flight crawls, not from real defects, so capping it would permanently kill
-        legitimate work. The 5-minute stale-sweep cadence is the natural backoff between
-        retries, so a genuinely poison job retries slowly rather than tight-looping.
+        transient failures retry. ``no_documents`` and other deterministic failures remain
+        terminal. Retries are bounded by ``PIPELINE_MAX_AUTO_RETRY_ATTEMPTS`` so poison jobs
+        don't churn indefinitely.
 
         At most one active job per product (enforced by the uniq_active_job_per_product
         partial index): products that already have an active job are skipped, and only one
@@ -212,33 +277,71 @@ class PipelineRepository(BaseRepository):
         claimed_slugs: set[str] = set(
             await db[self.COLLECTION].distinct("product_slug", {"active": True})
         )
-        candidates: list[dict[str, Any]] = (
-            await db[self.COLLECTION].find({"status": "failed"}).to_list(length=None)
-        )
+        query: dict[str, Any] = {
+            "status": "failed",
+            "active": {"$ne": True},
+            "auto_retry_disabled": {"$ne": True},
+        }
+        cursor = db[self.COLLECTION].find(query).sort("updated_at", 1)
+        candidates: list[dict[str, Any]] = await cursor.to_list(length=MAX_REQUEUE_BATCH_SIZE)
 
         count = 0
         for job in candidates:
+            reason = _retry_block_reason(job)
+            if reason:
+                await db[self.COLLECTION].update_one(
+                    {"id": job["id"], "status": "failed", "active": {"$ne": True}},
+                    {
+                        "$set": {
+                            "auto_retry_disabled": True,
+                            "auto_retry_disabled_reason": reason,
+                            "updated_at": datetime.now(),
+                        }
+                    },
+                )
+                continue
             slug = job["product_slug"]
             if slug in claimed_slugs:  # product already has (or just got) an active job
                 continue
             claimed_slugs.add(slug)
-            await db[self.COLLECTION].update_one(
-                {"id": job["id"]},
-                {
-                    "$set": {
-                        "status": "pending",
-                        "active": True,
-                        "steps": fresh_steps,
-                        "error": None,
-                        "error_detail": None,
-                        "started_at": None,
-                        "completed_at": None,
-                        "last_heartbeat": None,
-                        "updated_at": datetime.now(),
-                    }
-                },
-            )
-            count += 1
+            try:
+                result = await db[self.COLLECTION].update_one(
+                    {
+                        "id": job["id"],
+                        "status": "failed",
+                        "active": {"$ne": True},
+                        "auto_retry_disabled": {"$ne": True},
+                    },
+                    {
+                        "$set": {
+                            "status": "pending",
+                            "active": True,
+                            "steps": fresh_steps,
+                            "error": None,
+                            "error_detail": None,
+                            "started_at": None,
+                            "completed_at": None,
+                            "last_heartbeat": None,
+                            "documents_found": 0,
+                            "documents_stored": 0,
+                            "crawl_errors": [],
+                            "crawl_skip_reasons": [],
+                            "auto_retry_disabled": False,
+                            "auto_retry_disabled_reason": None,
+                            "updated_at": datetime.now(),
+                        }
+                    },
+                )
+            except DuplicateKeyError:
+                # Another worker revived/claimed this product concurrently.
+                logger.debug(
+                    "Skipped requeue for %s/%s due to concurrent active-job claim",
+                    slug,
+                    job["id"],
+                )
+                continue
+            if result.modified_count:
+                count += 1
         if count:
             logger.info("Re-queued %d failed job(s) for retry", count)
         return count
@@ -274,6 +377,8 @@ class PipelineRepository(BaseRepository):
                     "status": "failed",
                     "active": False,
                     "error": "Server restart — job was orphaned",
+                    "auto_retry_disabled": False,
+                    "auto_retry_disabled_reason": None,
                     "updated_at": datetime.now(),
                     "completed_at": datetime.now(),
                 }

--- a/packages/backend/src/routes/pipeline.py
+++ b/packages/backend/src/routes/pipeline.py
@@ -3,15 +3,13 @@
 Provides a DeepWiki-style API: submit a URL, get a job ID, poll for status.
 """
 
-from datetime import datetime
-
 from fastapi import APIRouter, Depends, HTTPException
 from motor.core import AgnosticDatabase
 from pydantic import BaseModel
 
 from src.core.database import get_db
 from src.core.logging import get_logger
-from src.models.pipeline_job import TERMINAL_PIPELINE_STATUSES, PipelineJob
+from src.models.pipeline_job import PipelineJob
 from src.repositories.pipeline_repository import PipelineRepository
 from src.services.service_factory import create_pipeline_service
 
@@ -151,29 +149,3 @@ async def get_job_status(
     if not job:
         raise HTTPException(status_code=404, detail="Pipeline job not found")
     return job
-
-
-@router.delete("/jobs/{job_id}", status_code=200)
-async def cancel_job(
-    job_id: str,
-    db: AgnosticDatabase = Depends(get_db),
-) -> dict[str, str]:
-    """Cancel a running pipeline job."""
-    pipeline_svc = create_pipeline_service()
-    job = await pipeline_svc.get_job(db, job_id)
-    if not job:
-        raise HTTPException(status_code=404, detail="Pipeline job not found")
-    if job.status in TERMINAL_PIPELINE_STATUSES:
-        raise HTTPException(status_code=409, detail=f"Job already {job.status}")
-
-    repo = PipelineRepository()
-    await repo.update_fields(
-        db,
-        job_id,
-        {
-            "status": "failed",
-            "error": "Cancelled by user",
-            "completed_at": datetime.now(),
-        },
-    )
-    return {"status": "cancelled", "job_id": job_id}

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -397,6 +397,11 @@ class PipelineService:
                     job.documents_found = stats.total_documents_found
                     job.documents_stored = stats.policy_documents_stored
 
+                    # Reset attempt-local crawl diagnostics so a retry cannot inherit
+                    # stale errors/skips from a previous failed attempt.
+                    job.crawl_errors = []
+                    job.crawl_skip_reasons = []
+
                     # Persist per-URL crawl failures on the job
                     if stats.crawl_errors:
                         job.crawl_errors = [CrawlError(**err) for err in stats.crawl_errors]

--- a/packages/backend/tests/unit/config_test.py
+++ b/packages/backend/tests/unit/config_test.py
@@ -76,3 +76,10 @@ class TestCrawlerConfig:
         assert c.required_doc_types == ["privacy_policy", "cookie_policy"]
         assert c.use_browser is False
         assert c.respect_robots_txt is False
+
+    def test_browser_concurrency_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from src.core.config import CrawlerConfig
+
+        monkeypatch.delenv("CRAWLER_BROWSER_CONCURRENCY", raising=False)
+        c = CrawlerConfig()
+        assert c.browser_concurrency == 4

--- a/packages/backend/tests/unit/crawler/locale_dedup_test.py
+++ b/packages/backend/tests/unit/crawler/locale_dedup_test.py
@@ -1,10 +1,11 @@
-"""Pure-translation URL variants are deduped; region-qualified locales are preserved.
+"""Pure-translation URL variants are deduped; English locale variants are capped.
 
 Sites like Steam (``?l=ukrainian`` over a path-locale matrix) and Epic (``?lang=…``)
 expose the same legal document in dozens of translations. Each one browser-renders and
 times out, so a single crawl burned ~30 min on hundreds of redundant fetches. We keep
-the canonical/English variant and skip the rest — but anything carrying a region
-qualifier (jurisdiction-distinct, e.g. GDPR vs CCPA) is always crawled.
+the canonical/English variant and skip the rest. English region variants are capped
+to representative coverage, while jurisdictional region paths (e.g. /eu vs /us)
+remain distinct.
 """
 
 from urllib.parse import urlparse
@@ -56,6 +57,24 @@ def test_region_variants_are_each_crawled() -> None:
     assert crawler.should_crawl_url(base + "/eu", base, 1) is True
     assert crawler.should_crawl_url(base + "/us", base, 1) is True
     assert crawler.should_crawl_url(base + "/en-GB", base, 1) is True
+
+
+def test_english_region_variants_are_each_crawled() -> None:
+    # en-us (CCPA), en-gb (GDPR), en-au are jurisdiction-distinct legal texts, not translations:
+    # never collapsed pre-fetch. Identical ones are dropped later by the content fingerprint.
+    crawler = _crawler()
+    base = "https://example.com/privacy"
+    assert crawler.should_crawl_url(base + "/en-us", base, 1) is True
+    assert crawler.should_crawl_url(base + "/en-gb", base, 1) is True
+    assert crawler.should_crawl_url(base + "/en-au", base, 1) is True
+
+
+def test_english_region_query_variants_are_each_crawled() -> None:
+    crawler = _crawler()
+    base = "https://legal.example.com/terms"
+    assert crawler.should_crawl_url(base + "?lang=en-gb", base, 1) is True
+    assert crawler.should_crawl_url(base + "?lang=en-ca", base, 1) is True
+    assert crawler.should_crawl_url(base + "?lang=en-au", base, 1) is True
 
 
 def test_hr_and_uk_path_segments_are_not_treated_as_languages() -> None:

--- a/packages/backend/tests/unit/crawler/shared_browser_test.py
+++ b/packages/backend/tests/unit/crawler/shared_browser_test.py
@@ -6,6 +6,7 @@ now render through one shared browser, and a stuck/failed launch returns None (d
 render-retry) instead of hanging until the 2h pipeline cap.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -31,3 +32,38 @@ async def test_browser_fetch_returns_none_when_launch_fails(monkeypatch):
     )
     # A failed/timed-out launch is a render failure, not a fatal crawl error.
     assert await crawler._browser_fetch("https://example.com/privacy") is None
+
+
+@pytest.mark.asyncio
+async def test_browser_fetch_waits_briefly_for_load_state(monkeypatch):
+    """Render path navigates on domcontentloaded then settles briefly on 'load' so partial-SSR
+    bodies are captured whole; a load timeout is swallowed, not fatal."""
+
+    crawler = ClauseaCrawler(use_browser=True)
+    url = "https://example.com/privacy"
+    page = AsyncMock()
+    page.goto = AsyncMock(return_value=SimpleNamespace(status=200))
+    page.title = AsyncMock(return_value="Privacy")
+    page.content = AsyncMock(
+        return_value=f"<html><head><title>Privacy</title></head><body>{'privacy ' * 200}</body></html>"
+    )
+    page.set_extra_http_headers = AsyncMock()
+    page.close = AsyncMock()
+    # Load never fires (SPA): the wait must time out and be swallowed, not abort the fetch.
+    page.wait_for_load_state = AsyncMock(side_effect=TimeoutError("load never fired"))
+    page.url = url
+
+    context = AsyncMock()
+    context.new_page = AsyncMock(return_value=page)
+
+    monkeypatch.setattr(crawler, "_setup_browser", AsyncMock(return_value=(AsyncMock(), context)))
+    monkeypatch.setattr(crawler_module, "_block_heavy_assets", AsyncMock())
+
+    result = await crawler._browser_fetch(url)
+
+    assert result is not None
+    assert result.status_code == 200
+    page.goto.assert_awaited_once()
+    assert page.goto.await_args.kwargs["wait_until"] == "domcontentloaded"
+    page.wait_for_load_state.assert_awaited_once()
+    assert page.wait_for_load_state.await_args.args[0] == "load"

--- a/packages/backend/tests/unit/crawler/state_test.py
+++ b/packages/backend/tests/unit/crawler/state_test.py
@@ -38,7 +38,8 @@ class TestRelevanceExhaustion:
     def test_stops_only_after_grace_once_leads_exhausted(self) -> None:
         crawler = ClauseaCrawler(strategy="best_first", min_legal_score=2.5)
         crawler._policy_pages_found = 1
-        crawler._frontier_real_leads = 0
+        # Only a boost-only URL remains (own score below the gate) — tail noise.
+        crawler._enqueue_best_first("https://x.com/random", 1, 3.0, 0.0)
         crawler._crawls_since_new_lead = CRAWL_EXHAUSTION_GRACE - 1
         assert crawler._relevance_exhausted() is False  # grace not yet elapsed
         crawler._crawls_since_new_lead = CRAWL_EXHAUSTION_GRACE

--- a/packages/backend/tests/unit/document_repository_recent_urls_test.py
+++ b/packages/backend/tests/unit/document_repository_recent_urls_test.py
@@ -22,6 +22,9 @@ class _FakeCursor:
     def __init__(self, rows: list[dict[str, Any]]) -> None:
         self._rows = rows
 
+    def sort(self, keys: list[tuple[str, int]]) -> _FakeCursor:
+        return self
+
     async def to_list(self, length: int | None = None) -> list[dict[str, Any]]:
         return list(self._rows)
 

--- a/packages/backend/tests/unit/pipeline/seed_selection_test.py
+++ b/packages/backend/tests/unit/pipeline/seed_selection_test.py
@@ -1,0 +1,51 @@
+"""Seed selection prefers domain roots and appends optional override seeds."""
+
+from src.models.product import Product
+from src.pipeline import PolicyDocumentPipeline
+
+
+def _pipeline() -> PolicyDocumentPipeline:
+    return PolicyDocumentPipeline()
+
+
+def test_domain_roots_are_primary_with_overrides_appended() -> None:
+    product = Product(
+        id="p1",
+        name="Acme",
+        slug="acme",
+        domains=["acme.com"],
+        crawl_base_urls=["https://acme.com/privacy", "https://legal.acme.com/policies"],
+    )
+    urls = _pipeline()._get_crawl_urls(product)
+    assert urls == [
+        "https://acme.com",
+        "https://acme.com/privacy",
+        "https://legal.acme.com/policies",
+    ]
+
+
+def test_root_override_is_deduped_against_domain_root() -> None:
+    product = Product(
+        id="p2",
+        name="Acme",
+        slug="acme",
+        domains=["acme.com"],
+        crawl_base_urls=["https://acme.com/", "https://acme.com"],
+    )
+    urls = _pipeline()._get_crawl_urls(product)
+    assert urls == ["https://acme.com"]
+
+
+def test_overrides_still_work_without_domains() -> None:
+    product = Product(
+        id="p3",
+        name="Acme",
+        slug="acme",
+        domains=[],
+        crawl_base_urls=["legal.acme.com/privacy", "https://help.acme.com/terms"],
+    )
+    urls = _pipeline()._get_crawl_urls(product)
+    assert urls == [
+        "https://legal.acme.com/privacy",
+        "https://help.acme.com/terms",
+    ]

--- a/packages/backend/tests/unit/pipeline_incremental_store_test.py
+++ b/packages/backend/tests/unit/pipeline_incremental_store_test.py
@@ -48,15 +48,20 @@ def _doc(url: str, doc_type: DocType) -> Document:
 class _FakeCrawler:
     """Stands in for ClauseaCrawler: replays canned results through the result_callback."""
 
-    def __init__(self, results: list[CrawlResult], result_callback) -> None:
+    def __init__(self, results: list[CrawlResult], result_callback, stop_callback=None) -> None:
         self._results = results
         self._result_callback = result_callback
+        self._stop_callback = stop_callback
 
     async def crawl_multiple(self, _urls: list[str]) -> list[CrawlResult]:
+        emitted: list[CrawlResult] = []
         for result in self._results:
+            if self._stop_callback is not None and self._stop_callback():
+                break
+            emitted.append(result)
             if self._result_callback is not None:
                 await self._result_callback(result)
-        return list(self._results)
+        return emitted
 
 
 @pytest.mark.asyncio
@@ -98,7 +103,11 @@ async def test_streams_store_per_result_and_counts_once(monkeypatch):
     monkeypatch.setattr(pipeline, "_finish_crawl_session", AsyncMock(return_value=None))
 
     def fake_create_crawler(_product, **kwargs):
-        return _FakeCrawler(discovery, kwargs.get("result_callback"))
+        return _FakeCrawler(
+            discovery,
+            kwargs.get("result_callback"),
+            kwargs.get("stop_callback"),
+        )
 
     monkeypatch.setattr(pipeline, "_create_crawler_for_product", fake_create_crawler)
 
@@ -154,7 +163,11 @@ async def test_streamed_docs_drive_fallback_decision(monkeypatch):
     crawlers_created: list[_FakeCrawler] = []
 
     def fake_create_crawler(_product, **kwargs):
-        crawler = _FakeCrawler(next(passes), kwargs.get("result_callback"))
+        crawler = _FakeCrawler(
+            next(passes),
+            kwargs.get("result_callback"),
+            kwargs.get("stop_callback"),
+        )
         crawlers_created.append(crawler)
         return crawler
 
@@ -169,3 +182,59 @@ async def test_streamed_docs_drive_fallback_decision(monkeypatch):
         "terms_of_service",
     }
     assert pipeline.stats.policy_documents_stored == 2
+
+
+@pytest.mark.asyncio
+async def test_discovery_stop_callback_stops_after_required_types(monkeypatch):
+    product = Product(
+        id="prod-1",
+        name="Acme",
+        slug="acme",
+        domains=["acme.com"],
+        crawl_base_urls=["https://acme.com/"],
+    )
+
+    discovery = [
+        _result("https://acme.com/privacy"),
+        _result("https://acme.com/terms"),
+        _result("https://acme.com/blog"),  # should be skipped once coverage is met
+    ]
+
+    classified_urls: list[str] = []
+
+    async def fake_process_crawl_result(result: CrawlResult, _product):
+        if "privacy" in result.url:
+            classified_urls.append(result.url)
+            return _doc(result.url, "privacy_policy")
+        if "terms" in result.url:
+            classified_urls.append(result.url)
+            return _doc(result.url, "terms_of_service")
+        classified_urls.append(result.url)
+        return None
+
+    pipeline = PolicyDocumentPipeline(
+        min_docs_before_fallback=1,
+        required_doc_types=["privacy_policy", "terms_of_service"],
+    )
+
+    monkeypatch.setattr(pipeline, "_process_crawl_result", fake_process_crawl_result)
+    monkeypatch.setattr(pipeline, "_store_documents", AsyncMock(side_effect=lambda docs: len(docs)))
+    monkeypatch.setattr(pipeline, "_start_crawl_session", AsyncMock(return_value=None))
+    monkeypatch.setattr(pipeline, "_finish_crawl_session", AsyncMock(return_value=None))
+
+    def fake_create_crawler(_product, **kwargs):
+        return _FakeCrawler(
+            discovery,
+            kwargs.get("result_callback"),
+            kwargs.get("stop_callback"),
+        )
+
+    monkeypatch.setattr(pipeline, "_create_crawler_for_product", fake_create_crawler)
+
+    documents = await pipeline._process_product(product)
+
+    assert {document.doc_type for document in documents} == {
+        "privacy_policy",
+        "terms_of_service",
+    }
+    assert "https://acme.com/blog" not in classified_urls

--- a/packages/backend/tests/unit/pipeline_stale_jobs_test.py
+++ b/packages/backend/tests/unit/pipeline_stale_jobs_test.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from src.models.pipeline_job import PipelineErrorCode
+from src.repositories import pipeline_repository as pr
 from src.repositories.pipeline_repository import PipelineRepository
 
 
@@ -33,22 +35,39 @@ def _failed_jobs_collection(active_slugs, candidates):
     collection = MagicMock()
     collection.distinct = AsyncMock(return_value=active_slugs)
     cursor = MagicMock()
+    cursor.sort.return_value = cursor
     cursor.to_list = AsyncMock(return_value=candidates)
     collection.find = MagicMock(return_value=cursor)
-    collection.update_one = AsyncMock()
+    collection.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
     return collection
 
 
 @pytest.mark.asyncio
-async def test_requeue_failed_retries_unlimited_regardless_of_attempts():
-    # Retries are unlimited: a job mostly accrues attempts from redeploys orphaning long
-    # crawls, not real defects, so there is no attempt ceiling. Even a high-attempt job
-    # must be requeued.
+async def test_requeue_failed_respects_retry_policy(monkeypatch):
+    monkeypatch.setattr(pr, "MAX_AUTO_RETRY_ATTEMPTS", 3)
+
     collection = _failed_jobs_collection(
         active_slugs=[],
         candidates=[
-            {"id": "a", "product_slug": "alpha", "attempts": 1},
-            {"id": "b", "product_slug": "beta", "attempts": 99},
+            {
+                "id": "a",
+                "product_slug": "alpha",
+                "attempts": 1,
+                "error": PipelineErrorCode.internal_error.value,
+            },
+            {
+                "id": "b",
+                "product_slug": "beta",
+                "attempts": 3,
+                "error": PipelineErrorCode.internal_error.value,
+            },
+            {
+                "id": "c",
+                "product_slug": "gamma",
+                "attempts": 1,
+                "error": PipelineErrorCode.no_documents_found.value,
+            },
+            {"id": "d", "product_slug": "delta", "attempts": 1, "error": "Cancelled by user"},
         ],
     )
     db = MagicMock()
@@ -57,17 +76,55 @@ async def test_requeue_failed_retries_unlimited_regardless_of_attempts():
     requeued = await PipelineRepository().requeue_failed_jobs(db)
 
     query = collection.find.call_args.args[0]
-    # Only failed jobs are retried; no_documents stays terminal.
+    # Only failed/non-active/non-disabled jobs are considered.
     assert query["status"] == "failed"
-    # No attempt cap: the query must not filter on attempts at all.
-    assert "$or" not in query
+    assert query["active"] == {"$ne": True}
+    assert query["auto_retry_disabled"] == {"$ne": True}
     assert "attempts" not in query
-    update = collection.update_one.call_args.args[1]
-    assert update["$set"]["status"] == "pending"
-    # Steps reset so a retry doesn't carry stale terminal step state.
-    assert all(s["status"] == "pending" for s in update["$set"]["steps"])
-    # The 99-attempt job is requeued too.
-    assert requeued == 2
+    # One retryable + under-budget job was requeued.
+    assert requeued == 1
+
+    by_id = {call.args[0]["id"]: call.args[1]["$set"] for call in collection.update_one.call_args_list}
+    assert by_id["a"]["status"] == "pending"
+    assert by_id["b"]["auto_retry_disabled"] is True
+    assert "attempt limit reached" in by_id["b"]["auto_retry_disabled_reason"]
+    assert by_id["c"]["auto_retry_disabled"] is True
+    assert "non-retryable failure" in by_id["c"]["auto_retry_disabled_reason"]
+    assert by_id["d"]["auto_retry_disabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_requeue_failed_resets_attempt_local_crawl_state():
+    collection = _failed_jobs_collection(
+        active_slugs=[],
+        candidates=[
+            {
+                "id": "a",
+                "product_slug": "alpha",
+                "attempts": 1,
+                "error": PipelineErrorCode.internal_error.value,
+                "documents_found": 42,
+                "documents_stored": 7,
+                "crawl_errors": [{"url": "https://example.com/p", "error_type": "http_error"}],
+                "crawl_skip_reasons": [
+                    {"url": "https://example.com/t", "reason": "non_policy_classification"}
+                ],
+            }
+        ],
+    )
+    db = MagicMock()
+    db.__getitem__.return_value = collection
+
+    requeued = await PipelineRepository().requeue_failed_jobs(db)
+
+    assert requeued == 1
+    update = collection.update_one.call_args.args[1]["$set"]
+    assert update["status"] == "pending"
+    assert update["documents_found"] == 0
+    assert update["documents_stored"] == 0
+    assert update["crawl_errors"] == []
+    assert update["crawl_skip_reasons"] == []
+    assert all(step["status"] == "pending" for step in update["steps"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
All local changes, in three commits.

## 1. Crawler discovery recall overhaul (`da44d13`)
Recall > quality > efficiency. Found/validated with local crawls + an adversarial review pass.
- **App-shell links (P0a):** a content-thin page that fails extraction now keeps its `discovered_links` and the loop follows links regardless of `success`. A thin SPA homepage is a poor *document* but the only path to its footer policy links. **deepseek: 1 visited/0 docs → 10/5.**
- **Jurisdiction-safe locale dedup (Prong B):** only bare `en`/`english` mirrors collapse; region-qualified `en-XX` (`en-us`=CCPA vs `en-gb`=GDPR) are distinct legal texts and each crawled — identical ones dropped later by the content fingerprint. Fixes a recall regression the review caught (could discard the US or GDPR policy).
- **Short `load` settle (2s):** restores capture of partial-SSR bodies truncated at `domcontentloaded` (`signal.org/legal` 7 838 → 13 173 chars) without the old 5s cost.
- **Root + curated seeds unioned** (Workstream 1); `browser_concurrency` 2→4.

## 2. Bounded auto-retry + user-cancellation (`c1ef6cb`)
`cancelled_by_user` terminal state + sticky `auto_retry_disabled` guard so stale-sweeps don't endlessly re-queue; per-attempt crawl diagnostics reset on retry; repository/index/route support.

## 3. Dev tooling (`9d8a13f`)
Read-only probes: `crawl_probe` (converged-vs-wander + before/after recall gate), `content_probe` (per-URL extracted-length diff), `queue_status` (prod queue snapshot).

## Validation (local, no prod)
deepseek 0→5 docs; `signal.org/legal` full content; clausea no regression; **651 unit tests pass**; ruff + ty clean. Worker stays paused — nothing shipped to prod until this lands and a full re-crawl is validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)