### PR TITLE
fix(products): compute logo.dev URLs server-side, fix env var name

### DIFF
--- a/packages/frontend/app/(dashboard)/products/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@clerk/nextjs/server";
 import { getBackendUrl } from "@lib/config";
+import { enrichLogos } from "@lib/logo";
 
 import {
   ProductsListClient,
@@ -7,19 +8,6 @@ import {
 } from "./products-list-client";
 
 const EMPTY_PAGE: ProductsPage = { items: [], total: 0, page: 1, pages: 1 };
-
-function enrichLogos(data: ProductsPage): ProductsPage {
-  const token = process.env.LOGO_DEV_API_KEY;
-  if (!token) return data;
-  return {
-    ...data,
-    items: data.items.map((item) => {
-      if (item.logo || !item.domains?.length) return item;
-      const domain = item.domains[0].replace(/^https?:\/\//, "");
-      return { ...item, logo: `https://img.logo.dev/${domain}?token=${token}` };
-    }),
-  };
-}
 
 async function fetchInitialProducts(page: number): Promise<ProductsPage> {
   try {

--- a/packages/frontend/app/(dashboard)/products/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/page.tsx
@@ -8,6 +8,19 @@ import {
 
 const EMPTY_PAGE: ProductsPage = { items: [], total: 0, page: 1, pages: 1 };
 
+function enrichLogos(data: ProductsPage): ProductsPage {
+  const token = process.env.LOGO_DEV_API_KEY;
+  if (!token) return data;
+  return {
+    ...data,
+    items: data.items.map((item) => {
+      if (item.logo || !item.domains?.length) return item;
+      const domain = item.domains[0].replace(/^https?:\/\//, "");
+      return { ...item, logo: `https://img.logo.dev/${domain}?token=${token}` };
+    }),
+  };
+}
+
 async function fetchInitialProducts(page: number): Promise<ProductsPage> {
   try {
     const { getToken } = await auth();
@@ -17,7 +30,7 @@ async function fetchInitialProducts(page: number): Promise<ProductsPage> {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
     if (!res.ok) return EMPTY_PAGE;
-    return (await res.json()) as ProductsPage;
+    return enrichLogos((await res.json()) as ProductsPage);
   } catch {
     return EMPTY_PAGE;
   }

--- a/packages/frontend/app/api/products/logos/route.ts
+++ b/packages/frontend/app/api/products/logos/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
 
       domain = domain.replace(/^https?:\/\//, "");
 
-      const logoDevToken = process.env.LOGO_DEV_PUBLIC_KEY;
+      const logoDevToken = process.env.LOGO_DEV_API_KEY;
 
       if (logoDevToken) {
         logo = `https://img.logo.dev/${domain}?token=${logoDevToken}`;

--- a/packages/frontend/app/api/products/route.ts
+++ b/packages/frontend/app/api/products/route.ts
@@ -2,23 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { apiEndpoints } from "@lib/config";
 import { httpJson } from "@lib/http";
+import { enrichLogos } from "@lib/logo";
 import { productsPageSchema } from "@lib/schemas";
-import type { z } from "zod";
-
-type ProductsPage = z.infer<typeof productsPageSchema>;
-
-function enrichLogos(data: ProductsPage): ProductsPage {
-  const token = process.env.LOGO_DEV_API_KEY;
-  if (!token) return data;
-  return {
-    ...data,
-    items: data.items.map((item) => {
-      if (item.logo || !item.domains?.length) return item;
-      const domain = item.domains[0].replace(/^https?:\/\//, "");
-      return { ...item, logo: `https://img.logo.dev/${domain}?token=${token}` };
-    }),
-  };
-}
 
 export async function GET(request: NextRequest) {
   try {

--- a/packages/frontend/app/api/products/route.ts
+++ b/packages/frontend/app/api/products/route.ts
@@ -3,6 +3,22 @@ import { NextRequest, NextResponse } from "next/server";
 import { apiEndpoints } from "@lib/config";
 import { httpJson } from "@lib/http";
 import { productsPageSchema } from "@lib/schemas";
+import type { z } from "zod";
+
+type ProductsPage = z.infer<typeof productsPageSchema>;
+
+function enrichLogos(data: ProductsPage): ProductsPage {
+  const token = process.env.LOGO_DEV_API_KEY;
+  if (!token) return data;
+  return {
+    ...data,
+    items: data.items.map((item) => {
+      if (item.logo || !item.domains?.length) return item;
+      const domain = item.domains[0].replace(/^https?:\/\//, "");
+      return { ...item, logo: `https://img.logo.dev/${domain}?token=${token}` };
+    }),
+  };
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -20,7 +36,7 @@ export async function GET(request: NextRequest) {
       schema: productsPageSchema,
     });
 
-    return NextResponse.json(data);
+    return NextResponse.json(enrichLogos(data));
   } catch (error) {
     console.error("Error fetching products:", error);
     return NextResponse.json(

--- a/packages/frontend/lib/logo.ts
+++ b/packages/frontend/lib/logo.ts
@@ -1,0 +1,23 @@
+type MinimalItem = { logo?: string | null | undefined; domains?: string[] | undefined };
+type MinimalPage<T extends MinimalItem> = { items: T[]; total: number; page: number; pages: number };
+
+function toHostname(raw: string): string {
+  try {
+    return new URL(raw.startsWith("http") ? raw : `https://${raw}`).hostname;
+  } catch {
+    return raw.replace(/^https?:\/\//, "").split(/[/?#]/)[0];
+  }
+}
+
+export function enrichLogos<T extends MinimalItem>(data: MinimalPage<T>): MinimalPage<T> {
+  const token = process.env.LOGO_DEV_API_KEY;
+  if (!token) return data;
+  return {
+    ...data,
+    items: data.items.map((item): T => {
+      if (item.logo || !item.domains?.length) return item;
+      const hostname = toHostname(item.domains[0]);
+      return { ...item, logo: `https://img.logo.dev/${hostname}?token=${token}` } as T;
+    }),
+  };
+}


### PR DESCRIPTION
## What this PR does

Product logos on `/products` were never appearing — spinning forever then silently falling back to initials. This fixes two root causes: a wrong env var name meant logo.dev URLs were never constructed, and each product card was firing a separate backend API call to resolve its logo (20 calls per page load), which could hang under load.

## Why

`LOGO_DEV_PUBLIC_KEY` was being read in the logo route, but the env var is named `LOGO_DEV_API_KEY` — so `token` was always `undefined` and every logo resolved to `null`.

Even with the correct env var, the per-card `/api/products/logos` route re-fetched the full product from the backend just to get its domain, producing N+1 calls per page. The backend's retry logic (2 retries with exponential backoff) meant a slow backend could keep spinners alive for several seconds.

## How to test

1. Visit `/products` — logos should appear immediately on load, no spinner.
2. Paginate or search — logos on subsequent pages should also load without spinners.
3. Hard-refresh (bypasses in-memory `logoCache`) — still no per-card API calls in DevTools Network tab.
4. Edge case: products without a `domains` field — should fall back to initials gracefully (no error thrown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
