### PR TITLE
feat(history): policy change tracking and 30-day monitoring

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -17,6 +17,7 @@ from src.repositories.pipeline_repository import PipelineRepository
 from src.routes import (
     contact,
     extension,
+    history,
     paddle,
     pipeline,
     products,
@@ -84,6 +85,7 @@ routes = [
     extension.router,
     contact.router,
     pipeline.router,
+    history.router,
 ]
 
 for route in routes:

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -1316,6 +1316,7 @@ async def generate_product_overview(
     document_svc: DocumentService | None = None,
     cancellation_token: CancellationToken | None = None,
     on_progress: HeartbeatCallback | None = None,
+    job_id: str | None = None,
 ) -> MetaSummary:
     """
     Generate a cached product overview from analyzed core policy documents.
@@ -1612,6 +1613,7 @@ Per-document analyses and extractions:
             db,
             product_slug=product_slug,
             meta_summary=meta_summary,
+            job_id=job_id,
         )
         logger.info(f"✓ Saved product overview for {product_slug}")
 

--- a/packages/backend/src/core/db_indexes.py
+++ b/packages/backend/src/core/db_indexes.py
@@ -254,6 +254,60 @@ async def ensure_document_version_indexes(db: AgnosticDatabase) -> None:
                 f"Could not create index on document_versions.(document_id, created_at): {e}"
             )
 
+    try:
+        await db.document_versions.create_index(
+            [("product_slug", 1), ("created_at", -1)],
+            name="idx_docversion_product_recent",
+            background=True,
+        )
+        logger.info("Created index on document_versions.(product_slug, created_at)")
+    except Exception as e:
+        if "already exists" in str(e).lower():
+            logger.debug("Index on document_versions.(product_slug, created_at) already exists")
+        else:
+            logger.warning(f"Could not create index on document_versions.(product_slug): {e}")
+
+
+async def ensure_monitoring_schedule_indexes(db: AgnosticDatabase) -> None:
+    try:
+        await db.monitoring_schedules.create_index(
+            "product_slug", unique=True, name="idx_monitoring_product_slug", background=True
+        )
+        logger.info("Created unique index on monitoring_schedules.product_slug")
+    except Exception as e:
+        if "already exists" in str(e).lower():
+            logger.debug("Index on monitoring_schedules.product_slug already exists")
+        else:
+            logger.warning(f"Could not create index on monitoring_schedules.product_slug: {e}")
+
+    try:
+        await db.monitoring_schedules.create_index(
+            [("next_crawl_due_at", 1)],
+            name="idx_monitoring_next_due",
+            background=True,
+        )
+        logger.info("Created index on monitoring_schedules.next_crawl_due_at")
+    except Exception as e:
+        if "already exists" in str(e).lower():
+            logger.debug("Index on monitoring_schedules.next_crawl_due_at already exists")
+        else:
+            logger.warning(f"Could not create index on monitoring_schedules.next_crawl_due_at: {e}")
+
+
+async def ensure_overview_history_indexes(db: AgnosticDatabase) -> None:
+    try:
+        await db.product_overview_history.create_index(
+            [("product_slug", 1), ("snapshot_at", -1)],
+            name="idx_overview_history_product_recent",
+            background=True,
+        )
+        logger.info("Created index on product_overview_history.(product_slug, snapshot_at)")
+    except Exception as e:
+        if "already exists" in str(e).lower():
+            logger.debug("Index on product_overview_history already exists")
+        else:
+            logger.warning(f"Could not create index on product_overview_history: {e}")
+
 
 async def ensure_pipeline_indexes(db: AgnosticDatabase) -> None:
     """Ensure indexes exist on pipeline-related collections."""
@@ -366,6 +420,8 @@ async def ensure_all_indexes(db: AgnosticDatabase) -> None:
     await ensure_deep_analysis_indexes(db)
     await ensure_aggregation_indexes(db)
     await ensure_document_version_indexes(db)
+    await ensure_monitoring_schedule_indexes(db)
+    await ensure_overview_history_indexes(db)
     await ensure_pipeline_indexes(db)
 
     # TTL indexes for ephemeral crawl data

--- a/packages/backend/src/models/document.py
+++ b/packages/backend/src/models/document.py
@@ -1473,6 +1473,7 @@ class Document(BaseModel):
     # freshness window, while older docs are still re-fetched for change detection.
     updated_at: datetime = Field(default_factory=datetime.now)
     tier_relevance: TierRelevance = "extended"
+    content_hash: str | None = None
 
 
 # Resolve forward references now that all classes are defined.

--- a/packages/backend/src/models/document_version.py
+++ b/packages/backend/src/models/document_version.py
@@ -29,3 +29,6 @@ class DocumentVersion(BaseModel):
     content_hash: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime = Field(default_factory=datetime.now)
+    product_slug: str | None = None
+    changed_fields: list[str] | None = None
+    job_id: str | None = None

--- a/packages/backend/src/models/monitoring_schedule.py
+++ b/packages/backend/src/models/monitoring_schedule.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import shortuuid
+from pydantic import BaseModel, Field
+
+
+class MonitoringSchedule(BaseModel):
+    id: str = Field(default_factory=shortuuid.uuid)
+    product_slug: str
+    product_id: str | None = None
+    enrolled_at: datetime = Field(default_factory=datetime.now)
+    last_crawl_triggered_at: datetime | None = None
+    next_crawl_due_at: datetime
+    interval_days: int = 30
+    enabled: bool = True

--- a/packages/backend/src/models/product_overview_history.py
+++ b/packages/backend/src/models/product_overview_history.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import shortuuid
+from pydantic import BaseModel, Field
+
+
+class ProductOverviewHistory(BaseModel):
+    id: str = Field(default_factory=shortuuid.uuid)
+    product_slug: str
+    snapshot_at: datetime = Field(default_factory=datetime.now)
+    risk_score: int | None = None
+    risk_score_delta: int | None = None
+    verdict: str | None = None
+    one_line_summary: str | None = None
+    changed_overview_fields: list[str] = Field(default_factory=list)
+    overview: dict[str, Any] = Field(default_factory=dict)
+    job_id: str | None = None

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -113,7 +113,16 @@ def _content_fingerprint(text: str) -> str:
 
 def _diff_fields(existing: "Document", incoming: "Document") -> list[str]:
     tracked = ["text", "title", "doc_type", "locale", "regions", "effective_date"]
-    return [f for f in tracked if getattr(existing, f) != getattr(incoming, f)]
+    changed = []
+    for field in tracked:
+        old_val = getattr(existing, field)
+        new_val = getattr(incoming, field)
+        if field == "regions":
+            if set(old_val or []) != set(new_val or []):
+                changed.append(field)
+        elif old_val != new_val:
+            changed.append(field)
+    return changed
 
 
 # Locale path segment (/es/, /fr/, /pt-br/, /en_US/) or locale subdomain (es., de.).
@@ -996,7 +1005,7 @@ class PolicyDocumentPipeline:
                                 f"updating existing document with changes: {document.url}"
                             )
                             document.id = existing_doc.id  # Preserve original ID
-                            document.content_hash = current_hash
+                            document.content_hash = _content_fingerprint(document.text)
                             await document_service.update_document(db, document)
                             stored_count += 1
                             updated_count += 1

--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -72,6 +72,7 @@ from src.models.document import Document, coerce_doc_type_from_classifier
 from src.models.pipeline_job import classify_crawl_error
 from src.models.product import Product
 from src.repositories.crawl_repository import CrawlRepository
+from src.repositories.document_version_repository import DocumentVersionRepository
 from src.services.service_factory import create_document_service, create_product_service
 from src.utils.llm_usage import usage_tracking
 from src.utils.llm_usage_tracking_mixin import LLMUsageTrackingMixin
@@ -108,6 +109,11 @@ def _content_fingerprint(text: str) -> str:
     """
     normalized = re.sub(r"\s+", " ", text.lower().strip())
     return hashlib.md5(normalized[:5000].encode()).hexdigest()
+
+
+def _diff_fields(existing: "Document", incoming: "Document") -> list[str]:
+    tracked = ["text", "title", "doc_type", "locale", "regions", "effective_date"]
+    return [f for f in tracked if getattr(existing, f) != getattr(incoming, f)]
 
 
 # Locale path segment (/es/, /fr/, /pt-br/, /en_US/) or locale subdomain (es., de.).
@@ -720,6 +726,7 @@ class PolicyDocumentPipeline:
         progress_callback: Callable[[str, int, int], None]
         | Callable[[str, int, int], Awaitable[None]]
         | None = None,  # Optional progress callback (phase, current, total)
+        job_id: str | None = None,
     ):
         """
         Initialize the policy document pipeline.
@@ -802,6 +809,7 @@ class PolicyDocumentPipeline:
             Callable[[str, int, int], None] | Callable[[str, int, int], Awaitable[None]] | None
         ) = progress_callback
         self._pending_progress_tasks: list[asyncio.Task] = []
+        self._job_id = job_id
 
         # Initialize components
         self.analyzer = DocumentAnalyzer()
@@ -978,11 +986,17 @@ class PolicyDocumentPipeline:
                                 duplicate_count += 1
                                 continue
 
+                            changed = _diff_fields(existing_doc, document)
+                            await DocumentVersionRepository().archive(
+                                db, existing_doc, job_id=self._job_id, changed_fields=changed
+                            )
+
                             # Update existing document with new content/metadata
                             logger_storage.info(
                                 f"updating existing document with changes: {document.url}"
                             )
                             document.id = existing_doc.id  # Preserve original ID
+                            document.content_hash = current_hash
                             await document_service.update_document(db, document)
                             stored_count += 1
                             updated_count += 1
@@ -1019,6 +1033,7 @@ class PolicyDocumentPipeline:
 
                         # Create new document
                         logger_storage.info(f"storing new document: {document.url}")
+                        document.content_hash = _content_fingerprint(document.text)
                         await document_service.store_document(db, document)
                         stored_count += 1
 

--- a/packages/backend/src/repositories/document_version_repository.py
+++ b/packages/backend/src/repositories/document_version_repository.py
@@ -17,6 +17,12 @@ class DocumentVersionRepository:
         job_id: str | None,
         changed_fields: list[str],
     ) -> None:
+        product_slug: str | None = None
+        if existing_doc.product_id:
+            product = await db.products.find_one({"id": existing_doc.product_id}, {"slug": 1})
+            if product:
+                product_slug = product.get("slug")
+
         version = DocumentVersion(
             document_id=existing_doc.id,
             product_id=existing_doc.product_id,
@@ -30,7 +36,7 @@ class DocumentVersionRepository:
             text=existing_doc.text,
             content_hash=existing_doc.content_hash,
             metadata=dict(existing_doc.metadata),
-            product_slug=None,
+            product_slug=product_slug,
             changed_fields=changed_fields,
             job_id=job_id,
         )

--- a/packages/backend/src/repositories/document_version_repository.py
+++ b/packages/backend/src/repositories/document_version_repository.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from motor.core import AgnosticDatabase
+
+from src.core.logging import get_logger
+from src.models.document import Document
+from src.models.document_version import DocumentVersion
+
+logger = get_logger(__name__)
+
+
+class DocumentVersionRepository:
+    async def archive(
+        self,
+        db: AgnosticDatabase,
+        existing_doc: Document,
+        job_id: str | None,
+        changed_fields: list[str],
+    ) -> None:
+        version = DocumentVersion(
+            document_id=existing_doc.id,
+            product_id=existing_doc.product_id,
+            url=existing_doc.url,
+            title=existing_doc.title,
+            doc_type=existing_doc.doc_type,
+            locale=existing_doc.locale,
+            regions=list(existing_doc.regions),
+            effective_date=existing_doc.effective_date,
+            markdown=existing_doc.markdown,
+            text=existing_doc.text,
+            content_hash=existing_doc.content_hash,
+            metadata=dict(existing_doc.metadata),
+            product_slug=None,
+            changed_fields=changed_fields,
+            job_id=job_id,
+        )
+        await db.document_versions.insert_one(version.model_dump())
+        logger.debug(
+            "Archived document version for %s (changed: %s)", existing_doc.url, changed_fields
+        )

--- a/packages/backend/src/repositories/monitoring_schedule_repository.py
+++ b/packages/backend/src/repositories/monitoring_schedule_repository.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import random
+from datetime import datetime, timedelta
+
+from motor.core import AgnosticDatabase
+
+from src.core.logging import get_logger
+from src.models.monitoring_schedule import MonitoringSchedule
+
+logger = get_logger(__name__)
+
+
+def _next_due(interval_days: int) -> datetime:
+    return datetime.now() + timedelta(days=interval_days) + timedelta(hours=random.randint(0, 23))
+
+
+class MonitoringScheduleRepository:
+    async def enroll(
+        self,
+        db: AgnosticDatabase,
+        product_slug: str,
+        product_id: str | None = None,
+        interval_days: int = 30,
+    ) -> None:
+        schedule = MonitoringSchedule(
+            product_slug=product_slug,
+            product_id=product_id,
+            next_crawl_due_at=_next_due(interval_days),
+            interval_days=interval_days,
+        )
+        await db.monitoring_schedules.update_one(
+            {"product_slug": product_slug},
+            {"$setOnInsert": schedule.model_dump()},
+            upsert=True,
+        )
+        logger.debug(
+            "Enrolled %s in monitoring schedule (interval=%dd)", product_slug, interval_days
+        )
+
+    async def find_due(self, db: AgnosticDatabase, limit: int = 50) -> list[MonitoringSchedule]:
+        now = datetime.now()
+        cursor = db.monitoring_schedules.find(
+            {"next_crawl_due_at": {"$lte": now}, "enabled": True}
+        ).limit(limit)
+        rows = await cursor.to_list(length=limit)
+        return [MonitoringSchedule(**row) for row in rows]
+
+    async def mark_triggered(self, db: AgnosticDatabase, product_slug: str) -> None:
+        schedule = await db.monitoring_schedules.find_one({"product_slug": product_slug})
+        interval_days = (schedule or {}).get("interval_days", 30)
+        await db.monitoring_schedules.update_one(
+            {"product_slug": product_slug},
+            {
+                "$set": {
+                    "last_crawl_triggered_at": datetime.now(),
+                    "next_crawl_due_at": _next_due(interval_days),
+                }
+            },
+        )

--- a/packages/backend/src/repositories/product_overview_history_repository.py
+++ b/packages/backend/src/repositories/product_overview_history_repository.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+from motor.core import AgnosticDatabase
+
+from src.core.logging import get_logger
+from src.models.product_overview_history import ProductOverviewHistory
+
+logger = get_logger(__name__)
+
+_TRACKED_OVERVIEW_FIELDS = [
+    "risk_score",
+    "verdict",
+    "one_line_summary",
+    "dangers",
+    "keypoints",
+    "summary",
+]
+
+
+def _changed_overview_fields(prev: dict[str, Any], current: dict[str, Any]) -> list[str]:
+    return [field for field in _TRACKED_OVERVIEW_FIELDS if prev.get(field) != current.get(field)]
+
+
+class ProductOverviewHistoryRepository:
+    async def save_snapshot(
+        self,
+        db: AgnosticDatabase,
+        product_slug: str,
+        overview_data: dict[str, Any],
+        prev_overview_data: dict[str, Any] | None,
+        job_id: str | None = None,
+    ) -> None:
+        risk_score = overview_data.get("risk_score")
+        prev_risk = prev_overview_data.get("risk_score") if prev_overview_data else None
+        risk_score_delta = (
+            (risk_score - prev_risk) if (risk_score is not None and prev_risk is not None) else None
+        )
+        changed = _changed_overview_fields(prev_overview_data or {}, overview_data)
+
+        snapshot = ProductOverviewHistory(
+            product_slug=product_slug,
+            risk_score=risk_score,
+            risk_score_delta=risk_score_delta,
+            verdict=overview_data.get("verdict"),
+            one_line_summary=overview_data.get("one_line_summary"),
+            changed_overview_fields=changed,
+            overview=overview_data,
+            job_id=job_id,
+        )
+        await db.product_overview_history.insert_one(snapshot.model_dump())
+        logger.debug(
+            "Saved overview snapshot for %s (delta=%s changed=%s)",
+            product_slug,
+            risk_score_delta,
+            changed,
+        )
+
+    async def find_by_product(
+        self, db: AgnosticDatabase, product_slug: str, limit: int = 50
+    ) -> list[ProductOverviewHistory]:
+        cursor = (
+            db.product_overview_history.find({"product_slug": product_slug})
+            .sort("snapshot_at", -1)
+            .limit(limit)
+        )
+        rows = await cursor.to_list(length=limit)
+        return [ProductOverviewHistory(**row) for row in rows]

--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -18,6 +18,7 @@ from src.models.document import (
 )
 from src.models.product import Product
 from src.repositories.base_repository import BaseRepository
+from src.repositories.product_overview_history_repository import ProductOverviewHistoryRepository
 
 logger = get_logger(__name__)
 
@@ -239,6 +240,7 @@ class ProductRepository(BaseRepository):
         db: AgnosticDatabase,
         product_slug: str,
         meta_summary: MetaSummary,
+        job_id: str | None = None,
     ) -> None:
         """Save the product overview payload to the database.
 
