### PR TITLE
feat(ci): add Jazz AI code review workflow

### DIFF
--- a/.github/jazz/agents/ci-reviewer.json
+++ b/.github/jazz/agents/ci-reviewer.json
@@ -1,0 +1,24 @@
+{
+  "id": "ci-reviewer",
+  "name": "ci-reviewer",
+  "description": "CI code review agent for Clausea AI — Python/TypeScript full-stack policy intelligence platform",
+  "model": "openrouter/owl-alpha",
+  "config": {
+    "persona": "coder",
+    "llmProvider": "openrouter",
+    "llmModel": "openrouter/owl-alpha",
+    "reasoningEffort": "high",
+    "tools": [
+      "context_info",
+      "find",
+      "git_diff",
+      "git_log",
+      "grep",
+      "http_request",
+      "ls",
+      "read_file",
+      "summarize_context",
+      "write_file"
+    ]
+  }
+}

--- a/.github/jazz/workflows/code-review/WORKFLOW.md
+++ b/.github/jazz/workflows/code-review/WORKFLOW.md
@@ -1,0 +1,189 @@
+---
+name: code-review
+description: Review pull request changes for quality, security, and correctness
+autoApprove: true
+agent: ci-reviewer
+maxIterations: 100
+---
+
+# Pull Request Code Review
+
+You are the final quality gate for Clausea AI pull requests.
+
+Your job is to find real issues before merge: behavior regressions, correctness bugs, security risks, poor error handling, and design choices that will break maintainability. Do not describe the PR. Review it.
+
+## Core Principles
+
+1. **Intent first** Understand what the change is trying to achieve before judging implementation details.
+2. **Behavior** Prioritize what can break users in real execution.
+3. **Signal over volume.** A short accurate review is better than many weak comments.
+4. **Evidence required.** Every finding must name a concrete failure mode on concrete diff lines.
+5. **Empty is valid.** Return `[]` when the diff is sound.
+
+Only emit a comment when you are confident the issue is real after reading code in context.
+
+## Context
+
+- Repository path: `__WORKSPACE__`
+- Diff range: `__PR_BASE_SHA__...__PR_HEAD_SHA__`
+- PR metadata snapshot: `/tmp/jazz-pr-context.json`
+
+The PR snapshot may include `title`, `body`, labels, top-level comments, review summaries, and prior inline review comments.
+
+If `/tmp/jazz-pr-context.json` is missing or contains `{"error": ...}`, continue without it. Do not block review execution.
+
+When using `read_file`, `ls`, `find`, or `grep`, always use paths under `__WORKSPACE__/...`.
+
+## Clausea AI Stack Reality (must guide your review)
+
+Clausea AI is a policy document intelligence platform. It analyzes privacy policies, terms of service, and other legal documents using LLMs.
+
+Review with this stack and domain in mind:
+
+- **Backend** (`packages/backend/`): Python 3.11+, FastAPI, MongoDB (motor async driver), LiteLLM (multi-LLM provider abstraction), pdfplumber, python-docx, structlog.
+- **Frontend** (`packages/frontend/`): TypeScript 6.x, Next.js 16, React 19, Tailwind CSS v4, GSAP, Clerk (auth), PostHog (analytics).
+- **Extension** (`packages/extension/`): TypeScript, React 18, WXT, Tailwind CSS v3 (Chrome + Firefox).
+- **Async everywhere**: backend uses async/await everywhere via FastAPI/motor; flag blocking synchronous calls in async paths.
+- **LLM interaction**: LiteLLM wraps calls to GPT-4, Claude, etc. Review prompt construction, input sanitization, and output parsing carefully — prompt injection is a real threat.
+- **Document processing**: PDFs, DOCX, HTML. Review for memory/processing overhead with large documents.
+- **MongoDB queries**: watch for unindexed queries, missing error handling, or N+1 patterns.
+
+## Mandatory Review Flow
+
+1. **Load intent and prior discussion**
+   - Read `/tmp/jazz-pr-context.json` when available.
+   - Extract intended product behavior and already-reported issues.
+
+2. **Load full change scope**
+   - `git_diff` with `nameOnly: true` to get all changed files.
+   - Read diff content for all files (batched if large).
+
+3. **Read beyond hunks when needed**
+   - Open surrounding code for touched modules.
+   - Verify contracts at call sites and boundary interfaces.
+
+4. **Run intent-vs-behavior check**
+   - Does implementation match intended behavior?
+   - Are normal paths and failure paths both coherent?
+   - Could this degrade Clausea's document analysis quality or UX in real usage?
+
+5. **Run engineering quality check by area**
+
+   **Python (backend):**
+   - Type annotations: all public functions should have proper types; flag missing return types on route handlers.
+   - Async hygiene: never call synchronous I/O (requests, file reads) in async endpoints without a thread pool.
+   - Error handling: FastAPI exception handlers, structured error responses (not raw 500s).
+   - Security: input validation on uploaded documents, path traversal in file operations, prompt injection in LLM calls.
+   - Performance: large document handling (streaming vs full load), MongoDB query efficiency.
+
+   **TypeScript/React (frontend + extension):**
+   - TypeScript: strict mode, no `any`, proper discriminated unions for state.
+   - React 19 / Next.js 16: server components vs client components, proper `use client` directives, hook rules.
+   - Async: proper error boundaries, loading states, stale-while-revalidate patterns.
+   - Performance: bundle size awareness, memoization where justified, lazy loading.
+   - Security: no secret exposure in client code, XSS prevention in document rendering.
+
+6. **De-duplicate and calibrate**
+   - Do not repeat issues already clearly raised in human review comments unless unresolved and still critical.
+   - Drop speculative concerns without a concrete reachable failure mode.
+
+7. **Emit final output in required format**
+   - Exactly two fenced blocks in the required order (see Output Format).
+
+### Large PR Handling
+
+If the PR is large (10+ files or 500+ changed lines), use subagents to review file batches in parallel, then merge findings into one final output.
+
+## What Good Findings Look Like
+
+A valid finding includes:
+
+- exact file and line(s) in the diff
+- what fails (specific runtime behavior)
+- why it fails (root cause)
+- concrete fix direction (or patch snippet when obvious)
+
+A valid finding does **not** sound like:
+
+- "this might be unsafe" without a realistic exploit path
+- "consider using X pattern" without showing current behavior is deficient
+- generic style preferences or formatting notes
+
+## Output Format (strict)
+
+Your output must contain **exactly two** fenced blocks, in this order:
+
+1. Four-backtick `markdown` block: non-empty review verdict
+2. Four-backtick `json` block: array of inline comments (`[]` allowed)
+
+No text before, between, or after those blocks.
+
+### Block 1: Markdown verdict (required, non-empty)
+
+This is a review verdict, not a PR summary.
+
+Must include:
+
+- files reviewed (count or short list)
+- what you found (or a clear "looks sound" verdict with reasons)
+- what you checked to reach that conclusion
+
+### Block 2: JSON inline comments (required, may be empty)
+
+Array of objects:
+
+- `path`: repo-relative file path in diff
+- `line`: target line from diff
+- `start_line`: optional for ranges
+- `side`: `RIGHT` for added/modified, `LEFT` for deleted
+- `body`: markdown with severity, explanation, and fix guidance
+
+Use `[]` when there are no inline issues.
+
+Outer fences must use four backticks to avoid collisions with triple-backtick snippets inside `body`.
+
+### Example (issues found)
+
+```markdown
+Reviewed 4 files. Found 2 concrete issues: one behavior regression in document parsing error recovery and one unsafe user-input path in prompt construction.
+```
+
+````json
+[
+  {
+    "path": "packages/backend/src/services/document_service.py",
+    "line": 42,
+    "side": "RIGHT",
+    "body": "**Critical**: This can throw when `document` is None in the retry path.\n\nSuggested fix:\n```python\nif not document:\n    raise DocumentNotFoundError()\n```"
+  }
+]
+````
+
+### Example (no issues)
+
+```markdown
+Reviewed 6 files. The diff is behaviorally consistent with the stated intent, keeps error channels explicit, and preserves document analysis quality. I checked changed call sites, boundary validation points, and edge-path cleanup. No concrete correctness or security issues found.
+```
+
+```json
+[]
+```
+
+## Self-check Before Emitting
+
+1. Did you prioritize intent and behavior, not feature description?
+2. Did every comment include concrete lines and a concrete failure mode?
+3. Did you remove speculative or duplicate comments?
+4. Did you emit exactly two blocks in order: `markdown`, then `json`?
+5. Did both outer blocks use four backticks?
+6. Did you avoid any trailing output after the JSON block?
+
+## Inline Comment Line Accuracy (critical)
+
+GitHub rejects comments on lines not present in diff hunks.
+
+Before outputting each comment:
+
+1. Confirm `line` exists in the diff hunk.
+2. Prefer commenting on changed (`+`) lines when possible.
+3. If relevant code is outside hunks, attach to the nearest valid line in the hunk and explain context in `body`.

