### PR TITLE
fix(crawler): dedup any bare lang= query value, not just an allowlist

### DIFF
--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -172,18 +172,28 @@ def _is_bare_language(token: str) -> bool:
     return lowered in _LANGUAGE_CODES or lowered in _LANGUAGE_NAMES
 
 
-def _is_locale_query_value(value: str) -> bool:
+# Locale query keys whose name doesn't itself prove "language": ``l`` and ``lr`` are
+# widely reused for layout/list/limit/quality, so their bare values still go through the
+# language allowlist. The explicit keys (lang, hl, locale, …) need no such guard.
+_AMBIGUOUS_LOCALE_QUERY_KEYS = frozenset({"l", "lr"})
+
+
+def _is_locale_query_value(key: str, value: str) -> bool:
     """True if a locale query value (e.g. the ``ta`` in ``?lang=ta``) names a translation.
 
-    The query key (``lang``, ``hl``, …) already proves the value is a locale, so — unlike
-    bare path segments — no language allowlist is needed: any bare alphabetic value is a
-    translation marker. Region-qualified values (``en-GB``, ``pt_BR``) keep their region
+    For an explicit locale key (``lang``, ``hl``, ``locale``, …) the key already proves the
+    value is a locale, so — unlike bare path segments — no language allowlist is needed: any
+    bare alphabetic value is a translation marker. The ambiguous short keys ``l``/``lr`` are
+    reused for non-locale purposes (``?l=list``, ``?l=grid``), so their values still go
+    through the allowlist. Region-qualified values (``en-GB``, ``pt_BR``) keep their region
     and return False so jurisdiction-distinct documents are never collapsed, and
     non-alphabetic values (``?l=10`` pagination) are left intact.
     """
     lowered = value.lower()
     if not lowered or "-" in lowered or "_" in lowered:
         return False
+    if key.lower() in _AMBIGUOUS_LOCALE_QUERY_KEYS:
+        return _is_bare_language(lowered)
     return lowered.isalpha()
 
 
@@ -209,7 +219,7 @@ def locale_canonical_key(parsed: ParseResult) -> tuple[str, bool, bool]:
 
     kept_query: list[tuple[str, str]] = []
     for key, value in parse_qsl(parsed.query, keep_blank_values=True):
-        if key.lower() in _LOCALE_QUERY_KEYS and _is_locale_query_value(value):
+        if key.lower() in _LOCALE_QUERY_KEYS and _is_locale_query_value(key, value):
             had_signal = True
             if value.lower() in _ENGLISH_TOKENS:
                 is_english = True

--- a/packages/backend/src/crawler.py
+++ b/packages/backend/src/crawler.py
@@ -172,6 +172,21 @@ def _is_bare_language(token: str) -> bool:
     return lowered in _LANGUAGE_CODES or lowered in _LANGUAGE_NAMES
 
 