@@ -246,10 +248,20 @@ class ProductRepository(BaseRepository):
             db: Database instance
             product_slug: Product slug
             meta_summary: Overview payload (MetaSummary shape)
+            job_id: Optional pipeline job that produced this overview
         """
         summary_data = meta_summary.model_dump()
         summary_data["product_slug"] = product_slug
         summary_data["updated_at"] = datetime.now()
+
+        existing = await db.product_overviews.find_one({"product_slug": product_slug})
+        await ProductOverviewHistoryRepository().save_snapshot(
+            db,
+            product_slug=product_slug,
+            overview_data=summary_data,
+            prev_overview_data=existing,
+            job_id=job_id,
+        )
 
         result = await db.product_overviews.update_one(
             {"product_slug": product_slug},

--- a/packages/backend/src/routes/history.py
+++ b/packages/backend/src/routes/history.py
@@ -1,0 +1,91 @@
+import difflib
+
+from fastapi import APIRouter, Depends, HTTPException
+from motor.core import AgnosticDatabase
+from pydantic import BaseModel
+
+from src.core.database import get_db
+from src.models.product_overview_history import ProductOverviewHistory
+from src.repositories.product_overview_history_repository import ProductOverviewHistoryRepository
+
+router = APIRouter(prefix="/history", tags=["history"])
+
+
+class DocumentVersionSummary(BaseModel):
+    id: str
+    created_at: str
+    changed_fields: list[str] | None
+    job_id: str | None
+    content_hash: str | None
+
+
+class DiffResponse(BaseModel):
+    version_a_id: str
+    version_b_id: str
+    unified_diff: str
+
+
+@router.get("/documents/{document_id}/versions", response_model=list[DocumentVersionSummary])
+async def list_document_versions(
+    document_id: str,
+    db: AgnosticDatabase = Depends(get_db),
+) -> list[DocumentVersionSummary]:
+    cursor = (
+        db.document_versions.find(
+            {"document_id": document_id}, {"text": 0, "markdown": 0, "raw_html": 0}
+        )
+        .sort("created_at", -1)
+        .limit(50)
+    )
+    rows = await cursor.to_list(length=50)
+    return [
+        DocumentVersionSummary(
+            id=str(row.get("id", "")),
+            created_at=str(row.get("created_at", "")),
+            changed_fields=row.get("changed_fields"),
+            job_id=row.get("job_id"),
+            content_hash=row.get("content_hash"),
+        )
+        for row in rows
+    ]
+
+
+@router.get("/documents/{document_id}/versions/{version_id}/diff", response_model=DiffResponse)
+async def diff_document_versions(
+    document_id: str,
+    version_id: str,
+    db: AgnosticDatabase = Depends(get_db),
+) -> DiffResponse:
+    target = await db.document_versions.find_one({"id": version_id, "document_id": document_id})
+    if not target:
+        raise HTTPException(status_code=404, detail="Version not found")
+
+    previous = await db.document_versions.find_one(
+        {"document_id": document_id, "created_at": {"$lt": target["created_at"]}},
+        sort=[("created_at", -1)],
+    )
+
+    text_a = (previous or {}).get("text") or ""
+    text_b = target.get("text") or ""
+    diff_lines = list(
+        difflib.unified_diff(
+            text_a.splitlines(keepends=True),
+            text_b.splitlines(keepends=True),
+            fromfile="previous",
+            tofile="current",
+            n=3,
+        )
+    )
+    return DiffResponse(
+        version_a_id=str((previous or {}).get("id", "")),
+        version_b_id=version_id,
+        unified_diff="".join(diff_lines),
+    )
+
+
+@router.get("/products/{slug}/overview-history", response_model=list[ProductOverviewHistory])
+async def list_overview_history(
+    slug: str,
+    db: AgnosticDatabase = Depends(get_db),
+) -> list[ProductOverviewHistory]:
+    return await ProductOverviewHistoryRepository().find_by_product(db, slug)

--- a/packages/backend/src/routes/history.py
+++ b/packages/backend/src/routes/history.py
@@ -1,4 +1,5 @@
 import difflib
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from motor.core import AgnosticDatabase
@@ -13,14 +14,14 @@ router = APIRouter(prefix="/history", tags=["history"])
 
 class DocumentVersionSummary(BaseModel):
     id: str
-    created_at: str
+    created_at: datetime
     changed_fields: list[str] | None
     job_id: str | None
     content_hash: str | None
 
 
 class DiffResponse(BaseModel):
-    version_a_id: str
+    version_a_id: str | None
     version_b_id: str
     unified_diff: str
 
@@ -41,7 +42,7 @@ async def list_document_versions(
     return [
         DocumentVersionSummary(
             id=str(row.get("id", "")),
-            created_at=str(row.get("created_at", "")),
+            created_at=row.get("created_at"),
             changed_fields=row.get("changed_fields"),
             job_id=row.get("job_id"),
             content_hash=row.get("content_hash"),
@@ -77,7 +78,7 @@ async def diff_document_versions(
         )
     )
     return DiffResponse(
-        version_a_id=str((previous or {}).get("id", "")),
+        version_a_id=previous.get("id") if previous else None,
         version_b_id=version_id,
         unified_diff="".join(diff_lines),
     )

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -32,6 +32,7 @@ from src.models.pipeline_job import (
 from src.models.product import Product
 from src.pipeline import PolicyDocumentPipeline
 from src.prompts.analysis_prompts import OVERVIEW_CORE_DOC_TYPES
+from src.repositories.monitoring_schedule_repository import MonitoringScheduleRepository
 from src.repositories.pipeline_repository import PipelineRepository
 from src.repositories.product_repository import ProductRepository
 from src.services.service_factory import create_document_service, create_product_service
@@ -404,7 +405,9 @@ class PipelineService:
                         )
                         crawl_tasks.append(task)
 
-                    pipeline = PolicyDocumentPipeline(progress_callback=_on_crawl_progress)
+                    pipeline = PolicyDocumentPipeline(
+                        progress_callback=_on_crawl_progress, job_id=job.id
+                    )
                     stats = await pipeline.run([product])
 
                     # Drain pending progress tasks before finalizing the crawl step
@@ -671,6 +674,7 @@ class PipelineService:
                         product_svc=product_svc_for_overview,
                         document_svc=doc_svc_for_overview,
                         on_progress=_on_overview_progress,
+                        job_id=job.id,
                     )
 
                     # Verify the overview actually persisted — same truthfulness lesson as
@@ -782,6 +786,20 @@ class PipelineService:
                         f"Pipeline job {job.id} completed for {job.product_slug} "
                         f"({job.documents_stored} documents)"
                     )
+
+                    # Auto-enroll in monitoring (best-effort)
+                    try:
+                        await MonitoringScheduleRepository().enroll(
+                            db,
+                            product_slug=job.product_slug,
+                            product_id=job.product_id,
+                        )
+                    except Exception as enroll_exc:  # noqa: BLE001
+                        logger.warning(
+                            "Failed to enroll %s in monitoring: %s",
+                            job.product_slug,
+                            enroll_exc,
+                        )
 
                     # Notify subscribers (best-effort)
                     try:

--- a/packages/backend/src/services/product_service.py
+++ b/packages/backend/src/services/product_service.py
@@ -255,6 +255,7 @@ class ProductService:
         db: AgnosticDatabase,
         product_slug: str,
         meta_summary: MetaSummary,
+        job_id: str | None = None,
     ) -> None:
         """Save the product overview payload to the database.
 
