### PR TITLE
perf(pipeline): reduce stall timeout 45m→20m

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -261,6 +261,9 @@ CONVERGENCE_LEGAL_SCORE = 0.2
 # Boost-only pages to keep crawling after the own-score frontier empties, in case one links a
 # policy reachable no other way. A new real lead resets it. See _relevance_exhausted.
 CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
+# Consecutive fetch failures before concluding the site is actively blocking us.
+# A successful fetch resets this counter — only sustained unbroken blocking triggers abort.
+CRAWL_BOT_WALL_ABORT = int(os.getenv("CRAWLER_BOT_WALL_ABORT", "50"))
 # Cap per-document English locale variants (e.g. en-us/en-gb) to reduce duplicate crawls.
 MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC = int(
     os.getenv("CRAWLER_MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC", "2")
@@ -4343,7 +4346,7 @@ class ClauseaCrawler:
                         )
                         break
 
-                    if self._consecutive_blocked >= CRAWL_EXHAUSTION_GRACE * 5:
+                    if self._consecutive_blocked >= CRAWL_BOT_WALL_ABORT:
                         logger.info(
                             f"🧭 Crawl bot-wall abort: {self._consecutive_blocked} consecutive "
                             f"fetch failures — site is actively blocking the crawler. "

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -261,11 +261,6 @@ CONVERGENCE_LEGAL_SCORE = 0.2
 # Boost-only pages to keep crawling after the own-score frontier empties, in case one links a
 # policy reachable no other way. A new real lead resets it. See _relevance_exhausted.
 CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
-# Pages to visit before giving up if zero policy-relevant content has been found.
-# Prevents blocked/bot-walled sites from holding a slot for 400 pages × 20-30 sec.
-# The relevance_exhausted check only fires once a policy page is found; this covers
-# sites where nothing is ever found.
-CRAWL_ZERO_POLICY_ABORT = int(os.getenv("CRAWLER_ZERO_POLICY_ABORT", "50"))
 # Cap per-document English locale variants (e.g. en-us/en-gb) to reduce duplicate crawls.
 MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC = int(
     os.getenv("CRAWLER_MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC", "2")
@@ -1705,6 +1700,7 @@ class ClauseaCrawler:
         self._frontier_real_leads: int = 0  # queued URLs whose own score clears the gate
         self._policy_pages_found: int = 0
         self._crawls_since_new_lead: int = 0
+        self._consecutive_blocked: int = 0  # consecutive fetch failures (bot-wall detection)
         self._sitemap_seeded: bool = False  # True when sitemaps provided seed URLs
         # Best policy-relevance score assigned to each queued URL (anchor-aware).
         # Consulted by the browser-fetch gate so opaque policy URLs discovered via
@@ -4275,6 +4271,7 @@ class ClauseaCrawler:
                         if result.success:
                             self.stats.crawled_urls += 1
                             self.results.append(result)
+                            self._consecutive_blocked = 0
 
                             if (
                                 result.legal_score is not None
@@ -4294,6 +4291,7 @@ class ClauseaCrawler:
                             self.stats.failed_urls += 1
                             self.failed_urls.add(url)
                             pages_since_policy_hit += 1
+                            self._consecutive_blocked += 1
                             logger.warning(f"❌ Failed: {url} - {result.error_message}")
                             # Surface robots.txt blocks so the pipeline can tell the user
                             # the SITE blocked us (not that we failed). Other failures stay
@@ -4345,16 +4343,11 @@ class ClauseaCrawler:
                         )
                         break
 
-                    if (
-                        self._policy_pages_found == 0
-                        and len(self.visited_urls) >= CRAWL_ZERO_POLICY_ABORT
-                        and self.strategy == "best_first"
-                        and (self._frontier_top_base_score() or 0) < self.min_legal_score
-                    ):
+                    if self._consecutive_blocked >= CRAWL_EXHAUSTION_GRACE * 5:
                         logger.info(
-                            f"🧭 Crawl zero-policy abort: {len(self.visited_urls)} pages visited "
-                            f"with 0 policy pages found and no promising URLs remaining; "
-                            f"site is likely blocked or has no accessible policy documents."
+                            f"🧭 Crawl bot-wall abort: {self._consecutive_blocked} consecutive "
+                            f"fetch failures — site is actively blocking the crawler. "
+                            f"Stopping at {len(self.visited_urls)} pages."
                         )
                         break
 

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -261,6 +261,11 @@ CONVERGENCE_LEGAL_SCORE = 0.2
 # Boost-only pages to keep crawling after the own-score frontier empties, in case one links a
 # policy reachable no other way. A new real lead resets it. See _relevance_exhausted.
 CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
+# Pages to visit before giving up if zero policy-relevant content has been found.
+# Prevents blocked/bot-walled sites from holding a slot for 400 pages × 20-30 sec.
+# The relevance_exhausted check only fires once a policy page is found; this covers
+# sites where nothing is ever found.
+CRAWL_ZERO_POLICY_ABORT = int(os.getenv("CRAWLER_ZERO_POLICY_ABORT", "50"))
 # Cap per-document English locale variants (e.g. en-us/en-gb) to reduce duplicate crawls.
 MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC = int(
     os.getenv("CRAWLER_MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC", "2")
@@ -4337,6 +4342,19 @@ class ClauseaCrawler:
                             f"page(s) found and no own-score lead left after a "
                             f"{CRAWL_EXHAUSTION_GRACE}-page grace; stopping discovery at "
                             f"{len(self.visited_urls)} pages (only boost-only links remained)."
+                        )
+                        break
+
+                    if (
+                        self._policy_pages_found == 0
+                        and len(self.visited_urls) >= CRAWL_ZERO_POLICY_ABORT
+                        and self.strategy == "best_first"
+                        and (self._frontier_top_base_score() or 0) < self.min_legal_score
+                    ):
+                        logger.info(
+                            f"🧭 Crawl zero-policy abort: {len(self.visited_urls)} pages visited "
+                            f"with 0 policy pages found and no promising URLs remaining; "
+                            f"site is likely blocked or has no accessible policy documents."
                         )
                         break
 

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -441,14 +441,28 @@ class PipelineService:
                     )
 
                     if stats.policy_documents_stored == 0:
-                        # The crawl ran to completion but found nothing storable. This
-                        # is a deterministic terminal outcome, NOT a failure to retry —
-                        # retrying yields the same result. Marking it `no_documents`
-                        # (rather than `failed`) stops the product page from
-                        # retriggering the pipeline on every visit. `failed` is
-                        # reserved for genuine interruptions/errors (see the except
-                        # and timeout handlers below).
-                        job.status = "no_documents"
+                        # Crawl stored nothing new. Before giving up, check if the
+                        # product already has documents from a previous run. If yes,
+                        # those docs are valid input for synthesis — deduplicated
+                        # re-crawls (same content hash) legitimately store 0 new docs
+                        # but must not skip the overview step.
+                        doc_svc_check = create_document_service()
+                        existing_docs = await doc_svc_check.get_product_documents_by_slug(
+                            db, job.product_slug
+                        )
+                        existing_policy_docs = [
+                            doc for doc in existing_docs if doc.doc_type != "other"
+                        ]
+                        if existing_policy_docs:
+                            logger.info(
+                                "Crawl stored 0 new docs but %d existing docs found for %s "
+                                "— proceeding to synthesis",
+                                len(existing_policy_docs),
+                                job.product_slug,
+                            )
+                            job.documents_stored = len(existing_policy_docs)
+                        else:
+                            job.status = "no_documents"
 
                         # Build a descriptive error based on crawl error types
                         robots_blocked = [

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -48,7 +48,7 @@ MAX_PIPELINE_DURATION_SECONDS = float(os.getenv("PIPELINE_MAX_DURATION_SECONDS",
 # Abort a job that makes no forward progress (no page/document/step update bumps updated_at)
 # for this long. Bounds *inactivity*, not total runtime: a slow-but-advancing pipeline runs
 # indefinitely, while a wedged one frees its worker slot fast instead of clogging it.
-STALL_TIMEOUT_SECONDS = float(os.getenv("PIPELINE_STALL_TIMEOUT_SECONDS", "2700"))
+STALL_TIMEOUT_SECONDS = float(os.getenv("PIPELINE_STALL_TIMEOUT_SECONDS", "1200"))
 
 
 class _PipelineStalled(Exception):

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -574,6 +574,11 @@ class PipelineService:
                         progress_callback=_on_synthesise_progress,
                     )
 
+                    # Update to total docs in product (not just newly stored this run).
+                    # documents_stored was set from crawl stats which only counts new/changed
+                    # docs — misleading when re-crawling a product that already has docs.
+                    job.documents_stored = len(analysed_docs)
+
                     # Truthful step state: a document either got analysis or it didn't.
                     # Per-document failures are isolated inside analyse_product_documents,
                     # so the call returns even when every document failed. If NONE were

--- a/packages/backend/tests/unit/pipeline_service_test.py
+++ b/packages/backend/tests/unit/pipeline_service_test.py
@@ -165,11 +165,19 @@ async def test_run_pipeline_zero_documents_marks_no_documents_not_failed(mock_db
     async def fake_db_session():
         yield mock_db
 
+    # No pre-existing docs — confirms no_documents is still reached
+    empty_doc_svc = MagicMock()
+    empty_doc_svc.get_product_documents_by_slug = AsyncMock(return_value=[])
+
     with (
         patch("src.services.pipeline_service.db_session", fake_db_session),
         patch(
             "src.services.pipeline_service.create_product_service",
             return_value=product_svc,
+        ),
+        patch(
+            "src.services.pipeline_service.create_document_service",
+            return_value=empty_doc_svc,
         ),
         patch(
             "src.services.pipeline_service.PolicyDocumentPipeline",


### PR DESCRIPTION
Anti-bot blocked sites burn a 45-min slot finding nothing. With Gemini removed there is no LLM rate-limit reason to hold a slot that long. 20 min gives real crawls enough runway while failing blocked sites 2.5x faster.