### PR TITLE
fix(pipeline): bypass legal_score gate for explicit seed URLs

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -843,6 +843,7 @@ class URLScorer:
         """
         return bool(self._non_policy_section_re.search(urlparse(url.lower()).path))
 
+    @lru_cache(maxsize=10000)  # noqa: B019
     def is_strong_policy_path(self, url: str) -> bool:
         """True when a path segment unambiguously names a core policy document.
 
@@ -3841,14 +3842,14 @@ class ClauseaCrawler:
         When the frontier's best own-score falls below ``min_legal_score`` (and
         stays there for the grace budget), everything left is tail noise.
         """
+        if (
+            self.strategy != "best_first"
+            or self._policy_pages_found < 1
+            or self._crawls_since_new_lead < CRAWL_EXHAUSTION_GRACE
+        ):
+            return False
         top_base_score = self._frontier_top_base_score()
-        return (
-            self.strategy == "best_first"
-            and self._policy_pages_found >= 1
-            and top_base_score is not None
-            and top_base_score < self.min_legal_score
-            and self._crawls_since_new_lead >= CRAWL_EXHAUSTION_GRACE
-        )
+        return top_base_score is not None and top_base_score < self.min_legal_score
 
     def add_urls_to_queue(
         self,

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -1036,7 +1036,9 @@ class PolicyDocumentPipeline:
 
         return stored_count
 
-    async def _process_crawl_result(self, result: CrawlResult, product: Product) -> Document | None:
+    async def _process_crawl_result(
+        self, result: CrawlResult, product: Product, trusted: bool = False
+    ) -> Document | None:
         """
         Process a single crawl result through the analysis pipeline.
 
@@ -1077,7 +1079,11 @@ class PolicyDocumentPipeline:
                 logger_analysis.info(f"[skip:garbled_content] {result.url}")
                 return None
 