@@ -262,8 +263,11 @@ class ProductService:
             db: Database instance
             product_slug: Product slug
             meta_summary: Overview payload (MetaSummary shape)
+            job_id: Optional pipeline job that produced this overview
         """
-        await self._product_repo.save_product_overview(db, product_slug, meta_summary)
+        await self._product_repo.save_product_overview(
+            db, product_slug, meta_summary, job_id=job_id
+        )
 
     # ============================================================================
     # Consumer Explainer Storage (product-level, consumer-facing)

--- a/packages/backend/tests/unit/policy_change_tracking_test.py
+++ b/packages/backend/tests/unit/policy_change_tracking_test.py
@@ -77,6 +77,8 @@ class TestDocumentVersionRepository:
         db = MagicMock()
         db.document_versions = MagicMock()
         db.document_versions.insert_one = AsyncMock()
+        db.products = MagicMock()
+        db.products.find_one = AsyncMock(return_value={"slug": "acme"})
 
         existing = _doc()
         repo = DocumentVersionRepository()
@@ -87,12 +89,15 @@ class TestDocumentVersionRepository:
         assert inserted["document_id"] == existing.id
         assert inserted["job_id"] == "job123"
         assert inserted["changed_fields"] == ["text"]
+        assert inserted["product_slug"] == "acme"
 
     @pytest.mark.asyncio
     async def test_archive_with_no_job_id(self) -> None:
         db = MagicMock()
         db.document_versions = MagicMock()
         db.document_versions.insert_one = AsyncMock()
+        db.products = MagicMock()
+        db.products.find_one = AsyncMock(return_value=None)
 
         existing = _doc()
         await DocumentVersionRepository().archive(db, existing, job_id=None, changed_fields=[])

--- a/packages/backend/tests/unit/policy_change_tracking_test.py
+++ b/packages/backend/tests/unit/policy_change_tracking_test.py
@@ -1,0 +1,144 @@
+"""Tests for policy change tracking: _diff_fields, DocumentVersionRepository, MonitoringScheduleRepository."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models.document import Document
+from src.pipeline import _diff_fields
+from src.repositories.document_version_repository import DocumentVersionRepository
+from src.repositories.monitoring_schedule_repository import MonitoringScheduleRepository
+
+
+def _doc(**overrides) -> Document:
+    defaults: dict = {
+        "id": "doc1",
+        "url": "https://example.com/privacy",
+        "title": "Privacy Policy",
+        "product_id": "prod1",
+        "doc_type": "privacy_policy",
+        "markdown": "# Privacy",
+        "text": "This is the privacy policy text.",
+        "locale": "en-US",
+        "regions": ["global"],
+        "effective_date": None,
+    }
+    defaults.update(overrides)
+    return Document(**defaults)
+
+
+class TestDiffFields:
+    def test_no_change(self) -> None:
+        doc = _doc()
+        assert _diff_fields(doc, doc) == []
+
+    def test_text_changed(self) -> None:
+        old = _doc(text="old text " * 50)
+        new = _doc(text="new text " * 50)
+        assert "text" in _diff_fields(old, new)
+
+    def test_title_changed(self) -> None:
+        old = _doc(title="Old Title")
+        new = _doc(title="New Title")
+        assert "title" in _diff_fields(old, new)
+
+    def test_doc_type_changed(self) -> None:
+        old = _doc(doc_type="privacy_policy")
+        new = _doc(doc_type="terms_of_service")
+        assert "doc_type" in _diff_fields(old, new)
+
+    def test_locale_changed(self) -> None:
+        old = _doc(locale="en-US")
+        new = _doc(locale="en-GB")
+        assert "locale" in _diff_fields(old, new)
+
+    def test_regions_changed(self) -> None:
+        old = _doc(regions=["global"])
+        new = _doc(regions=["US", "EU"])
+        assert "regions" in _diff_fields(old, new)
+
+    def test_effective_date_changed(self) -> None:
+        old = _doc(effective_date=None)
+        new = _doc(effective_date=datetime(2025, 1, 1))
+        assert "effective_date" in _diff_fields(old, new)
+
+    def test_multiple_fields_changed(self) -> None:
+        old = _doc(title="Old", text="old " * 50)
+        new = _doc(title="New", text="new " * 50)
+        changed = _diff_fields(old, new)
+        assert "title" in changed
+        assert "text" in changed
+
+
+class TestDocumentVersionRepository:
+    @pytest.mark.asyncio
+    async def test_archive_inserts_version(self) -> None:
+        db = MagicMock()
+        db.document_versions = MagicMock()
+        db.document_versions.insert_one = AsyncMock()
+
+        existing = _doc()
+        repo = DocumentVersionRepository()
+        await repo.archive(db, existing, job_id="job123", changed_fields=["text"])
+
+        db.document_versions.insert_one.assert_called_once()
+        inserted = db.document_versions.insert_one.call_args[0][0]
+        assert inserted["document_id"] == existing.id
+        assert inserted["job_id"] == "job123"
+        assert inserted["changed_fields"] == ["text"]
+
+    @pytest.mark.asyncio
+    async def test_archive_with_no_job_id(self) -> None:
+        db = MagicMock()
+        db.document_versions = MagicMock()
+        db.document_versions.insert_one = AsyncMock()
+
+        existing = _doc()
+        await DocumentVersionRepository().archive(db, existing, job_id=None, changed_fields=[])
+
+        inserted = db.document_versions.insert_one.call_args[0][0]
+        assert inserted["job_id"] is None
+
+
+class TestMonitoringScheduleRepository:
+    @pytest.mark.asyncio
+    async def test_enroll_upserts(self) -> None:
+        db = MagicMock()
+        db.monitoring_schedules = MagicMock()
+        db.monitoring_schedules.update_one = AsyncMock()
+
+        repo = MonitoringScheduleRepository()
+        await repo.enroll(db, product_slug="netflix", product_id="prod1")
+
+        db.monitoring_schedules.update_one.assert_called_once()
+        filter_arg, update_arg = db.monitoring_schedules.update_one.call_args[0]
+        assert filter_arg == {"product_slug": "netflix"}
+        assert "$setOnInsert" in update_arg
+
+    @pytest.mark.asyncio
+    async def test_find_due_returns_schedules(self) -> None:
+        now = datetime.now()
+        db = MagicMock()
+        db.monitoring_schedules = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.limit = MagicMock(return_value=mock_cursor)
+        mock_cursor.to_list = AsyncMock(
+            return_value=[
+                {
+                    "id": "sched1",
+                    "product_slug": "netflix",
+                    "enrolled_at": now,
+                    "next_crawl_due_at": now,
+                    "interval_days": 30,
+                    "enabled": True,
+                }
+            ]
+        )
+        db.monitoring_schedules.find = MagicMock(return_value=mock_cursor)
+
+        repo = MonitoringScheduleRepository()
+        results = await repo.find_due(db, limit=50)
+
+        assert len(results) == 1
+        assert results[0].product_slug == "netflix"

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -81,6 +81,14 @@ async def _sweep_monitoring() -> None:
                 else:
                     crawl_url = None
                 if not crawl_url:
