### PR TITLE
fix(crawler): collect full policy set; prioritise policy paths over marketing

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -656,6 +656,17 @@ class URLScorer:
             re.IGNORECASE,
         )
 
+        # Segment-anchored so "platforms" never matches "terms". URLs matching this
+        # are drained from the best-first frontier ahead of everything else, so a
+        # boost-inflated marketing section (e.g. a 100-page /security tree) cannot
+        # exhaust the page budget before the real policy docs are fetched.
+        self._strong_policy_path_re = re.compile(
+            r"(?:^|/)(?:privacy|terms|tos|legal|cookies?|gdpr|ccpa|dpa|"
+            r"data-processing(?:-addendum)?|sub-?processors?|site-policy|policies|"
+            r"policy|eula|acceptable-use|community-guidelines)(?:[-_/]|$)",
+            re.IGNORECASE,
+        )
+
         self.legal_keywords = {
             # Generic legal terms
             "legal": 3.5,
@@ -831,6 +842,14 @@ class URLScorer:
         boosts — see ``add_urls_to_queue``.
         """
         return bool(self._non_policy_section_re.search(urlparse(url.lower()).path))
+
+    def is_strong_policy_path(self, url: str) -> bool:
+        """True when a path segment unambiguously names a core policy document.
+
+        Such URLs are crawled before any other lead so a high-volume marketing
+        section can't consume the page budget ahead of the real policy docs.
+        """
+        return bool(self._strong_policy_path_re.search(urlparse(url.lower()).path))
 
 
 class ContentAnalyzer:
@@ -1667,7 +1686,7 @@ class ClauseaCrawler:
         self.url_queue: deque[tuple[str, int]] = deque()  # For BFS
         self.url_stack: list[tuple[str, int]] = []  # For DFS
         # best-first frontier: (-score, url, depth, base_score). base_score excludes parent boost.
-        self.url_priority_queue: list[tuple[float, str, int, float]] = []
+        self.url_priority_queue: list[tuple[int, float, str, int, float]] = []
         self._frontier_real_leads: int = 0  # queued URLs whose own score clears the gate
         self._policy_pages_found: int = 0
         self._crawls_since_new_lead: int = 0
@@ -3803,7 +3822,8 @@ class ClauseaCrawler:
 
     def _enqueue_best_first(self, url: str, depth: int, score: float, base_score: float) -> None:
         """Push to the frontier; only an own-score lead (not a boost-only link) counts as real."""
-        heapq.heappush(self.url_priority_queue, (-score, url, depth, base_score))
+        policy_rank = 0 if self.url_scorer.is_strong_policy_path(url) else 1
+        heapq.heappush(self.url_priority_queue, (policy_rank, -score, url, depth, base_score))
         if base_score >= self.min_legal_score:
             self._frontier_real_leads += 1
             self._crawls_since_new_lead = 0
@@ -3812,7 +3832,7 @@ class ClauseaCrawler:
         """Best remaining own-score in the frontier (ignores parent-page boost)."""
         if self.strategy != "best_first" or not self.url_priority_queue:
             return None
-        return max(base_score for _, _, _, base_score in self.url_priority_queue)
+        return max(base_score for _, _, _, _, base_score in self.url_priority_queue)
 
     def _relevance_exhausted(self) -> bool:
         """True once only low-own-score URLs remain after policy has been found.
@@ -3967,7 +3987,7 @@ class ClauseaCrawler:
         elif self.strategy == "dfs" and self.url_stack:
             return self.url_stack.pop()
         elif self.strategy == "best_first" and self.url_priority_queue:
-            _, url, depth, base_score = heapq.heappop(self.url_priority_queue)
+            _, _, url, depth, base_score = heapq.heappop(self.url_priority_queue)
             if base_score >= self.min_legal_score:
                 self._frontier_real_leads -= 1
             return url, depth

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -1440,8 +1440,6 @@ class PolicyDocumentPipeline:
             seen_fingerprints: set[str] = set()
             total_results = 0
             processed_documents: list[Document] = []
-            discovered_doc_types: set[str] = set()
-            discovery_coverage_met = False
 
             # Stream each crawled result through classification + storage as it is
             # produced, so a crawl killed at the time ceiling or by a stall keeps the
@@ -1450,7 +1448,6 @@ class PolicyDocumentPipeline:
             # per-result calls exactly as the old batch call did. _store_documents is
             # idempotent (dedupes by URL/fingerprint), so re-arrivals are safe.
             async def result_callback(result: CrawlResult) -> None:
-                nonlocal discovery_coverage_met
                 docs = await self._classify_results(
                     [result], product, processed_urls, seen_fingerprints
                 )
@@ -1458,16 +1455,6 @@ class PolicyDocumentPipeline:
                     stored = await self._store_documents(docs)
                     self.stats.policy_documents_stored += stored
                     processed_documents.extend(docs)
-                    discovered_doc_types.update(
-                        str(doc.doc_type) for doc in docs if getattr(doc, "doc_type", None)
-                    )
-                    if len(processed_documents) >= self.min_docs_before_fallback and all(
-                        req in discovered_doc_types for req in self.required_doc_types
-                    ):
-                        discovery_coverage_met = True
-
-            def stop_discovery_callback() -> bool:
-                return discovery_coverage_met
 
             # Docs stored within the resume freshness window. A retried crawl skips
             # re-fetching these so it resumes instead of re-rendering hours of work;
@@ -1497,19 +1484,12 @@ class PolicyDocumentPipeline:
                 strategy=self.discovery_strategy,
                 progress_phase="discovery",
                 result_callback=result_callback,
-                stop_callback=stop_discovery_callback,
                 recently_stored_urls=recently_stored_urls,
             )
             discovery_results = await self._crawl_base_urls(discovery_crawler, crawl_urls)
             logger_discovery.info(
                 f"discovery pass complete for '{product.name}': found {len(discovery_results)} pages"
             )
