### PR TITLE
fix(analysis): score absent dimensions as omitted, not worst-case

### DIFF
--- a/packages/backend/src/prompts/analysis_prompts.py
+++ b/packages/backend/src/prompts/analysis_prompts.py
@@ -93,14 +93,14 @@ DOCUMENT_ANALYSIS_PROMPT = f"""You are a senior privacy analyst. Produce an evid
 3-5 concrete sentences. Name exact data types ("precise GPS", "biometric identifiers"), exact recipients ("Meta Pixel", "Google Analytics"), exact rights paths ("Settings > Privacy > Delete"). Start with the service/product name, never with "This document" or "This policy".
 
 ## SCORES
-Six dimensions, each 0-10 (higher = better for user). Only include a key when the extraction provides real evidence — a missing key is an honest signal.
+Each dimension is 0-10 (higher = better for the user). Include a dimension ONLY when the document substantively addresses it. If the document is silent on a dimension — e.g. a security/trust page that says nothing about data collection — OMIT that key. A score of 0 means the document EXPLICITLY describes the worst-case practice; silence or "not mentioned" is NEVER 0, omit instead.
 
 - **transparency**: clarity of what is collected, why, and by whom. 10=crystal clear, 0=deliberately opaque.
-- **data_collection_scope**: breadth of collection. 10=minimal/necessary only, 0=sweeping.
-- **user_control**: self-service controls. 10=full opt-out/deletion/portability, 0=none.
-- **third_party_sharing**: breadth of sharing. 10=no sharing, 0=unrestricted.
-- **data_retention_score**: retention specificity. 10=short specific periods, 0=indefinite. **Omit if extraction has no retention data.**
-- **security_score**: stated security measures. 10=E2EE/SOC2/pen-tests, 0=no mention. **Omit if extraction has no security data.**
+- **data_collection_scope**: breadth of collection. 10=minimal/necessary only, 0=explicitly sweeping.
+- **user_control**: self-service controls. 10=full opt-out/deletion/portability, 0=explicitly none.
+- **third_party_sharing**: breadth of sharing. 10=no sharing, 0=explicitly unrestricted.
+- **data_retention_score**: retention specificity. 10=short specific periods, 0=explicitly indefinite.
+- **security_score**: stated security measures. 10=E2EE/SOC2/pen-tests, 0=explicitly weak.
 
 Calibration: minimal-collection + E2EE → high collection/sharing scores (7-10). Ad-tech ecosystem + AI training on user content → low (0-4). Clear disclosure of invasive practices does NOT raise scores.
 


### PR DESCRIPTION
## What & why

Monitoring surfaced security/trust pages (figma.com/security, github.com/trust-center) scoring **`risk=9 / very_pervasive`** with zero critical clauses. These pages are **intentionally in scope** — customers want to know how a vendor protects data — so the bug is not classification, it's **scoring**.

**Root cause:** the per-document rubric forced `transparency`, `data_collection_scope`, `user_control`, `third_party_sharing` on *every* document — only `data_retention`/`security` had an "omit" escape. So a security page that says nothing about data collection got `data_collection_scope=0` ("sweeping"), `user_control=0` ("none"), `third_party_sharing=0` ("unrestricted") — the model read **silence as worst-case**. The risk math then yields 9:
```
transparency=2, collection=0, control=0, sharing=0; retention/security absent→5
weighted = 1.18 → risk = 10 − 1.18 ≈ 9
```

This inflated product grades (those phantom risk-9 docs feed the product risk blend).

## Fix

Prompt rubric only (`DOCUMENT_ANALYSIS_PROMPT`):
- Include a dimension **only when the document substantively addresses it**; silence → **omit**.
- `0` means the document **explicitly describes** the worst practice — never mere silence.

No code change: `_calculate_risk_score` already maps absent dimensions to **neutral (5)** — that's the correct design and is covered by `test_missing_optional_scores_filled_with_neutral`.

## Validation (live re-analysis, cache bypassed)

`figma.com/security`:

| | scores | risk | verdict | grade |
|---|---|---|---|---|
| before | transparency=2, collection=0, control=0, sharing=0 | 9 | very_pervasive | E |
| after | only `security_score=5` (4 core dims omitted) | 5 | moderate | C |

The page now ranks as honest "moderate — can't assess data practices from a security page," not falsely "very_pervasive."

## Notes
- Prompt/LLM behaviour isn't unit-testable; validated empirically above. Existing risk-score tests (15) pass; `ruff` clean.
- Follow-up candidates (separate): `PRODUCT_OVERVIEW_PROMPT` has the same "always provide the 4" mandate at product level; and a one-off re-analysis to clear already-stored phantom scores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)