+                    async with db_session() as db:
+                        await db.monitoring_schedules.update_one(
+                            {"product_slug": schedule.product_slug},
+                            {"$set": {"enabled": False}},
+                        )
+                    logger.warning(
+                        "Disabled monitoring for %s: no crawl URL found", schedule.product_slug
+                    )
                     continue
                 async with db_session() as db:
                     await pipeline_svc.create_job_for_url(db, crawl_url)

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -18,6 +18,7 @@ import signal
 
 from src.core.database import close_motor_client, db_session
 from src.core.logging import get_logger, setup_logging
+from src.repositories.monitoring_schedule_repository import MonitoringScheduleRepository
 from src.repositories.pipeline_repository import PipelineRepository
 from src.services.service_factory import create_pipeline_service
 
@@ -33,6 +34,7 @@ _CONCURRENCY = max(
 )
 _POLL_SECONDS = float(os.getenv("PIPELINE_WORKER_POLL_SECONDS", "3"))
 _STALE_SWEEP_SECONDS = float(os.getenv("PIPELINE_WORKER_STALE_SWEEP_SECONDS", "300"))
+_MONITORING_SWEEP_SECONDS = float(os.getenv("PIPELINE_MONITORING_SWEEP_SECONDS", "3600"))
 _SHUTDOWN_GRACE_SECONDS = float(os.getenv("PIPELINE_WORKER_SHUTDOWN_GRACE", "20"))
 
 
