### PR TITLE
fix(auth): split try/catch so getToken fallback runs when template call throws

### DIFF
--- a/packages/frontend/lib/http.ts
+++ b/packages/frontend/lib/http.ts
@@ -33,11 +33,21 @@ export async function http(
   let token: string | null | undefined = undefined;
   try {
     token = await userAuth.getToken?.({ template: "default" });
-    if (!token) {
+  } catch (err) {
+    console.warn("[http] getToken template=default failed, falling back:", err);
+  }
+  if (!token) {
+    try {
       token = await userAuth.getToken?.();
+    } catch (err) {
+      console.warn("[http] getToken fallback failed:", err);
     }
-  } catch (_) {
-    // ignore
+  }
+  if (!token) {
+    console.warn(
+      "[http] no token obtained for request to:",
+      typeof input === "string" ? input : input.toString(),
+    );
   }
 
   const mergedHeaders: HeadersInit = {


### PR DESCRIPTION
Both getToken calls were in one try/catch — if the template call throws, the catch fires and the fallback never runs. Split into two separate try/catch blocks. Added console.warn so Vercel logs show exactly what happens when token acquisition fails.