### PR TITLE
fix(pipeline): completion log says "policy docs this run", not "policy/legal docs"

### DIFF
--- a/packages/backend/src/pipeline.py
+++ b/packages/backend/src/pipeline.py
@@ -1590,7 +1590,7 @@ class PolicyDocumentPipeline:
             log_memory_usage(f"Completed {product.name}")
             logger.info(
                 f"✅ Completed {product.name} in {product_duration:.2f}s "
-                f"({len(processed_documents)} policy/legal docs)"
+                f"({len(processed_documents)} policy docs this run)"
             )
 
             return processed_documents


### PR DESCRIPTION
## What

Fixes the per-product completion log line (`pipeline.py:1593`).

Before: `✅ Completed X in Ns (N policy/legal docs)`
After:  `✅ Completed X in Ns (N policy docs this run)`

## Why

Two things were misleading:

1. **"legal" → "policy".** We collect policy content broadly — `CORE_DOC_TYPES` includes `community_guidelines`, `security_policy`, `children_privacy_policy`, `copyright_policy`, plus policy-adjacent pages (`/trust`, `/transparency`). Those aren't "legal documents" in the contract sense. Policy is the superset; calling the output "legal docs" undersells and mislabels the scope.
2. **"this run".** The count is `len(processed_documents)` — docs processed in *this* crawl, not the total in the DB. A product with full coverage from a prior run that re-crawls and finds nothing new logged `0 policy/legal docs`, which reads as a failure when it isn't. Concrete case: **MyFitnessPal** has 4 policy docs in the DB (privacy, terms, community guidelines, WA health privacy) but logged `0 policy/legal docs` this run — we misread it as a zero-doc product.

## Scope

Only the user-facing log string. The internal `legal` naming (`min_legal_score`, `legal_score`, …, and the `CRAWLER_*_MIN_LEGAL_SCORE` env vars set in Railway) is a separate, larger rename — not in this PR. Other `legal` references (`/legal/` path patterns, scoring keywords) are correct: they match the literal token "legal" that sites use.