@@ -53,6 +55,43 @@ async def _sweep_stale(repo: PipelineRepository) -> None:
             logger.info("Re-queued %d failed job(s) for retry", requeued)
     except Exception as exc:  # noqa: BLE001 - the queue self-heal must not kill the worker
         logger.error("Stale sweep failed (continuing): %s", exc, exc_info=True)
+
+
+async def _sweep_monitoring() -> None:
+    try:
+        monitoring_repo = MonitoringScheduleRepository()
+        pipeline_svc = create_pipeline_service()
+        triggered = 0
+        async with db_session() as db:
+            due = await monitoring_repo.find_due(db)
+        for schedule in due:
+            try:
+                async with db_session() as db:
+                    product_docs = await db.products.find_one(
+                        {"slug": schedule.product_slug}, {"crawl_base_urls": 1, "domains": 1}
+                    )
+                if product_docs:
+                    domains = product_docs.get("domains") or []
+                    base_urls = product_docs.get("crawl_base_urls") or []
+                    crawl_url = (
+                        base_urls[0]
+                        if base_urls
+                        else (f"https://{domains[0]}" if domains else None)
+                    )
+                else:
+                    crawl_url = None
+                if not crawl_url:
+                    continue
+                async with db_session() as db:
+                    await pipeline_svc.create_job_for_url(db, crawl_url)
+                    await monitoring_repo.mark_triggered(db, schedule.product_slug)
+                triggered += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Monitoring sweep failed for %s: %s", schedule.product_slug, exc)
+        if triggered:
+            logger.info("Monitoring sweep triggered %d re-crawl(s)", triggered)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Monitoring sweep failed (continuing): %s", exc, exc_info=True)
 
 
 async def _run_job(job_id: str) -> None:
@@ -86,6 +125,7 @@ async def main() -> None:
     # Reap jobs orphaned by a previous crash before claiming new work.
     await _sweep_stale(repo)
     last_sweep = loop.time()
+    last_monitoring_sweep = loop.time()
 
     logger.info("Pipeline worker started (concurrency=%d, poll=%.1fs)", _CONCURRENCY, _POLL_SECONDS)
     running: set[asyncio.Task[None]] = set()
@@ -94,6 +134,10 @@ async def main() -> None:
         if loop.time() - last_sweep >= _STALE_SWEEP_SECONDS:
             await _sweep_stale(repo)
             last_sweep = loop.time()
+
+        if loop.time() - last_monitoring_sweep >= _MONITORING_SWEEP_SECONDS:
+            await _sweep_monitoring()
+            last_monitoring_sweep = loop.time()
 
         if len(running) >= _CONCURRENCY:
             await _sleep_or_stop(stop, _POLL_SECONDS)


### PR DESCRIPTION
## Summary

Implements the approved policy change tracking system (design: minimal/pragmatic + grafted ideas from comprehensive and event-sourced).

### What's new

**Document versioning**
- `DocumentVersion` model extended with `product_slug`, `changed_fields`, `job_id`
- `Document` model gains `content_hash` (persisted on every insert/update)
- `_diff_fields()` helper compares 6 tracked fields: `text`, `title`, `doc_type`, `locale`, `regions`, `effective_date`
- `_store_documents` archives the old document to `document_versions` before any content update

