### PR TITLE
feat(extension): harvest live-DOM footer seeds to bypass anti-bot walls

### DIFF
--- a/packages/backend/src/models/pipeline_job.py
+++ b/packages/backend/src/models/pipeline_job.py
@@ -173,3 +173,8 @@ class PipelineJob(BaseModel):
     # categorized failure message when crawl_errors is empty but the
     # pipeline still found no policy documents.
     crawl_skip_reasons: list[CrawlSkip] = Field(default_factory=list)
+
+    # Policy-page URLs harvested from the live DOM by the browser extension
+    # (footer links the server crawler cannot reach due to anti-bot walls).
+    # Injected as high-priority seeds at the start of the crawl.
+    seed_urls: list[str] = Field(default_factory=list)

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -1393,7 +1393,9 @@ class PolicyDocumentPipeline:
         )
         return results
 
-    async def _process_product(self, product: Product) -> list[Document]:
+    async def _process_product(
+        self, product: Product, seed_urls: list[str] | None = None
+    ) -> list[Document]:
         """
         Process a single product through the complete pipeline.
 
@@ -1405,6 +1407,23 @@ class PolicyDocumentPipeline:
         """
         product_start_time = time.time()
         log_memory_usage(f"Starting {product.name}")
+
+        # Extension-provided footer seeds: fold them into crawl_base_urls so
+        # _get_crawl_urls dedupes them with existing seeds and
+        # _allowed_domains_for_product adds their registered domains to the allowed list.
+        # These are direct policy-page URLs harvested from the rendered DOM (the user's
+        # browser already bypassed any anti-bot wall), so they arrive before the regular
+        # discovery seeds and get policy_rank=0 in the best-first frontier.
+        if seed_urls:
+            product = product.model_copy(
+                update={"crawl_base_urls": list(product.crawl_base_urls or []) + seed_urls}
+            )
+            logger.info(
+                "injecting %d extension footer seed(s) for %s: %s",
+                len(seed_urls),
+                product.name,
+                seed_urls,
+            )
 
         # Get crawl URLs (domain roots primary, crawl_base_urls as optional overrides).
         crawl_urls = self._get_crawl_urls(product)
@@ -1575,7 +1594,11 @@ class PolicyDocumentPipeline:
             self.stats.failed_product_slugs.append(product.slug)
             return []
 
-    async def run(self, products: list[Product] | None = None) -> ProcessingStats:
+    async def run(
+        self,
+        products: list[Product] | None = None,
+        seed_urls: list[str] | None = None,
+    ) -> ProcessingStats:
         """
         Execute the complete policy document crawling pipeline.
 
@@ -1606,7 +1629,7 @@ class PolicyDocumentPipeline:
             async def _process_product_with_semaphore(idx: int, product: Product) -> None:
                 async with semaphore:
                     logger.info(f"🏢 [{idx}/{len(products)}] Starting product: {product.name}")
-                    await self._process_product(product)
+                    await self._process_product(product, seed_urls=seed_urls)
                     logger.info(f"✅ [{idx}/{len(products)}] Finished product: {product.name}")
 
             # Create tasks for all products

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -1393,9 +1393,7 @@ class PolicyDocumentPipeline:
         )
         return results
 
-    async def _process_product(
-        self, product: Product, seed_urls: list[str] | None = None
-    ) -> list[Document]:
+    async def _process_product(self, product: Product) -> list[Document]:
         """
         Process a single product through the complete pipeline.
 
@@ -1407,23 +1405,6 @@ class PolicyDocumentPipeline:
         """
         product_start_time = time.time()
         log_memory_usage(f"Starting {product.name}")
-
-        # Extension-provided footer seeds: fold them into crawl_base_urls so
-        # _get_crawl_urls dedupes them with existing seeds and
-        # _allowed_domains_for_product adds their registered domains to the allowed list.
-        # These are direct policy-page URLs harvested from the rendered DOM (the user's
-        # browser already bypassed any anti-bot wall), so they arrive before the regular
-        # discovery seeds and get policy_rank=0 in the best-first frontier.
-        if seed_urls:
-            product = product.model_copy(
-                update={"crawl_base_urls": list(product.crawl_base_urls or []) + seed_urls}
-            )
-            logger.info(
-                "injecting %d extension footer seed(s) for %s: %s",
-                len(seed_urls),
-                product.name,
-                seed_urls,
-            )
 
         # Get crawl URLs (domain roots primary, crawl_base_urls as optional overrides).
         crawl_urls = self._get_crawl_urls(product)
@@ -1594,11 +1575,7 @@ class PolicyDocumentPipeline:
             self.stats.failed_product_slugs.append(product.slug)
             return []
 
-    async def run(
-        self,
-        products: list[Product] | None = None,
-        seed_urls: list[str] | None = None,
-    ) -> ProcessingStats:
+    async def run(self, products: list[Product] | None = None) -> ProcessingStats:
         """
         Execute the complete policy document crawling pipeline.
 