-            if discovery_coverage_met:
-                logger_discovery.info(
-                    f"discovery coverage target met for '{product.name}' "
-                    f"(required types: {', '.join(self.required_doc_types)}); "
-                    "stopped discovery early"
-                )
             total_results += len(discovery_results)
 
             # Fallback deep crawl (recall-first) if coverage is low. The decision runs

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -99,7 +99,7 @@ def test_add_urls_to_queue_respects_rel_nofollow_and_meta():
     all_urls = (
         {u for u, _ in crawler.url_queue}
         | {u for u, _ in crawler.url_stack}
-        | {u for _, u, _, _ in crawler.url_priority_queue}
+        | {u for _, _, u, _, _ in crawler.url_priority_queue}
     )
     assert "https://example.com/privacy" not in all_urls
 
@@ -109,7 +109,7 @@ def test_add_urls_to_queue_respects_rel_nofollow_and_meta():
     all_urls2 = (
         {u for u, _ in crawler2.url_queue}
         | {u for u, _ in crawler2.url_stack}
-        | {u for _, u, _, _ in crawler2.url_priority_queue}
+        | {u for _, _, u, _, _ in crawler2.url_priority_queue}
     )
     assert "https://example.com/privacy" in all_urls2
 

--- a/packages/backend/tests/unit/crawler/state_test.py
+++ b/packages/backend/tests/unit/crawler/state_test.py
@@ -142,7 +142,7 @@ class TestCrawlerState:
         import heapq
 
         crawler = ClauseaCrawler(strategy="best_first")
-        heapq.heappush(crawler.url_priority_queue, (-5.0, "https://example.com/a", 1, 5.0))
+        heapq.heappush(crawler.url_priority_queue, (1, -5.0, "https://example.com/a", 1, 5.0))
         assert crawler._get_pending_url_count() == 1
 
 

--- a/packages/backend/tests/unit/crawler/url_scorer_test.py
+++ b/packages/backend/tests/unit/crawler/url_scorer_test.py
@@ -228,7 +228,7 @@ class TestParentPageBoost:
         )
 
         assert len(crawler.url_priority_queue) == 1
