### PR TITLE
fix(crawler): stop the multi-seed crawl stall→reset loop

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -264,6 +264,7 @@ CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
 # Consecutive fetch failures before concluding the site is actively blocking us.
 # A successful fetch resets this counter — only sustained unbroken blocking triggers abort.
 CRAWL_BOT_WALL_ABORT = int(os.getenv("CRAWLER_BOT_WALL_ABORT", "50"))
+MIN_PAGES_PER_SEED = int(os.getenv("CRAWLER_MIN_PAGES_PER_SEED", "60"))
 # Cap per-document English locale variants (e.g. en-us/en-gb) to reduce duplicate crawls.
 MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC = int(
     os.getenv("CRAWLER_MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC", "2")
@@ -4114,6 +4115,9 @@ class ClauseaCrawler:
                     await self._emit_result(result)
                 else:
                     logger.warning(f"❌ Still failed after serial retry: {url}")
+                # A heartbeat per retry so a long drain of failing renders isn't read as a stall.
+                self.stats.total_urls += 1
+                self._report_crawl_progress(force=True)
         finally:
             self._in_render_retry = False
 
@@ -4388,8 +4392,16 @@ class ClauseaCrawler:
                 await self._shutdown_log_executor()
 
     async def crawl_multiple(self, urls: list[str]) -> list[CrawlResult]:
-        """Crawl multiple base URLs."""
+        """Crawl multiple base URLs, sharing one page budget across all of them."""
         all_results = []
+
+        full_max_pages = self.max_pages
+        per_seed_max_pages = max(MIN_PAGES_PER_SEED, full_max_pages // max(1, len(urls)))
+        if per_seed_max_pages < full_max_pages:
+            logger.info(
+                f"📐 {len(urls)} seeds share a {full_max_pages}-page budget: "
+                f"{per_seed_max_pages} pages per seed."
+            )
 
         try:
             for i, url in enumerate(urls, 1):
@@ -4400,6 +4412,7 @@ class ClauseaCrawler:
                     )
                     break
                 logger.info(f"🔄 Processing URL {i}/{len(urls)}: {url}")
+                self.max_pages = per_seed_max_pages
                 results = await self.crawl(url, cleanup=False)
                 all_results.extend(results)
                 logger.info(
@@ -4428,6 +4441,7 @@ class ClauseaCrawler:
                 if self.robots_checker:
                     self.robots_checker.clear_cache()
         finally:
+            self.max_pages = full_max_pages
             await self._shutdown_log_executor()
             # The shared browser is process-owned and reused across products — it is torn
             # down only on a crash (see _cleanup_browser) or when the worker exits.

--- a/packages/backend/tests/unit/crawler/multi_seed_budget_test.py
+++ b/packages/backend/tests/unit/crawler/multi_seed_budget_test.py
@@ -1,0 +1,58 @@
+"""crawl_multiple shares one page budget across all seed URLs.
+
+A product with many seed URLs (e.g. 10 distinct policy pages) would otherwise run N full
+max_pages crawls back to back — enough work to blow the pipeline stall timeout and loop
+reset→recrawl forever. The budget is divided across seeds, with a floor so each seed keeps
+enough breadth for the convergence/exhaustion stoppers to fire naturally.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.crawler import MIN_PAGES_PER_SEED, ClauseaCrawler
+
+
+async def _record_budgets(crawler: ClauseaCrawler, seeds: list[str]) -> list[int]:
+    seen: list[int] = []
+
+    async def fake_crawl(_url: str, *, cleanup: bool = True):
+        seen.append(crawler.max_pages)
+        return []
+
+    crawler.crawl = AsyncMock(side_effect=fake_crawl)  # type: ignore[method-assign]
+    await crawler.crawl_multiple(seeds)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_single_seed_keeps_full_budget():
+    crawler = ClauseaCrawler(max_pages=400)
+    budgets = await _record_budgets(crawler, ["https://example.com"])
+    assert budgets == [400]
+
+
+@pytest.mark.asyncio
+async def test_many_seeds_divide_the_budget():
+    crawler = ClauseaCrawler(max_pages=400)
+    seeds = [f"https://example.com/p{i}" for i in range(8)]
+    budgets = await _record_budgets(crawler, seeds)
+    # 400 // 8 = 50, floored to MIN_PAGES_PER_SEED so convergence (budget 50) can still fire.
+    assert budgets == [MIN_PAGES_PER_SEED] * 8
+    assert all(b < 400 for b in budgets)
+
+
+@pytest.mark.asyncio
+async def test_few_seeds_split_without_hitting_the_floor():
+    crawler = ClauseaCrawler(max_pages=400)
+    seeds = [f"https://example.com/p{i}" for i in range(4)]
+    budgets = await _record_budgets(crawler, seeds)
+    assert budgets == [100, 100, 100, 100]
+
+
+@pytest.mark.asyncio
+async def test_budget_restored_after_crawl_multiple():
+    crawler = ClauseaCrawler(max_pages=400)
+    await _record_budgets(crawler, [f"https://example.com/p{i}" for i in range(10)])
+    # Later products reuse the crawler config; the divided budget must not leak.
+    assert crawler.max_pages == 400

--- a/packages/backend/tests/unit/crawler/render_retry_test.py
+++ b/packages/backend/tests/unit/crawler/render_retry_test.py
@@ -83,3 +83,30 @@ async def test_drain_is_noop_when_queue_empty(monkeypatch):
     monkeypatch.setattr(crawler, "fetch_page", fetch_page)
     await crawler._drain_render_retries(session=_NO_SESSION)
     fetch_page.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_drain_bumps_heartbeat_on_every_retry_even_when_all_fail(monkeypatch):
+    """A long drain of failing renders must keep the job alive.
+
+    Failing retries emit no result, so without a per-retry progress report the pipeline
+    stall guard cancels the job mid-drain and loops reset→recrawl. Each retry must report
+    progress regardless of outcome.
+    """
+    heartbeats: list[int] = []
+    crawler = ClauseaCrawler(progress_callback=lambda current, total: heartbeats.append(current))
+    crawler._render_retry_queue = [
+        "https://example.com/a",
+        "https://example.com/b",
+        "https://example.com/c",
+    ]
+    monkeypatch.setattr(
+        crawler,
+        "fetch_page",
+        AsyncMock(side_effect=lambda _session, url: _result(url, success=False)),
+    )
+
+    await crawler._drain_render_retries(session=_NO_SESSION)
+
+    # One progress report per retried URL, not just on the (zero) successes.
+    assert len(heartbeats) == 3


### PR DESCRIPTION
## Problem

The pipeline queue stopped draining: `completed` was frozen at 4 for 3.5h while crawl slots churned through products that never reached a terminal state. Root cause is a **stall→reset→recrawl loop** on certain products:

- **Many-seed products** (e.g. Shein has 10 seed URLs) crawl **each seed as a separate full `max_pages` crawl** — `crawl_multiple` resets all state between seeds, so each gets a fresh 400-page budget. Ten seeds × two passes = up to ~8000 pages of work per product, far exceeding `PIPELINE_STALL_TIMEOUT_SECONDS=1200` (20m).
- The **end-of-crawl render-retry drain** (`_drain_render_retries`) is **silent on failure** — it only emits a result/heartbeat when a retry *succeeds*. On bot-walled sites (Cloudflare/datacenter-IP: OpenAI, Shein captcha pages, etc.) the drain queue fills with renders that each take ~20s and almost all fail, so the job goes silent long enough that the stall guard cancels it mid-drain.

Either way the job is reset and recrawled from scratch, repeating forever. Evidence from prod logs: `Render stats: 37 attempts, 37 failed, 0 recovered`; `job … stalled (no progress for 20m)` immediately followed by the same product restarting.

## Fix

1. **`crawl_multiple` shares one page budget across all seeds** — `max_pages // N`, floored at `MIN_PAGES_PER_SEED=60` (env `CRAWLER_MIN_PAGES_PER_SEED`). Single-seed products are unaffected. Each seed's own page is still fetched first (depth-0), and convergence/relevance-exhaustion still stop each seed naturally; the floor keeps enough breadth for those stoppers to fire before the cap bites.
2. **`_drain_render_retries` reports progress on every retry**, not just successes, so a long drain keeps the job heartbeat alive. A truly bot-walled crawl now *completes* (as `no_documents`) instead of looping.

## Scope / not in this PR

Renders **failing** on Cloudflare/datacenter-IP sites is a separate issue — verified locally that Camoufox renders OpenAI's policy pages in ~1.5s with the exact prod config, so the prod failure is egress-IP reputation, fixable only with a **residential proxy** (`CRAWLER_PROXY`, already wired). This PR only stops the reset loop.

## Tests

- `tests/unit/crawler/multi_seed_budget_test.py` (new): single-seed keeps full budget; many seeds divide to the floor; few seeds split evenly; budget restored after.
- `tests/unit/crawler/render_retry_test.py`: new case asserting a heartbeat fires per retry even when all fail.
- Full crawler + pipeline suites green (210 passed); ruff + ty clean.