+def _is_locale_query_value(value: str) -> bool:
+    """True if a locale query value (e.g. the ``ta`` in ``?lang=ta``) names a translation.
+
+    The query key (``lang``, ``hl``, …) already proves the value is a locale, so — unlike
+    bare path segments — no language allowlist is needed: any bare alphabetic value is a
+    translation marker. Region-qualified values (``en-GB``, ``pt_BR``) keep their region
+    and return False so jurisdiction-distinct documents are never collapsed, and
+    non-alphabetic values (``?l=10`` pagination) are left intact.
+    """
+    lowered = value.lower()
+    if not lowered or "-" in lowered or "_" in lowered:
+        return False
+    return lowered.isalpha()
+
+
 def locale_canonical_key(parsed: ParseResult) -> tuple[str, bool, bool]:
     """Reduce a URL to a key shared by all pure-translation variants of one document.
 
@@ -194,7 +209,7 @@ def locale_canonical_key(parsed: ParseResult) -> tuple[str, bool, bool]:
 
     kept_query: list[tuple[str, str]] = []
     for key, value in parse_qsl(parsed.query, keep_blank_values=True):
-        if key.lower() in _LOCALE_QUERY_KEYS and _is_bare_language(value):
+        if key.lower() in _LOCALE_QUERY_KEYS and _is_locale_query_value(value):
             had_signal = True
             if value.lower() in _ENGLISH_TOKENS:
                 is_english = True

--- a/packages/backend/tests/unit/crawler/locale_dedup_test.py
+++ b/packages/backend/tests/unit/crawler/locale_dedup_test.py
@@ -131,3 +131,19 @@ def test_non_alphabetic_query_value_is_not_treated_as_language() -> None:
     key, had_signal, _ = locale_canonical_key(urlparse("https://shop.example.com/items?l=10"))
     assert key == "https://shop.example.com/items?l=10"
     assert had_signal is False
+
+
+def test_ambiguous_l_query_value_falls_back_to_allowlist() -> None:
+    # ?l= also means layout/list/grid on many sites; alphabetic-but-not-a-language values
+    # must NOT collapse, while a real language under ?l= still does.
+    for value in ("list", "grid", "home"):
+        key, had_signal, _ = locale_canonical_key(
+            urlparse(f"https://shop.example.com/items?l={value}")
+        )
+        assert key == f"https://shop.example.com/items?l={value}"
+        assert had_signal is False
+    key, had_signal, _ = locale_canonical_key(
+        urlparse("https://store.steampowered.com/privacy?l=english")
+    )
+    assert key == "https://store.steampowered.com/privacy"
+    assert had_signal is True

--- a/packages/backend/tests/unit/crawler/locale_dedup_test.py
+++ b/packages/backend/tests/unit/crawler/locale_dedup_test.py
@@ -92,3 +92,42 @@ def test_english_variant_kept_over_other_translations() -> None:
     assert crawler.should_crawl_url(base + "?lang=en", base, 1) is True
     # A non-English sibling is then a redundant translation.
     assert crawler.should_crawl_url(base + "?lang=fr", base, 1) is False
+
+
+def test_query_language_dedup_is_not_limited_to_an_allowlist() -> None:
+    # ta/te/ur are real languages absent from the path-segment allowlist; the query key
+    # already proves they're translations, so they must dedup like any other ?lang= value.
+    for code in ("ta", "te", "ur", "sw", "uz"):
+        key, had_signal, is_english = locale_canonical_key(
+            urlparse(f"https://www.whatsapp.com/security?lang={code}")
+        )
+        assert key == "https://www.whatsapp.com/security"
+        assert had_signal is True
+        assert is_english is False
+
+
+def test_unlisted_query_translations_collapse_to_one_crawl() -> None:
+    crawler = _crawler()
+    base = "https://www.whatsapp.com/security"
+    assert crawler.should_crawl_url(base, base, 1) is True
+    # Tamil/Telugu/Urdu siblings are now redundant translations, not rendered.
+    assert crawler.should_crawl_url(base + "?lang=ta", base, 1) is False
+    assert crawler.should_crawl_url(base + "?lang=te", base, 1) is False
+    assert crawler.should_crawl_url(base + "?lang=ur", base, 1) is False
+
+
+def test_region_qualified_query_value_is_preserved() -> None:
+    # zh-hk (Cantonese/HK) and pt_BR carry a region — jurisdiction-distinct, never collapse.
+    for value in ("zh-hk", "pt_BR", "en-GB"):
+        key, had_signal, _ = locale_canonical_key(
+            urlparse(f"https://www.whatsapp.com/security?lang={value}")
+        )
+        assert key == f"https://www.whatsapp.com/security?lang={value}"
+        assert had_signal is False
+
+
+def test_non_alphabetic_query_value_is_not_treated_as_language() -> None:
+    # ?l= doubles as pagination/limit on some sites; a numeric value must not collapse pages.
+    key, had_signal, _ = locale_canonical_key(urlparse("https://shop.example.com/items?l=10"))
+    assert key == "https://shop.example.com/items?l=10"
+    assert had_signal is False


### PR DESCRIPTION
## What changes

Locale dedup now collapses **any** bare-language `?lang=` (or `?hl=`/`?locale=`/…) query value as a translation, instead of only the 34 ISO 639-1 codes that happened to be in the `_LANGUAGE_CODES` allowlist.

## Why

`locale_canonical_key` ran query-param locale values through `_is_bare_language()`, whose allowlist holds 34 codes. Real languages outside it — `ta`, `te`, `ur`, `sw`, `uz`, … — weren't recognized as translation markers, so `had_signal` stayed `False` and the URL bypassed dedup entirely.

In production this meant pages like `https://www.whatsapp.com/security?lang=ta` got **enqueued and browser-rendered**, timed out on Railway's datacenter IP (~20s each), then scored `legal_score=0.00` and were discarded — pure wasted render budget, the crawler's scarcest resource. A single WhatsApp crawl showed dozens of these.

## The reasoning

The query **key** (`lang`, `hl`, `locale`, …) already proves the value is a locale — so an allowlist of *which* languages count is redundant there. A bare alphabetic value is a translation, period.

The allowlist is still correct for **bare path segments** (`/de/`, `/it/`), where a 2-letter token is genuinely ambiguous (`/hr/` = HR policy, `/uk/` = UK region), so that path is unchanged.

## Behavioural changes

| URL | before | after |
|---|---|---|
| `…/security?lang=ta` (canonical already seen) | enqueued + rendered, then discarded | **deduped pre-fetch** |
| `…/security?lang=te`, `?lang=ur`, `?lang=sw` | enqueued + rendered | deduped pre-fetch |
| `…?lang=en-GB`, `?lang=zh-hk`, `?lang=pt_BR` | preserved (region-distinct) | **still preserved** (hyphen/underscore rule) |
| `…/items?l=10` (pagination) | preserved | **still preserved** (non-alphabetic guard) |
| bare path segments `/hr/`, `/uk/` | preserved | **still preserved** (allowlist unchanged) |

No region/jurisdiction variant is collapsed, and no recall is lost: the English/first-seen canonical is always kept; only redundant translations of an already-seen document are dropped.

## Verification

- `tests/unit/crawler/locale_dedup_test.py`: 13 passed (5 new — unlisted-language dedup, region-qualified preservation, `?l=10` guard)
- `tests/unit/crawler/`: 207 passed
- `ruff check` + pre-commit hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)