@@ -1629,7 +1606,7 @@ class PolicyDocumentPipeline:
             async def _process_product_with_semaphore(idx: int, product: Product) -> None:
                 async with semaphore:
                     logger.info(f"🏢 [{idx}/{len(products)}] Starting product: {product.name}")
-                    await self._process_product(product, seed_urls=seed_urls)
+                    await self._process_product(product)
                     logger.info(f"✅ [{idx}/{len(products)}] Finished product: {product.name}")
 
             # Create tasks for all products

--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -93,6 +93,13 @@ class ProductRepository(BaseRepository):
         logger.debug(f"Created product {product.slug}")
         return product
 
+    async def add_crawl_seeds(self, db: AgnosticDatabase, product_id: str, urls: list[str]) -> None:
+        """Append URLs to crawl_base_urls, ignoring duplicates already present."""
+        await db.products.update_one(
+            {"id": product_id},
+            {"$addToSet": {"crawl_base_urls": {"$each": urls}}},
+        )
+
     async def find_all(self, db: AgnosticDatabase) -> list[Product]:
         """Get all products.
 

--- a/packages/backend/src/routes/extension.py
+++ b/packages/backend/src/routes/extension.py
@@ -68,6 +68,7 @@ class ExtensionAnalyzeRequest(BaseModel):
     """Request body for triggering analysis from the extension."""
 
     url: str
+    seed_urls: list[str] | None = None
 
 
 class ExtensionAnalyzeResponse(BaseModel):
@@ -321,9 +322,13 @@ async def analyze_url(
     domain = extract_domain(url)
     normalized_url = f"https://{domain}"
 
+    # Cap and sanitize extension-provided seeds (best-effort; malformed URLs are
+    # skipped by the crawler's URL gate, so no strict validation needed here).
+    seed_urls = [s for s in (payload.seed_urls or []) if s.startswith("http")][:20] or None
+
     pipeline_svc = create_pipeline_service()
 
-    result = await pipeline_svc.create_job_for_url(db, normalized_url)
+    result = await pipeline_svc.create_job_for_url(db, normalized_url, seed_urls=seed_urls)
 
     if result.get("already_indexed"):
         return ExtensionAnalyzeResponse(

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -91,7 +91,9 @@ class PipelineService:
         """Get the active (running) pipeline job for a product, if any."""
         return await self._pipeline_repo.find_active_by_product_slug(db, product_slug)
 
-    async def create_job_for_url(self, db: AgnosticDatabase, url: str) -> dict:
+    async def create_job_for_url(
+        self, db: AgnosticDatabase, url: str, seed_urls: list[str] | None = None
+    ) -> dict:
         """Create a pipeline job for a URL.
 
         If the product is already fully indexed (completed overview exists), returns
@@ -152,6 +154,7 @@ class PipelineService:
             product_id=product.id,
             product_name=product.name,
             url=url,
+            seed_urls=seed_urls or [],
         )
         job, created = await self._pipeline_repo.find_or_create_active(db, job)
         if created:
@@ -388,7 +391,7 @@ class PipelineService:
                         crawl_tasks.append(task)
 
                     pipeline = PolicyDocumentPipeline(progress_callback=_on_crawl_progress)
-                    stats = await pipeline.run([product])
+                    stats = await pipeline.run([product], seed_urls=job.seed_urls or None)
 
                     # Drain pending progress tasks before finalizing the crawl step
                     if crawl_tasks:

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -33,6 +33,7 @@ from src.models.product import Product
 from src.pipeline import PolicyDocumentPipeline
 from src.prompts.analysis_prompts import OVERVIEW_CORE_DOC_TYPES
 from src.repositories.pipeline_repository import PipelineRepository
+from src.repositories.product_repository import ProductRepository
 from src.services.service_factory import create_document_service, create_product_service
 from src.utils.domain import extract_domain as _extract_domain
 
@@ -148,6 +149,19 @@ class PipelineService:
             )
             await product_svc.create_product(db, product)
             logger.info(f"Created new product '{product.name}' ({product.slug}) from URL: {url}")