-        neg_score, url, _depth, _base = crawler.url_priority_queue[0]
+        _rank, neg_score, url, _depth, _base = crawler.url_priority_queue[0]
         actual_score = -neg_score
 
         # Score should exceed the base URL score thanks to the parent boost
@@ -258,7 +258,7 @@ class TestParentPageBoost:
             page_metadata={"title": "Legal Resources"},
         )
 
-        queued = {url for _neg, url, _depth, _base in crawler.url_priority_queue}
+        queued = {url for _rank, _neg, url, _depth, _base in crawler.url_priority_queue}
         assert "https://example.com/template/holiday" not in queued
         assert "https://example.com/templates/legal-case/exp9" not in queued
         # The boost still works for non-excluded opaque policy URLs.
@@ -394,3 +394,60 @@ class TestMirrorSubdomainExclusion:
             "www",
         ):
             assert not _MIRROR_SUBDOMAIN_RE.search(subdomain), subdomain
+
+
+class TestStrongPolicyPathPriority:
+    """Strong policy-path URLs drain from the best-first frontier before any other
+    lead, so a boost-inflated marketing section can't exhaust the page budget first."""
+
+    def _make_crawler(self) -> ClauseaCrawler:
+        crawler = ClauseaCrawler(
+            respect_robots_txt=False,
+            strategy="best_first",
+            min_legal_score=0.0,
+            allowed_domains=["example.com"],
+        )
+        crawler._sitemap_seeded = True
+        return crawler
+
+    def test_strong_policy_path_predicate(self) -> None:
+        scorer = URLScorer()
+        assert scorer.is_strong_policy_path("https://example.com/legal/privacy")
+        assert scorer.is_strong_policy_path("https://example.com/terms-of-service")
+        assert scorer.is_strong_policy_path("https://example.com/cookie-policy")
+        assert scorer.is_strong_policy_path(
+            "https://docs.github.com/en/site-policy/privacy-policies/github-cookies"
+        )
+        # Ambiguous / non-policy segments stay out of the priority tier.
+        assert not scorer.is_strong_policy_path("https://example.com/security/overview")
+        assert not scorer.is_strong_policy_path("https://example.com/platforms")
+        assert not scorer.is_strong_policy_path("https://example.com/blog/our-policy-update")
+
+    def test_policy_path_dequeued_before_higher_scored_marketing(self) -> None:
+        crawler = self._make_crawler()
+        # Marketing page with an inflated (parent-boosted) score...
+        crawler._enqueue_best_first("https://example.com/security/overview", 1, 9.0, 9.0)
+        # ...still loses to a genuine policy path scored far lower.
+        crawler._enqueue_best_first("https://example.com/legal/privacy", 1, 3.0, 3.0)
+
+        first = crawler.get_next_url()
+        assert first is not None and first[0] == "https://example.com/legal/privacy"
+
+    def test_all_policy_paths_drain_before_any_marketing(self) -> None:
+        crawler = self._make_crawler()
+        crawler._enqueue_best_first("https://example.com/security/a", 1, 9.0, 9.0)
+        crawler._enqueue_best_first("https://example.com/security/b", 1, 8.5, 8.5)
+        crawler._enqueue_best_first("https://example.com/cookie-policy", 1, 2.0, 2.0)
+        crawler._enqueue_best_first("https://example.com/terms", 1, 4.0, 4.0)
+
+        order: list[str] = []
+        while (nxt := crawler.get_next_url()) is not None:
+            order.append(nxt[0])
+
+        # Higher score leads within the policy tier; both policy paths precede marketing.
+        assert order == [
+            "https://example.com/terms",
+            "https://example.com/cookie-policy",
+            "https://example.com/security/a",
+            "https://example.com/security/b",
+        ]