--- a/.github/workflows/jazz-review.yml
+++ b/.github/workflows/jazz-review.yml
@@ -1,0 +1,428 @@
+name: Jazz Code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  push:
+    paths:
+      - ".github/workflows/jazz-review.yml"
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: "PR number (required when run from Actions tab)"
+        required: true
+        type: number
+      request:
+        description: "Additional request for the review"
+        required: false
+        type: string
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      base_sha: ${{ steps.resolve.outputs.base_sha }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      pr_head_repo_full_name: ${{ steps.resolve.outputs.pr_head_repo_full_name }}
+      request: ${{ steps.resolve.outputs.request }}
+    steps:
+      - name: Resolve PR context
+        id: resolve
+        uses: actions/github-script@v7
+        with:
+          script: |
+            function extractRequest(body) {
+              if (!body) return '';
+              const trimmed = body.trim();
+              const match = trimmed.match(/^\/jazz(?!-review)(?:\s*[:,-])?\s*([\s\S]*)/i);
+              return match?.[1]?.trim() ?? '';
+            }
+
+            let prNumber, baseSha, headSha, prHeadRepoFullName;
+            let request = '';
+
+            if (context.payload.pull_request) {
+              const pr = context.payload.pull_request;
+              prNumber = pr.number;
+              baseSha = pr.base.sha;
+              headSha = pr.head.sha;
+              prHeadRepoFullName = pr.head.repo.full_name;
+            } else if (context.eventName === 'workflow_dispatch') {
+              prNumber = Number(context.payload.inputs.pull_request_number);
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              baseSha = pr.base.sha;
+              headSha = pr.head.sha;
+              prHeadRepoFullName = pr.head.repo.full_name;
+              request = String(context.payload.inputs.request ?? '').trim();
+            } else if (context.eventName === 'push') {
+              const ref = context.payload.ref ?? '';
+              const branch = ref.replace(/^refs\/heads\//, '');
+              const defaultBranch = context.payload.repository?.default_branch;
+              if (!branch || branch === defaultBranch) {
+                core.notice(`Push to ${branch || '(no branch)'}; no PR context, skipping jazz jobs.`);
+                core.setOutput('pr_number', '');
+                core.setOutput('base_sha', '');
+                core.setOutput('head_sha', context.payload.after ?? '');
+                core.setOutput('pr_head_repo_full_name', '');
+                core.setOutput('request', '');
+                return;
+              }
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${branch}`,
+                state: 'open',
+              });
+              const pr = prs[0];
+              if (!pr) {
+                core.notice(`No open PR for branch ${branch}; skipping jazz jobs.`);
+                core.setOutput('pr_number', '');
+                core.setOutput('base_sha', '');
+                core.setOutput('head_sha', context.payload.after ?? '');
+                core.setOutput('pr_head_repo_full_name', '');
+                core.setOutput('request', '');
+                return;
+              }
+              prNumber = pr.number;
+              baseSha = pr.base.sha;
+              headSha = context.payload.after ?? pr.head.sha;
+              prHeadRepoFullName = pr.head.repo.full_name;
+            } else {
+              const issueNumber = context.payload.issue?.number;
+              if (!issueNumber) {
+                throw new Error('issue_comment event missing issue number');
+              }
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: issueNumber,
+              });
+              prNumber = pr.number;
+              baseSha = pr.base.sha;
+              headSha = pr.head.sha;
+              prHeadRepoFullName = pr.head.repo.full_name;
+              request = extractRequest(context.payload.comment?.body);
+            }
+
+            if (!request) {
+              request = 'Review this pull request and call out anything important.';
+            }
+
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('base_sha', baseSha);
+            core.setOutput('head_sha', headSha);
+            core.setOutput('pr_head_repo_full_name', prHeadRepoFullName);
+            core.setOutput('request', request);
+
+      - name: React with eyes on triggering comment
+        if: |
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request != null &&
+          contains(github.event.comment.body, '/jazz') && (
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          ) &&
+          steps.resolve.outputs.pr_head_repo_full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commentId = context.payload.comment?.id;
+            if (!commentId) {
+              core.warning('issue_comment event missing comment id; skipping reaction');
+              return;
+            }
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                content: 'eyes',
+              });
+            } catch (e) {
+              if (e.status === 422) {
+                core.info('Reaction already present; continuing');
+                return;
+              }
+              if (e.status === 403) {
+                core.warning(`Could not react with eyes (403): ${e.message}`);
+                return;
+              }
+              core.warning(`Could not react with eyes: ${e.message}`);
+            }
+
+  code-review:
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' && needs.resolve.outputs.pr_head_repo_full_name == github.repository) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '/jazz-review') && (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      ) && needs.resolve.outputs.pr_head_repo_full_name == github.repository) ||
+      (github.event_name == 'push' && needs.resolve.outputs.pr_number != '' && needs.resolve.outputs.pr_head_repo_full_name == github.repository)
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Jazz
+        run: npm install -g jazz-ai
+
+      - name: Setup Jazz agent and workflow
+        env:
+          PR_BASE_SHA: ${{ needs.resolve.outputs.base_sha }}
+          PR_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          mkdir -p "$HOME/.jazz/agents" workflows/code-review
+          cp .github/jazz/agents/ci-reviewer.json "$HOME/.jazz/agents/"
+          sed -e "s/__PR_BASE_SHA__/$PR_BASE_SHA/g" -e "s/__PR_HEAD_SHA__/$PR_HEAD_SHA/g" -e "s|__WORKSPACE__|$WORKSPACE|g" \
+            .github/jazz/workflows/code-review/WORKFLOW.md > workflows/code-review/WORKFLOW.md
+
+      - name: Snapshot PR context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          OUT=/tmp/jazz-pr-context.json
+          if gh pr view "$PR_NUMBER" --repo "$REPO" \
+               --json title,body,labels,comments,reviews \
+               > /tmp/pr-base.json \
+             && gh api "repos/$REPO/pulls/$PR_NUMBER/comments?per_page=100" \
+                  > /tmp/pr-review-comments.json; then
+            jq -s '.[0] + {reviewComments: .[1]}' \
+              /tmp/pr-base.json /tmp/pr-review-comments.json > "$OUT"
+          else
+            echo '{"error":"Failed to fetch PR context; agent will proceed without it."}' > "$OUT"
+          fi
+
+      - name: Run code review
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          CI: "true"
+          JAZZ_DISABLE_CATCH_UP: "1"
+        run: |
+          jazz --output raw workflow run code-review --auto-approve --agent ci-reviewer \
+            | tee /tmp/jazz-review.txt
+
+      - name: Post review comments
+        if: always()
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('/tmp/jazz-review.txt', 'utf8');
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const headSha = process.env.PR_HEAD_SHA;
+
+            let modelLabel = '';
+            try {
+              const agent = JSON.parse(fs.readFileSync('.github/jazz/agents/ci-reviewer.json', 'utf8'));
+              if (agent.model) modelLabel = `\n\n*Model: ${agent.model}*`;
+            } catch (_) {}
+
+            const extractFencedMarkdown = (text) => {
+              const fourFence = text.match(/````markdown\s*\n([\s\S]*?)\n?````/);
+              if (fourFence) return fourFence[1].trim();
+              const threeFence = text.match(/```markdown\s*\n([\s\S]*?)\n?```/);
+              if (threeFence) return threeFence[1].trim();
+              return null;
+            };
+
+            const extractFencedJson = (text) => {
+              const fourFence = text.match(/````json\s*\n([\s\S]*?)\n?````/);
+              if (fourFence) return fourFence[1].trim();
+              const open = text.lastIndexOf('```json');
+              if (open < 0) return null;
+              const after = text.slice(open + '```json'.length);
+              const close = after.lastIndexOf('```');
+              if (close < 0) return null;
+              return after.slice(0, close).trim();
+            };
+
+            const markdownSummary = extractFencedMarkdown(output);
+
+            let comments = [];
+            const jsonText = extractFencedJson(output);
+            if (jsonText) {
+              try {
+                comments = JSON.parse(jsonText);
+              } catch (e) {
+                console.log('Failed to parse JSON:', e.message);
+              }
+            }
+
+            const summarySection = markdownSummary
+              || (Array.isArray(comments) && comments.length > 0
+                ? `Found ${comments.length} issue(s). See inline comments below.`
+                : 'No issues found.');
+
+            if (!Array.isArray(comments) || comments.length === 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `## Jazz Code Review\n\n${summarySection}${modelLabel}`,
+              });
+              return;
+            }
+
+            const sanitized = comments.map(c => {
+              const copy = { ...c };
+              const validStartLine =
+                Number.isInteger(copy.start_line) &&
+                copy.start_line > 0 &&
+                copy.start_line < copy.line;
+              if (!validStartLine) delete copy.start_line;
+              return copy;
+            });
+            const validComments = sanitized.filter(c =>
+              c.path && c.line > 0 && !c.path.startsWith('/') && c.path !== 'NO_DIFF'
+            );
+
+            const invalidComments = sanitized.filter(c => !validComments.includes(c));
+            let reviewBody = `## Jazz Code Review\n\n${summarySection}${modelLabel}`;
+            if (invalidComments.length > 0) {
+              reviewBody += '\n\n### General Comments\n\n';
+              reviewBody += invalidComments.map(c => `- ${c.body}`).join('\n');
+            }
+
+            if (validComments.length > 0) {
+              const { data: prFiles } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              const deletedPaths = new Set(
+                prFiles.filter((f) => f.status === 'removed').map((f) => f.filename)
+              );
+
+              const diffLines = new Map();
+              for (const file of prFiles) {
+                if (!file.patch) continue;
+                const left = new Set();
+                const right = new Set();
+                const lines = file.patch.split('\n');
+                let oldLine = 0;
+                let newLine = 0;
+                for (const line of lines) {
+                  const hunkMatch = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+                  if (hunkMatch) {
+                    oldLine = parseInt(hunkMatch[1], 10);
+                    newLine = parseInt(hunkMatch[2], 10);
+                    continue;
+                  }
+                  if (line.startsWith('\\ ')) continue;
+                  if (line.startsWith('-')) {
+                    left.add(oldLine);
+                    oldLine++;
+                  } else if (line.startsWith('+')) {
+                    right.add(newLine);
+                    newLine++;
+                  } else {
+                    left.add(oldLine);
+                    right.add(newLine);
+                    oldLine++;
+                    newLine++;
+                  }
+                }
+                diffLines.set(file.filename, { left, right });
+              }
+
+              const isLineInDiff = (c) => {
+                const fileDiff = diffLines.get(c.path);
+                if (!fileDiff) return false;
+                const side = deletedPaths.has(c.path) ? 'LEFT' : (c.side || 'RIGHT');
+                const validSet = side === 'LEFT' ? fileDiff.left : fileDiff.right;
+                if (!validSet.has(c.line)) return false;
+                const hasStartLine =
+                  Number.isInteger(c.start_line) && c.start_line > 0 && c.start_line < c.line;
+                if (hasStartLine && !validSet.has(c.start_line)) return false;
+                return true;
+              };
+
+              const inlineComments = validComments.filter(isLineInDiff);
+              const unresolvedComments = validComments.filter(c => !isLineInDiff(c));
+
+              if (unresolvedComments.length > 0) {
+                reviewBody += '\n\n### Comments on lines outside the diff\n\n';
+                reviewBody += unresolvedComments.map(c => `- **${c.path}:${c.line}** — ${c.body}`).join('\n');
+              }
+
+              const mapComment = (c) => {
+                const isDeleted = deletedPaths.has(c.path);
+                const side = isDeleted ? 'LEFT' : (c.side || 'RIGHT');
+                const hasValidRange =
+                  Number.isInteger(c.start_line) &&
+                  Number.isInteger(c.line) &&
+                  c.start_line > 0 &&
+                  c.start_line < c.line;
+                return {
+                  path: c.path,
+                  line: c.line,
+                  ...(hasValidRange && {
+                    start_line: c.start_line,
+                    start_side: side
+                  }),
+                  side,
+                  body: c.body
+                };
+              };
+
+              if (inlineComments.length > 0) {
+                await github.rest.pulls.createReview({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  commit_id: headSha,
+                  event: 'COMMENT',
+                  body: reviewBody,
+                  comments: inlineComments.map(mapComment)
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: reviewBody
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: reviewBody
+              });
+            }


### PR DESCRIPTION
## What this PR does

Adds automated AI code review for pull requests using Jazz (`jazz-ai`), the same workflow used by the `github/lvndry/jazz` project. Every non-draft PR gets reviewed by a Jazz agent that posts inline comments on issues.

## How it works

- **Trigger**: PR opened/ready/sync, `/jazz-review` comment (collaborators+), or manual dispatch
- The workflow resolves PR metadata, checks out the head, installs `jazz-ai`, and runs a code review agent against the diff
- The agent reviews for correctness, security, performance, and best practices — tailored to Clausea's stack (Python/FastAPI/MongoDB + TypeScript/Next.js)
- Inline review comments are posted directly on the PR with file:line references

## Files added

| File | Purpose |
|---|---|
| `.github/workflows/jazz-review.yml` | GitHub Actions workflow (resolve + code-review jobs) |
| `.github/jazz/agents/ci-reviewer.json` | Jazz agent config (`openrouter/owl-alpha`) |
| `.github/jazz/workflows/code-review/WORKFLOW.md` | Review rubric and output contract (Clausea-tailored) |

## How to test

1. Open a PR against `main` — the workflow runs automatically and posts a review comment
2. Comment `/jazz-review` on a PR to trigger a re-review
3. Verify that inline comments reference valid diff lines (hunk-aware validation in the posting step)