+
+        # Persist extension-provided seeds into the product so every future re-crawl
+        # can reach them. Sites behind anti-bot walls are unreachable without these
+        # URLs — discarding them after one use means monitoring re-crawls will find
+        # zero documents. $addToSet ensures no duplicates.
+        if seed_urls:
+            product_repo = ProductRepository()
+            await product_repo.add_crawl_seeds(db, product.id, seed_urls)
+            logger.info(
+                "persisted %d extension seed(s) to product %s crawl_base_urls",
+                len(seed_urls),
+                product.slug,
+            )
 
         job = PipelineJob(
             product_slug=product.slug,
@@ -391,7 +405,7 @@ class PipelineService:
                         crawl_tasks.append(task)
 
                     pipeline = PolicyDocumentPipeline(progress_callback=_on_crawl_progress)
-                    stats = await pipeline.run([product], seed_urls=job.seed_urls or None)
+                    stats = await pipeline.run([product])
 
                     # Drain pending progress tasks before finalizing the crawl step
                     if crawl_tasks:

--- a/packages/backend/tests/unit/pipeline/seed_selection_test.py
+++ b/packages/backend/tests/unit/pipeline/seed_selection_test.py
@@ -96,15 +96,20 @@ def test_extension_seed_domain_added_to_allowed_domains() -> None:
 
 @pytest.mark.asyncio
 async def test_extension_seeds_reach_crawl_multiple(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_process_product must pass extension seeds to crawl_multiple."""
+    """Seeds persisted into product.crawl_base_urls reach crawl_multiple naturally.
+
+    The extension writes seeds to the product in the DB before the pipeline runs.
+    The pipeline fetches the updated product and _get_crawl_urls includes the seeds
+    without any special parameter threading.
+    """
+    seed = "https://fr.shein.com/Consumer-Privacy-Notice-s-101.html"
     product = Product(
         id="p6",
         name="Shein",
         slug="shein",
         domains=["shein.com"],
-        crawl_base_urls=[],
+        crawl_base_urls=[seed],  # seeds already persisted to the product
     )
-    seed = "https://fr.shein.com/Consumer-Privacy-Notice-s-101.html"
     batches: list[list[str]] = []
 
     class _FakeCrawler:
@@ -123,7 +128,7 @@ async def test_extension_seeds_reach_crawl_multiple(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(pipeline, "_finish_crawl_session", AsyncMock(return_value=None))
     monkeypatch.setattr(pipeline, "_get_recently_stored_urls", AsyncMock(return_value=[]))
 
-    await pipeline._process_product(product, seed_urls=[seed])
+    await pipeline._process_product(product)
 
     all_crawled = [url for batch in batches for url in batch]
     assert seed in all_crawled

--- a/packages/backend/tests/unit/pipeline/seed_selection_test.py
+++ b/packages/backend/tests/unit/pipeline/seed_selection_test.py
@@ -1,5 +1,9 @@
 """Seed selection prefers domain roots and appends optional override seeds."""
 
+from unittest.mock import AsyncMock
+
+import pytest
+
 from src.models.product import Product
 from src.pipeline import PolicyDocumentPipeline
 
@@ -49,3 +53,77 @@ def test_overrides_still_work_without_domains() -> None:
         "https://legal.acme.com/privacy",
         "https://help.acme.com/terms",
     ]
+
+
+# ---------------------------------------------------------------------------
+# Extension footer seeds
+# ---------------------------------------------------------------------------
+
+
+def test_extension_seeds_appear_in_crawl_urls() -> None:
+    """seed_urls injected via _process_product must appear in the crawl URL list."""
+    product = Product(
+        id="p4",
+        name="Shein",
+        slug="shein",
+        domains=["shein.com"],
+        crawl_base_urls=[],
+    )
+    seed = "https://fr.shein.com/Consumer-Privacy-Notice-s-101.html"
+    augmented = product.model_copy(
+        update={"crawl_base_urls": list(product.crawl_base_urls or []) + [seed]}
+    )
+    urls = _pipeline()._get_crawl_urls(augmented)
+    assert seed in urls
+
+
+def test_extension_seed_domain_added_to_allowed_domains() -> None:
+    """A seed from a different subdomain expands the crawler's allowed-domain list."""
+    product = Product(
+        id="p5",
+        name="Shein",
+        slug="shein",
+        domains=["shein.com"],
+        crawl_base_urls=[],
+    )
+    seed = "https://fr.shein.com/Consumer-Privacy-Notice-s-101.html"
+    augmented = product.model_copy(
+        update={"crawl_base_urls": list(product.crawl_base_urls or []) + [seed]}
+    )
+    allowed = PolicyDocumentPipeline._allowed_domains_for_product(augmented)
+    assert any("shein" in d for d in allowed)
+
+
+@pytest.mark.asyncio
+async def test_extension_seeds_reach_crawl_multiple(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_process_product must pass extension seeds to crawl_multiple."""
+    product = Product(
+        id="p6",
+        name="Shein",
+        slug="shein",
+        domains=["shein.com"],
+        crawl_base_urls=[],
+    )
+    seed = "https://fr.shein.com/Consumer-Privacy-Notice-s-101.html"
+    batches: list[list[str]] = []
+
+    class _FakeCrawler:
+        def __init__(self, result_callback=None, **_kwargs):
+            self._result_callback = result_callback
+
+        async def crawl_multiple(self, urls: list[str]) -> list:
+            batches.append(list(urls))
+            return []
+
+    pipeline = _pipeline()
+    monkeypatch.setattr(
+        pipeline, "_create_crawler_for_product", lambda _p, **kw: _FakeCrawler(**kw)
+    )
+    monkeypatch.setattr(pipeline, "_start_crawl_session", AsyncMock(return_value=None))
+    monkeypatch.setattr(pipeline, "_finish_crawl_session", AsyncMock(return_value=None))
+    monkeypatch.setattr(pipeline, "_get_recently_stored_urls", AsyncMock(return_value=[]))
+
+    await pipeline._process_product(product, seed_urls=[seed])
+
+    all_crawled = [url for batch in batches for url in batch]
+    assert seed in all_crawled

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -167,6 +167,41 @@ export default defineBackground(() => {
     }
   });
 
+  /**
+   * Scan the active tab's rendered DOM for footer policy links.
+   * Runs in the page context via chrome.scripting.executeScript.
+   * Returns up to 20 URLs whose path segments name a core policy document.
+   */
+  function collectPolicyLinks(): string[] {
+    const policyRe =
+      /\/(privacy|terms|tos|legal|cookies?|gdpr|ccpa|dpa|data-processing|sub-?processors?|policies?|policy|eula|acceptable-use|community-guidelines)/i;
+
+    const footerEls = Array.from(
+      document.querySelectorAll('footer, [role="contentinfo"], .footer, #footer'),
+    );
+    const scope: Element[] = footerEls.length > 0 ? footerEls : [document.body];
+
+    const seen = new Set<string>();
+    const seeds: string[] = [];
+
+    for (const el of scope) {
+      for (const a of Array.from(el.querySelectorAll("a[href]")) as HTMLAnchorElement[]) {
+        const href = a.href;
+        if (!href?.startsWith("http") || seen.has(href)) continue;
+        try {
+          if (policyRe.test(new URL(href).pathname)) {
+            seen.add(href);
+            seeds.push(href);
+            if (seeds.length >= 20) return seeds;
+          }
+        } catch {
+          // malformed href — skip
+        }
+      }
+    }
+    return seeds;
+  }
+
   // Handle messages from popup
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type === "CHECK_URL") {
@@ -204,6 +239,27 @@ export default defineBackground(() => {
       getExtensionHeaders()
         .then((headers) => sendResponse({ success: true, headers }))
         .catch(() => sendResponse({ success: true, headers: {} }));
+      return true;
+    }
+
+    if (message.type === "COLLECT_FOOTER_SEEDS") {
+      // Inject collectPolicyLinks into the active tab's page context.
+      // activeTab grants temporary access to the current tab when the user
+      // opens the popup, so no broad host_permissions are required.
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        const tabId = tabs[0]?.id;
+        if (!tabId) {
+          sendResponse({ success: true, seeds: [] });
+          return;
+        }
+        chrome.scripting
+          .executeScript({ target: { tabId }, func: collectPolicyLinks })
+          .then((results) => {
+            const seeds = (results[0]?.result as string[]) ?? [];
+            sendResponse({ success: true, seeds });
+          })
+          .catch(() => sendResponse({ success: true, seeds: [] }));
+      });
       return true;
     }
   });

--- a/packages/extension/entrypoints/popup/App.tsx
+++ b/packages/extension/entrypoints/popup/App.tsx
@@ -210,8 +210,29 @@ export default function App() {
             resolve({});
           }
         });
-      const headers = await getExtensionHeaders();
-      const result = await analyzeUrl(currentUrl, headers);
+
+      // Harvest rendered footer policy links from the active tab. Best-effort:
+      // failures fall through to a normal analyze call without seeds.
+      const collectFooterSeeds = (): Promise<string[]> =>
+        new Promise((resolve) => {
+          try {
+            chrome.runtime.sendMessage({ type: "COLLECT_FOOTER_SEEDS" }, (response) => {
+              if (chrome.runtime.lastError || !response?.success) {
+                resolve([]);
+                return;
+              }
+              resolve((response.seeds as string[]) ?? []);
+            });
+          } catch {
+            resolve([]);
+          }
+        });
+
+      const [headers, seeds] = await Promise.all([
+        getExtensionHeaders(),
+        collectFooterSeeds(),
+      ]);
+      const result = await analyzeUrl(currentUrl, headers, seeds.length > 0 ? seeds : undefined);
       setAnalyzeResult(result);
 
       if (result.status === "already_indexed") {

--- a/packages/extension/lib/api.ts
+++ b/packages/extension/lib/api.ts
@@ -91,20 +91,28 @@ export async function checkUrl(url: string): Promise<ExtensionCheckResponse> {
  *
  * Creates the product from URL metadata if it doesn't exist,
  * then starts the background pipeline. Idempotent per domain.
+ *
+ * seedUrls: policy-page URLs harvested from the rendered DOM footer. Passed
+ * as high-priority crawl seeds so sites behind anti-bot walls can still be
+ * analyzed when the server crawler cannot reach them.
  */
 export async function analyzeUrl(
   url: string,
   extraHeaders?: Record<string, string>,
+  seedUrls?: string[],
 ): Promise<ExtensionAnalyzeResponse> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...extraHeaders,
   };
 
+  const body: Record<string, unknown> = { url };
+  if (seedUrls && seedUrls.length > 0) body.seed_urls = seedUrls;
+
   const response = await fetch(`${API_BASE_URL}/extension/analyze`, {
     method: "POST",
     headers,
-    body: JSON.stringify({ url }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -27,7 +27,10 @@ export default defineConfig({
       //   1. Get the current tab URL when popup opens (App.tsx:136)
       //   2. Listen for tab updates/activation to update extension icon (background.ts:112,119)
       //   3. Set extension icon for specific tabs based on privacy policy verdict (background.ts:56)
-      permissions: ["activeTab", "cookies", "storage"],
+      // - "scripting": Required to inject the footer-link collector into the active
+      //   tab via chrome.scripting.executeScript when the user clicks "Analyze".
+      //   Works with activeTab — no broad host_permissions needed for this purpose.
+      permissions: ["activeTab", "cookies", "storage", "scripting"],
       // Host permission justifications:
       // - "https://api.clausea.co/*": Production API endpoint for:
       //   1. /extension/check - Check if privacy analysis exists for URL (api.ts:33, background.ts:92,139, App.tsx:190)


### PR DESCRIPTION
## Summary

- **Extension** reads the rendered DOM footer of the active tab via `chrome.scripting.executeScript` and collects policy-page links (privacy, terms, cookies, DPA, etc.) when the user clicks "Analyze"
- **Backend** accepts `seed_urls` on `POST /extension/analyze`, stores them on `PipelineJob`, and injects them as high-priority crawl seeds before the discovery pass runs
- **Pipeline** folds the seeds into `crawl_base_urls` via `product.model_copy` so `_get_crawl_urls` includes them and `_allowed_domains_for_product` automatically adds their registered domains (e.g. `fr.shein.com` alongside `shein.com`)

This is the solution for hard-tier sites (shein, amazon) where the server crawler is blocked by anti-bot walls or geo-redirects. The user's real browser is already through the wall; the extension just harvests what it can already see.

## What changes

| Layer | Change |
|-------|--------|
| `PipelineJob` | `seed_urls: list[str]` field |
| `POST /extension/analyze` | `seed_urls?: string[]` in request body |
| `pipeline_service.create_job_for_url` | accepts and stores `seed_urls` |
| `pipeline_service.run_pipeline` | passes `job.seed_urls` to `PolicyDocumentPipeline.run` |
| `PolicyDocumentPipeline.run` + `_process_product` | accept `seed_urls`; inject via `model_copy` before `_get_crawl_urls` |
| `extension/lib/api.ts` | `analyzeUrl(url, headers, seedUrls?)` |
| `extension/wxt.config.ts` | adds `"scripting"` permission |
| `extension/background.ts` | `COLLECT_FOOTER_SEEDS` handler + `collectPolicyLinks` function |
| `extension/popup/App.tsx` | collects seeds in parallel with auth headers before `analyzeUrl` |

## Test plan

- [ ] 3 new unit tests in `seed_selection_test.py`: seed URL appears in crawl list, seed domain added to allowed list, seeds reach `crawl_multiple`
- [ ] All 654 existing backend tests pass
- [ ] ty + ruff clean