--- a/packages/backend/tests/unit/pipeline_incremental_store_test.py
+++ b/packages/backend/tests/unit/pipeline_incremental_store_test.py
@@ -185,7 +185,10 @@ async def test_streamed_docs_drive_fallback_decision(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_discovery_stop_callback_stops_after_required_types(monkeypatch):
+async def test_discovery_does_not_stop_after_required_types(monkeypatch):
+    """Having privacy + terms must NOT halt discovery: the crawl keeps streaming so
+    cookie/DPA/subprocessor docs found later are still classified and stored. The
+    old coverage-met stop dropped every policy doc after the first two."""
     product = Product(
         id="prod-1",
         name="Acme",
@@ -197,20 +200,18 @@ async def test_discovery_stop_callback_stops_after_required_types(monkeypatch):
     discovery = [
         _result("https://acme.com/privacy"),
         _result("https://acme.com/terms"),
-        _result("https://acme.com/blog"),  # should be skipped once coverage is met
+        _result("https://acme.com/cookies"),  # arrives AFTER the required types are met
     ]
 
     classified_urls: list[str] = []
 
     async def fake_process_crawl_result(result: CrawlResult, _product):
+        classified_urls.append(result.url)
         if "privacy" in result.url:
-            classified_urls.append(result.url)
             return _doc(result.url, "privacy_policy")
         if "terms" in result.url:
-            classified_urls.append(result.url)
             return _doc(result.url, "terms_of_service")
-        classified_urls.append(result.url)
-        return None
+        return _doc(result.url, "cookie_policy")
 
     pipeline = PolicyDocumentPipeline(
         min_docs_before_fallback=1,
@@ -236,5 +237,6 @@ async def test_discovery_stop_callback_stops_after_required_types(monkeypatch):
     assert {document.doc_type for document in documents} == {
         "privacy_policy",
         "terms_of_service",
+        "cookie_policy",
     }
-    assert "https://acme.com/blog" not in classified_urls
+    assert "https://acme.com/cookies" in classified_urls


### PR DESCRIPTION
## Problem

Every product was storing exactly **2 docs** (privacy + terms) and nothing else — cookies, DPA, subprocessors, community guidelines were all dropped, even when the crawler discovered them. This violates the recall mandate (never drop a policy page).

**Root cause (verified in code + e2e):** the discovery pass wired a `stop_discovery_callback` that halted the crawl the instant `min_docs_before_fallback` was met **and** all `required_doc_types` (`privacy_policy,terms_of_service`) were stored. So the crawl stopped after the first privacy + terms doc, before reaching anything else.

## Proof (local e2e, early-stop neutralized via env, no code change)

| product | before | after | recovered |
|---|---|---|---|
| deepseek | 2 | **4** | `cookie_policy` (en-US + en-UK) |
| github | 2 | **7** | `github-cookies`, `subprocessors`, `trust-center` |

## Changes

1. **`pipeline.py` — remove the coverage-met early-stop.** The discovery pass now runs to its own convergence (`no_policy_page_budget` / relevance-exhaustion), collecting all reachable policy docs. `required_doc_types` still drives the recall-first **fallback** trigger (unchanged).
2. **`crawler.py` — policy-path priority tier in the best-first frontier.** Strong policy-path URLs (`privacy|terms|legal|cookie|site-policy|gdpr|ccpa|dpa|subprocessors|…`) are drained before any other lead, so a boost-inflated marketing section (e.g. github's 106-page `/security` tree) can't exhaust the page budget before the real policy docs are fetched. Segment-anchored matching, so `/platforms` ≠ `terms` and ambiguous `/security` stays un-prioritized (never blocklisted — github's `trust-center` is a legit security policy).

These ship together: removing the early-stop (1) without policy-first ordering (2) would let a large site wander marketing pages into the cap.

## Tests
- `pipeline_incremental_store_test`: flipped the old "stops after required types" test to assert discovery **keeps collecting** past privacy+terms (cookie policy arriving later is still stored).
- `url_scorer_test`: `is_strong_policy_path` predicate cases + frontier-ordering (policy paths drain before higher-scored marketing).
- Full suite: 654 passed; `ruff check .` + `ty check` clean.

## Validation still pending before merge
Hard-tier e2e (shein/amazon) to confirm full policy recall **without** runaway wander into the page cap. Worker stays paused until that clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)