### PR TITLE
chore: add prettier formatter to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,13 @@ repos:
   # Local hooks for project-specific checks
   - repo: local
     hooks:
+      - id: frontend-format
+        name: Frontend Prettier
+        entry: bash -c 'cd packages/frontend && bun run format'
+        language: system
+        files: ^packages/frontend/
+        pass_filenames: false
+
       - id: frontend-lint
         name: Frontend ESLint
         entry: bash -c 'cd packages/frontend && bun run lint'


### PR DESCRIPTION
Adds a `frontend-format` pre-commit hook that runs `prettier --write .` on the frontend package before every commit, keeping formatting enforced automatically.