### PR TITLE
fix(auth): normalise JWT payload to user_id in AuthMiddleware

### DIFF
--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -140,7 +140,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         try:
             token = auth_header.split(" ")[1]
-            user_info: dict[str, Any] = await clerk_auth_service.verify_token(token)
+            payload: dict[str, Any] = await clerk_auth_service.verify_token(token)
+
+            # Normalise to the same shape as SERVICE_ACCOUNT_IDENTITY so
+            # _get_user_id / check_usage_limit always find "user_id".
+            # Clerk JWTs use "sub" (standard) or "id" (template custom claim).
+            user_id = payload.get("sub") or payload.get("id")
+            user_info = {
+                "user_id": user_id,
+                "email": payload.get("email"),
+                "name": payload.get("name"),
+            }
 
             self.logger.info(
                 "JWT authentication successful",

--- a/packages/backend/tests/unit/core/middleware_test.py
+++ b/packages/backend/tests/unit/core/middleware_test.py
@@ -176,12 +176,13 @@ class TestJWTAuth:
     @patch("src.core.middleware.clerk_auth_service")
     async def test_valid_jwt(self, mock_clerk: MagicMock, middleware: AuthMiddleware) -> None:
         mock_clerk.verify_token = AsyncMock(
-            return_value={"user_id": "user_123", "email": "user@example.com"}
+            return_value={"sub": "user_123", "email": "user@example.com", "name": "Test User"}
         )
         request = _make_request()
         result = await middleware._authenticate_jwt("Bearer valid-token", request)
         assert result is not None
         assert result["user_id"] == "user_123"
+        assert result["email"] == "user@example.com"
 
     @pytest.mark.asyncio
     @patch("src.core.middleware.clerk_auth_service")


### PR DESCRIPTION
## Root cause

`verify_token()` returns the raw Clerk JWT payload which has `sub` (standard claim) and optionally `id` (template custom claim) — but NOT `user_id`. `_get_user_id()` reads `request.state.user.get("user_id")` so `check_usage_limit` always saw `None` → 401, even for authenticated users.

Confirmed in Railway logs:
\`\`\`
"JWT authentication successful", "user_id": null, "email": "the.landry98@gmail.com"
\`\`\`

## Fix

Map `sub`/`id` → `user_id` in `_authenticate_jwt` so the returned dict has the same shape as `SERVICE_ACCOUNT_IDENTITY` and the localhost bypass. Updated test mock to use `sub` (matching real Clerk JWT format) instead of `user_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)