### PR TITLE
fix(frontend): handle product page 429 limit state

### DIFF
--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.test.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ReactNode } from "react";
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+import CompanyPage from "./product-page-client";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ slug: "acme-inc" }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: vi.fn(),
+  },
+}));
+
+vi.mock("@/app/actions/pipeline", () => ({
+  triggerPipeline: vi.fn(),
+}));
+
+vi.mock("@/app/actions/products", () => ({
+  subscribeIndexationNotify: vi.fn(),
+}));
+
+function createJsonResponse(status: number, payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}
+
+describe("CompanyPage limit reached state", () => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = getRequestUrl(input);
+
+    if (url.endsWith("/api/products/acme-inc")) {
+      return createJsonResponse(429, { error: "rate_limited" });
+    }
+    if (url.endsWith("/api/products/acme-inc/documents")) {
+      return createJsonResponse(200, []);
+    }
+    if (url.endsWith("/api/products/acme-inc/overview")) {
+      return createJsonResponse(429, { error: "rate_limited" });
+    }
+    if (url.endsWith("/api/products/acme-inc/explainer")) {
+      return createJsonResponse(429, { error: "rate_limited" });
+    }
+    if (url.endsWith("/api/products/acme-inc/topics")) {
+      return createJsonResponse(429, { error: "rate_limited" });
+    }
+
+    return createJsonResponse(500, { error: `Unexpected URL: ${url}` });
+  });
+
+  beforeEach(() => {
+    fetchMock.mockClear();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders limit reached UI when product is missing", async () => {
+    render(<CompanyPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", {
+          name: "Acme Inc",
+        }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Usage Limit Reached")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", {
+        name: "Product Not Found",
+      }),
+    ).not.toBeInTheDocument();
+
+    const pipelineFetchCalled = fetchMock.mock.calls.some(([input]) =>
+      getRequestUrl(input).includes("/api/pipeline/"),
+    );
+    expect(pipelineFetchCalled).toBe(false);
+  });
+});

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -46,6 +46,8 @@ import type {
   ProductTopicReport,
 } from "@/types";
 