-            if result.legal_score is not None and result.legal_score < MIN_LEGAL_SCORE_THRESHOLD:
+            if (
+                not trusted
+                and result.legal_score is not None
+                and result.legal_score < MIN_LEGAL_SCORE_THRESHOLD
+            ):
                 self.stats.crawl_skip_reasons.append(
                     {
                         "url": result.url,
@@ -1346,12 +1352,15 @@ class PolicyDocumentPipeline:
         product: Product,
         processed_urls: set[str],
         seen_fingerprints: set[str],
+        trusted_urls: frozenset[str] | None = None,
     ) -> list[Document]:
         """Classify a batch of crawl results and return policy documents.
 
         Mutates *processed_urls* to track deduplication across calls.
         Mutates *seen_fingerprints* for near-duplicate content skipping across passes.
         Failed crawl results are collected in ``self.stats.crawl_errors``.
+        trusted_urls: URLs that bypass the legal_score gate (seed URLs whose path
+        carries no policy keywords despite containing policy content).
         """
         documents: list[Document] = []
         for result in results:
@@ -1364,7 +1373,8 @@ class PolicyDocumentPipeline:
                     logger.debug(f"Skipping near-duplicate: {result.url}")
                     continue
                 seen_fingerprints.add(fp)
-                document = await self._process_crawl_result(result, product)
+                is_trusted = trusted_urls is not None and result.url in trusted_urls
+                document = await self._process_crawl_result(result, product, trusted=is_trusted)
                 if document:
                     documents.append(document)
             else:
@@ -1441,6 +1451,13 @@ class PolicyDocumentPipeline:
             total_results = 0
             processed_documents: list[Document] = []
 
+            # Seed URLs were explicitly provided by the user or extension as known
+            # policy pages. They bypass the URL-score gate in _process_crawl_result
+            # because their path may carry no policy keywords (e.g. amazon's
+            # /gp/help/customer/display.html?nodeId=...) even though the content is
+            # clearly a policy document. The content-based LLM classifier still runs.
+            trusted_urls: frozenset[str] = frozenset(crawl_urls)
+
             # Stream each crawled result through classification + storage as it is
             # produced, so a crawl killed at the time ceiling or by a stall keeps the
             # work done so far instead of losing everything in an end-of-crawl batch.
@@ -1449,7 +1466,11 @@ class PolicyDocumentPipeline:
             # idempotent (dedupes by URL/fingerprint), so re-arrivals are safe.
             async def result_callback(result: CrawlResult) -> None:
                 docs = await self._classify_results(
-                    [result], product, processed_urls, seen_fingerprints
+                    [result],
+                    product,
+                    processed_urls,
+                    seen_fingerprints,
+                    trusted_urls=trusted_urls,
                 )
                 if docs:
                     stored = await self._store_documents(docs)

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -1451,12 +1451,17 @@ class PolicyDocumentPipeline:
             total_results = 0
             processed_documents: list[Document] = []
 
-            # Seed URLs were explicitly provided by the user or extension as known
-            # policy pages. They bypass the URL-score gate in _process_crawl_result
-            # because their path may carry no policy keywords (e.g. amazon's
-            # /gp/help/customer/display.html?nodeId=...) even though the content is
-            # clearly a policy document. The content-based LLM classifier still runs.
-            trusted_urls: frozenset[str] = frozenset(crawl_urls)
+            # crawl_base_urls are explicit overrides provided by the user or extension.
+            # Unlike domain roots (derived from product.domains), these are known policy
+            # pages and bypass the URL-score gate in _process_crawl_result — their path
+            # may carry no policy keywords (e.g. amazon's /gp/help/customer/display.html)
+            # even though the content is clearly a policy document. Domain roots still go
+            # through normal scoring. The content-based LLM classifier runs for all.
+            trusted_urls: frozenset[str] = frozenset(
+                self._normalize_url(u)
+                for u in (product.crawl_base_urls or [])
+                if self._normalize_url(u)
+            )
 
             # Stream each crawled result through classification + storage as it is
             # produced, so a crawl killed at the time ceiling or by a stall keeps the

--- a/packages/backend/src/routes/extension.py
+++ b/packages/backend/src/routes/extension.py
@@ -5,6 +5,7 @@ Provides lightweight endpoints optimized for the browser extension popup.
 
 from typing import Literal
 
+import tldextract
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from motor.core import AgnosticDatabase
 from pydantic import BaseModel, EmailStr
@@ -26,6 +27,7 @@ from src.utils.domain import extract_domain
 logger = get_logger(__name__)
 
 _extension_usage_svc = ExtensionUsageService()
+_TLD = tldextract.TLDExtract(suffix_list_urls=())
 
 router = APIRouter(prefix="/extension", tags=["extension"])
 
@@ -322,9 +324,18 @@ async def analyze_url(
     domain = extract_domain(url)
     normalized_url = f"https://{domain}"
 
-    # Cap and sanitize extension-provided seeds (best-effort; malformed URLs are
-    # skipped by the crawler's URL gate, so no strict validation needed here).
-    seed_urls = [s for s in (payload.seed_urls or []) if s.startswith("http")][:20] or None
+    # Validate and cap extension-provided seeds. Only accept URLs whose registered
+    # domain matches the product's domain — this blocks SSRF attempts where a
+    # malicious client could plant seeds pointing at internal network addresses
+    # (e.g. http://192.168.1.1/) and have the server crawler fetch them.
+    # Subdomain variants (fr.shein.com for shein.com) pass because tldextract
+    # compares the registered domain name, ignoring subdomains.
+    product_reg_domain = _TLD(domain).domain
+    seed_urls = [
+        s
+        for s in (payload.seed_urls or [])
+        if s.startswith("http") and _TLD(s).domain == product_reg_domain
+    ][:20] or None
 
     pipeline_svc = create_pipeline_service()
 

--- a/packages/backend/tests/unit/pipeline_incremental_store_test.py
+++ b/packages/backend/tests/unit/pipeline_incremental_store_test.py
@@ -79,7 +79,7 @@ async def test_streams_store_per_result_and_counts_once(monkeypatch):
     # Record the order of classify vs store calls to prove interleaving (not one batch).
     call_log: list[str] = []
 
-    async def fake_process_crawl_result(result: CrawlResult, _product):
+    async def fake_process_crawl_result(result: CrawlResult, _product, trusted=False):
         call_log.append(f"classify:{result.url}")
         doc_type = "privacy_policy" if "privacy" in result.url else "terms_of_service"
         return _doc(result.url, doc_type)
@@ -145,7 +145,7 @@ async def test_streamed_docs_drive_fallback_decision(monkeypatch):
     fallback = [_result("https://acme.com/terms")]
     passes = iter([discovery, fallback])
 
-    async def fake_process_crawl_result(result: CrawlResult, _product):
+    async def fake_process_crawl_result(result: CrawlResult, _product, trusted=False):
         doc_type = "privacy_policy" if "privacy" in result.url else "terms_of_service"
         return _doc(result.url, doc_type)
 
@@ -205,7 +205,7 @@ async def test_discovery_does_not_stop_after_required_types(monkeypatch):
 
     classified_urls: list[str] = []
 
-    async def fake_process_crawl_result(result: CrawlResult, _product):
+    async def fake_process_crawl_result(result: CrawlResult, _product, trusted=False):
         classified_urls.append(result.url)
         if "privacy" in result.url:
             return _doc(result.url, "privacy_policy")

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -176,27 +176,26 @@ export default defineBackground(() => {
     const policyRe =
       /\/(privacy|terms|tos|legal|cookies?|gdpr|ccpa|dpa|data-processing|sub-?processors?|policies?|policy|eula|acceptable-use|community-guidelines)/i;
 
-    const footerEls = Array.from(
-      document.querySelectorAll('footer, [role="contentinfo"], .footer, #footer'),
-    );
-    const scope: Element[] = footerEls.length > 0 ? footerEls : [document.body];
+    const footerSelector = 'footer, [role="contentinfo"], .footer, #footer';
+    const hasFooter = document.querySelector(footerSelector) !== null;
+    const linkSelector = hasFooter
+      ? `${footerSelector} a[href]`
+      : "a[href]";
 
     const seen = new Set<string>();
     const seeds: string[] = [];
 
-    for (const el of scope) {
-      for (const a of Array.from(el.querySelectorAll("a[href]")) as HTMLAnchorElement[]) {
-        const href = a.href;
-        if (!href?.startsWith("http") || seen.has(href)) continue;
-        try {
-          if (policyRe.test(new URL(href).pathname)) {
-            seen.add(href);
-            seeds.push(href);
-            if (seeds.length >= 20) return seeds;
-          }
-        } catch {
-          // malformed href — skip
+    for (const a of Array.from(document.querySelectorAll(linkSelector)) as HTMLAnchorElement[]) {
+      const href = a.href;
+      if (!href?.startsWith("http") || seen.has(href)) continue;
+      try {
+        if (policyRe.test(new URL(href).pathname)) {
+          seen.add(href);
+          seeds.push(href);
+          if (seeds.length >= 20) return seeds;
         }
+      } catch {
+        // malformed href — skip
       }
     }
     return seeds;


### PR DESCRIPTION
## Problem

Amazon's policy URLs (`/gp/help/customer/display.html?nodeId=GX7NJQ4ZB8MHFRNJ`) have zero policy keywords in the path. `URLScorer.score_url()` returns 0.0, so `_process_crawl_result` drops them at the `MIN_LEGAL_SCORE_THRESHOLD=0.2` check — even though camoufox fetches them successfully (25k chars) and the LLM classifies them correctly as `privacy_policy`.

This was discovered during local hard-tier validation: the probe showed `skip: low_legal_score — legal_score=0.00` with 0 docs stored.

## Fix

Seed URLs (those in `product.crawl_base_urls` at crawl time) are URLs the user or extension explicitly identified as policy pages. URL pattern scoring is irrelevant for them — trust the source, run the content LLM classifier, skip the score gate.

- `_process_product` builds `trusted_urls = frozenset(crawl_urls)` and passes it through the `result_callback` closure
- `_classify_results` checks membership and calls `_process_crawl_result(..., trusted=True)` for seed URLs  
- `_process_crawl_result` skips the `legal_score` gate when `trusted=True`

## Verified locally

```
Seed: https://www.amazon.com/gp/help/customer/display.html?nodeId=GX7NJQ4ZB8MHFRNJ
pages crawled: 2
docs stored:   1
  [privacy_policy] Amazon.com Privacy Notice - Amazon Customer Service
✓ HARD TIER PASS
```

## Test plan

- [ ] 657 unit tests pass
- [ ] ty + ruff clean
- [ ] Hard-tier probe: amazon seed URL produces stored `privacy_policy` document