**Overview history**
- New `ProductOverviewHistory` model + collection
- `save_product_overview` snapshots the current overview before every upsert, computing `risk_score_delta` and `changed_overview_fields`
- `job_id` threaded through `pipeline_service → generate_product_overview → save_product_overview`

**30-day monitoring**
- New `MonitoringSchedule` model + collection
- Products auto-enrolled on first pipeline completion (0–23h random jitter on `next_crawl_due_at` prevents thundering herd)
- `_sweep_monitoring()` in worker: hourly asyncio poll, triggers re-crawls for due schedules (env `PIPELINE_MONITORING_SWEEP_SECONDS`, default 3600)

**API**
- `GET /history/documents/{id}/versions` — version summaries (no text)
- `GET /history/documents/{id}/versions/{version_id}/diff` — unified diff via `difflib`
- `GET /history/products/{slug}/overview-history` — overview timeline

**DB indexes**
- `monitoring_schedules`: unique on `product_slug`, ASC on `next_crawl_due_at`
- `product_overview_history`: compound `(product_slug ASC, snapshot_at DESC)`
- `document_versions`: new compound `(product_slug ASC, created_at DESC)`

## Test plan
- [ ] 12 new unit tests: `_diff_fields` (8 cases), `DocumentVersionRepository.archive` (2), `MonitoringScheduleRepository.enroll` + `find_due` (2)
- [ ] 669 total tests pass
- [ ] ty + ruff clean