+import { deriveProductPageOverviewState } from "./product-page-fetch-state";
+
 function derivePipelineUrl(product: Product): string | null {
   const fromWebsite = product.website?.trim();
   if (fromWebsite) return fromWebsite;
@@ -100,7 +102,7 @@ export default function CompanyPage({
   const [loading, setLoading] = useState(!initialProduct || !initialOverview);
   const [documentsLoading, setDocumentsLoading] = useState(false);
   const [indexationMode, setIndexationMode] = useState<
-    "ready" | "indexing" | "unknown"
+    "ready" | "indexing" | "limit_reached" | "unknown"
   >(initialOverview ? "ready" : "unknown");
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [failedJob, setFailedJob] = useState<FailedCrawlJob | null>(null);
@@ -158,15 +160,31 @@ export default function CompanyPage({
         setDocuments(docsJson);
         setDocumentsLoading(false);
 
+        const overviewState = deriveProductPageOverviewState({
+          overviewOk: overviewRes.ok,
+          overviewStatus: overviewRes.status,
+          explainerStatus: explainerRes.status,
+          topicsStatus: topicsRes.status,
+        });
+
         // Overview was fetched in parallel — use the result immediately.
-        if (overviewRes.ok) {
+        if (overviewState === "ready") {
           setData((await overviewRes.json()) as ProductOverview);
           setIndexationMode("ready");
           return;
         }
 
-        if (overviewRes.status === 401) {
+        if (overviewState === "unauthorized") {
           setIndexationMode("ready");
+          return;
+        }
+
+        if (overviewState === "limit_reached") {
+          setData(null);
+          setActiveJobId(null);
+          setFailedJob(null);
+          setEmptyJob(null);
+          setIndexationMode("limit_reached");
           return;
         }
 
@@ -324,6 +342,61 @@ export default function CompanyPage({
   }
 
   if (!data) {
+    if (product && indexationMode === "limit_reached") {
+      return (
+        <div className="space-y-6">
+          <div className="border-b border-border pb-8">
+            <h1 className="text-4xl md:text-5xl font-display font-medium tracking-tight text-foreground">
+              {product.name}
+            </h1>
+            <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-relaxed">
+              You have reached your current plan&apos;s analysis limit for
+              product reports.
+            </p>
+          </div>
+
+          <div className="border border-border bg-background">
+            <div className="p-6 border-b border-border bg-muted/5">
+              <div className="flex items-center gap-3">
+                <ShieldBan
+                  className="h-5 w-5 text-amber-600"
+                  strokeWidth={1.5}
+                />
+                <h3 className="text-[10px] uppercase tracking-[0.2em] font-medium text-foreground">
+                  Usage Limit Reached
+                </h3>
+              </div>
+            </div>
+            <div className="p-6 space-y-4">
+              <h2 className="text-xl font-display font-medium text-foreground">
+                Upgrade to continue this analysis
+              </h2>
+              <p className="text-sm text-muted-foreground leading-relaxed max-w-2xl">
+                This report is unavailable right now because your monthly quota
+                is exhausted. Upgrade your plan for more analyses, or return
+                after your quota resets.
+              </p>
+              <div className="pt-2 flex flex-col sm:flex-row gap-3">
+                <Link href="/pricing">
+                  <Button className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold">
+                    View plans
+                  </Button>
+                </Link>
+                <Link href="/settings">
+                  <Button
+                    variant="outline"
+                    className="h-11 px-6 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+                  >
+                    Check my limits
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     // If product exists but indexation isn't ready, show the indexation message + email capture
     if (product && indexationMode === "indexing") {
       // Terminal outcomes that must NOT retrigger the pipeline:

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -67,6 +67,28 @@ function derivePipelineUrl(product: Product): string | null {
   return null;
 }
 
+function deriveLimitReachedDisplayName(
+  productName: string | null | undefined,
+  productSlug: string,
+): string {
+  const normalizedName = productName?.trim();
+  if (normalizedName) return normalizedName;
+
+  const normalizedSlug = productSlug
+    .trim()
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ");
+
+  if (!normalizedSlug) {
+    return "this company";
+  }
+
+  return normalizedSlug
+    .split(" ")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
 interface CompanyPageProps {
   initialProduct?: Product | null;
   initialData?: ProductOverview | null;
@@ -144,14 +166,16 @@ export default function CompanyPage({
           setTopics((await topicsRes.json()) as ProductTopicReport);
         }
 
-        if (!prodRes.ok) {
-          setProduct(null);
-          setData(null);
-          setDocumentsLoading(false);
-          setIndexationMode("ready"); // render not-found
-          return;
-        }
-        const prodJson = (await prodRes.json()) as Product;
+        const overviewState = deriveProductPageOverviewState({
+          overviewOk: overviewRes.ok,
+          overviewStatus: overviewRes.status,
+          explainerStatus: explainerRes.status,
+          topicsStatus: topicsRes.status,
+        });
+
+        const prodJson = prodRes.ok
+          ? ((await prodRes.json()) as Product)
+          : null;
         setProduct(prodJson);
 
         const docsJson = docsRes.ok
@@ -160,12 +184,20 @@ export default function CompanyPage({
         setDocuments(docsJson);
         setDocumentsLoading(false);
 
-        const overviewState = deriveProductPageOverviewState({
-          overviewOk: overviewRes.ok,
-          overviewStatus: overviewRes.status,
-          explainerStatus: explainerRes.status,
-          topicsStatus: topicsRes.status,
-        });
+        if (overviewState === "limit_reached") {
+          setData(null);
+          setActiveJobId(null);
+          setFailedJob(null);
+          setEmptyJob(null);
+          setIndexationMode("limit_reached");
+          return;
+        }
+
+        if (!prodJson) {
+          setData(null);
+          setIndexationMode("ready"); // render not-found
+          return;
+        }
 
         // Overview was fetched in parallel — use the result immediately.
         if (overviewState === "ready") {
@@ -176,15 +208,6 @@ export default function CompanyPage({
 
         if (overviewState === "unauthorized") {
           setIndexationMode("ready");
-          return;
-        }
-
-        if (overviewState === "limit_reached") {
-          setData(null);
-          setActiveJobId(null);
-          setFailedJob(null);
-          setEmptyJob(null);
-          setIndexationMode("limit_reached");
           return;
         }
 
@@ -341,13 +364,18 @@ export default function CompanyPage({
     );
   }
 
+  const limitReachedDisplayName = deriveLimitReachedDisplayName(
+    product?.name,
+    slug,
+  );
+
   if (!data) {
-    if (product && indexationMode === "limit_reached") {
+    if (indexationMode === "limit_reached") {
       return (
         <div className="space-y-6">
           <div className="border-b border-border pb-8">
             <h1 className="text-4xl md:text-5xl font-display font-medium tracking-tight text-foreground">
-              {product.name}
+              {limitReachedDisplayName}
             </h1>
             <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-relaxed">
               You have reached your current plan&apos;s analysis limit for

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.test.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveProductPageOverviewState } from "./product-page-fetch-state";
+
+describe("deriveProductPageOverviewState", () => {
+  it("returns ready when overview request succeeds", () => {
+    const result = deriveProductPageOverviewState({
+      overviewOk: true,
+      overviewStatus: 200,
+      explainerStatus: 429,
+      topicsStatus: 429,
+    });
+
+    expect(result).toBe("ready");
+  });
+
+  it("returns unauthorized when overview returns 401", () => {
+    const result = deriveProductPageOverviewState({
+      overviewOk: false,
+      overviewStatus: 401,
+      explainerStatus: 200,
+      topicsStatus: 200,
+    });
+
+    expect(result).toBe("unauthorized");
+  });
+
+  it("returns limit_reached when overview returns 429", () => {
+    const result = deriveProductPageOverviewState({
+      overviewOk: false,
+      overviewStatus: 429,
+      explainerStatus: 200,
+      topicsStatus: 200,
+    });
+
+    expect(result).toBe("limit_reached");
+  });
+
+  it("returns limit_reached when explainer or topics return 429", () => {
+    const result = deriveProductPageOverviewState({
+      overviewOk: false,
+      overviewStatus: 503,
+      explainerStatus: 429,
+      topicsStatus: 200,
+    });
+
+    expect(result).toBe("limit_reached");
+  });
+
+  it("returns indexing for non-limit overview misses like 425", () => {
+    const result = deriveProductPageOverviewState({
+      overviewOk: false,
+      overviewStatus: 425,
+      explainerStatus: 425,
+      topicsStatus: 425,
+    });
+
+    expect(result).toBe("indexing");
+  });
+});

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.ts
@@ -1,0 +1,42 @@
+export type ProductPageOverviewState =
+  | "ready"
+  | "unauthorized"
+  | "limit_reached"
+  | "indexing";
+
+interface ProductPageOverviewStateInput {
+  overviewOk: boolean;
+  overviewStatus: number;
+  explainerStatus: number;
+  topicsStatus: number;
+}
+
+const USAGE_LIMIT_HTTP_STATUS = 429;
+const OVERVIEW_UNAUTHORIZED_HTTP_STATUS = 401;
+
+export function deriveProductPageOverviewState({
+  overviewOk,
+  overviewStatus,
+  explainerStatus,
+  topicsStatus,
+}: ProductPageOverviewStateInput): ProductPageOverviewState {
+  if (overviewOk) {
+    return "ready";
+  }
+
+  if (overviewStatus === OVERVIEW_UNAUTHORIZED_HTTP_STATUS) {
+    return "unauthorized";
+  }
+
+  const hasUsageLimitResponse = [
+    overviewStatus,
+    explainerStatus,
+    topicsStatus,
+  ].some((status) => status === USAGE_LIMIT_HTTP_STATUS);
+
+  if (hasUsageLimitResponse) {
+    return "limit_reached";
+  }
+
+  return "indexing";
+}


### PR DESCRIPTION
## Summary
- add a dedicated product-page fetch-state helper that classifies overview/explainer/topics responses and surfaces `limit_reached` on HTTP 429
- update the product page client to branch on derived fetch state and render a clear upgrade/limits CTA when quota is exhausted
- add focused unit tests for the fetch-state helper to lock expected behavior for ready, indexing, unauthorized, and limit-reached paths

## Test plan
- [x] `bun run test -- \"app/(dashboard)/products/[slug]/product-page-fetch-state.test.ts\"`
- [x] `bunx eslint \"app/(dashboard)/products/[slug]/product-page-client.tsx\" \"app/(dashboard)/products/[slug]/product-page-fetch-state.ts\" \"app/(dashboard)/products/[slug]/product-page-fetch-state.test.ts\"`
- [x] `bun run type-check`