### PR TITLE
fix(crawler): browser zombie/memory-leak hardening

### DIFF
--- a/packages/backend/src/crawler/browser.py
+++ b/packages/backend/src/crawler/browser.py
@@ -34,6 +34,7 @@ from playwright.async_api import Browser, BrowserContext, Page, Route
 
 from src.core.logging import get_logger
 from src.crawler.constants import _BLOCKED_ASSETS_RE, BROWSER_LAUNCH_TIMEOUT_S
+from src.utils.perf import _log_browser_processes, _log_top_processes
 
 logger = get_logger(__name__, component="crawler:browser")
 
@@ -143,6 +144,8 @@ async def cleanup_browser() -> None:
                 _shared_browser_contexts.pop(loop, None)
 
             if graceful_close_failed:
+                _log_top_processes(logger)
+                _log_browser_processes(logger)
                 try:
                     result = subprocess.run(
                         ["pkill", "-TERM", "-f", "firefox"],

--- a/packages/backend/src/crawler/browser.py
+++ b/packages/backend/src/crawler/browser.py
@@ -144,8 +144,8 @@ async def cleanup_browser() -> None:
                 _shared_browser_contexts.pop(loop, None)
 
             if graceful_close_failed:
-                _log_top_processes(logger)
-                _log_browser_processes(logger)
+                await _log_top_processes(logger)
+                await _log_browser_processes(logger)
                 try:
                     result = subprocess.run(
                         ["pkill", "-TERM", "-f", "firefox"],

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -87,6 +87,7 @@ from src.crawler.models import CrawlResult, CrawlStats, PageContent, StaticFetch
 from src.crawler.rate_limiter import DomainRateLimiter
 from src.crawler.robots import RobotsTxtChecker
 from src.crawler.url_scorer import URLScorer
+from src.utils.perf import _log_browser_processes, _log_top_processes
 
 logger = get_logger(__name__, component="crawler")
 
@@ -807,6 +808,8 @@ class ClauseaCrawler:
         except Exception as e:
             error_str = str(e).lower()
             if any(marker in error_str for marker in self._BROWSER_CRASH_MARKERS):
+                _log_top_processes(logger)
+                _log_browser_processes(logger)
                 await self._cleanup_browser()
             else:
                 logger.warning(f"Browser fetch failed for {url}: {e}", exc_info=True)

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -744,6 +744,7 @@ class ClauseaCrawler:
             return None
 
         page = None
+        _browser_cleaned_up = False
         try:
             page = await context.new_page()
             await page.set_extra_http_headers({"Accept-Encoding": "gzip, deflate"})
@@ -808,14 +809,15 @@ class ClauseaCrawler:
         except Exception as e:
             error_str = str(e).lower()
             if any(marker in error_str for marker in self._BROWSER_CRASH_MARKERS):
-                _log_top_processes(logger)
-                _log_browser_processes(logger)
+                await _log_top_processes(logger)
+                await _log_browser_processes(logger)
+                _browser_cleaned_up = True
                 await self._cleanup_browser()
             else:
                 logger.warning(f"Browser fetch failed for {url}: {e}", exc_info=True)
             return None
         finally:
-            if page is not None:
+            if page is not None and not _browser_cleaned_up:
                 try:
                     await asyncio.wait_for(page.close(), timeout=10.0)
                 except Exception:

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -742,10 +742,10 @@ class ClauseaCrawler:
             logger.warning("Browser setup failed for %s: %s", url, e)
             return None
 
-        page = await context.new_page()
-        await page.set_extra_http_headers({"Accept-Encoding": "gzip, deflate"})
-
+        page = None
         try:
+            page = await context.new_page()
+            await page.set_extra_http_headers({"Accept-Encoding": "gzip, deflate"})
             await _block_heavy_assets(page)
 
             nav_timeout_ms = min(self.timeout * 1000, BROWSER_NAV_TIMEOUT_MS)
@@ -812,10 +812,15 @@ class ClauseaCrawler:
                 logger.warning(f"Browser fetch failed for {url}: {e}", exc_info=True)
             return None
         finally:
-            try:
-                await page.close()
-            except Exception:
-                pass
+            if page is not None:
+                try:
+                    await asyncio.wait_for(page.close(), timeout=10.0)
+                except Exception:
+                    logger.warning("page.close() failed or timed out; triggering browser cleanup")
+                    try:
+                        await self._cleanup_browser()
+                    except Exception:
+                        pass
 
     def _build_crawl_result(self, url: str, page: PageContent) -> CrawlResult:
         resolved_url = self._choose_effective_url(url, page.metadata)

--- a/packages/backend/src/utils/perf.py
+++ b/packages/backend/src/utils/perf.py
@@ -1,4 +1,5 @@
 import asyncio
+import resource
 from pathlib import Path
 
 import psutil
@@ -36,6 +37,28 @@ def _get_cgroup_memory_usage_bytes() -> int | None:
     return None
 
 
+def _get_proc_self_memory_bytes() -> int | None:
+    """Read process RSS from /proc/self/status (portable; works in Railway containers)."""
+    try:
+        for line in Path("/proc/self/status").read_text().splitlines():
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1]) * 1024  # kB → bytes
+    except Exception:
+        pass
+    return None
+
+
+def _get_rlimit_memory_bytes() -> int | None:
+    """Return RLIMIT_AS soft limit as a proxy for the container memory ceiling."""
+    try:
+        soft, _ = resource.getrlimit(resource.RLIMIT_AS)
+        if soft != resource.RLIM_INFINITY and soft > 0:
+            return soft
+    except Exception:
+        pass
+    return None
+
+
 def get_memory_usage() -> dict[str, float]:
     """Get current memory usage statistics."""
     process = psutil.Process()
@@ -48,9 +71,18 @@ def get_memory_usage() -> dict[str, float]:
         system_used_percent = (cgroup_usage / cgroup_limit) * 100
         system_available_gb = (cgroup_limit - cgroup_usage) / 1024 / 1024 / 1024
     else:
-        system_memory = psutil.virtual_memory()
-        system_used_percent = system_memory.percent
-        system_available_gb = system_memory.available / 1024 / 1024 / 1024
+        # Fallback: per-process memory from /proc/self/status + RLIMIT_AS.
+        # These are always correct inside Railway containers where /sys/fs/cgroup
+        # is absent or read-only.
+        proc_rss = _get_proc_self_memory_bytes()
+        rlimit = _get_rlimit_memory_bytes()
+        if proc_rss is not None and rlimit is not None:
+            system_used_percent = (proc_rss / rlimit) * 100
+            system_available_gb = (rlimit - proc_rss) / 1024 / 1024 / 1024
+        else:
+            system_memory = psutil.virtual_memory()
+            system_used_percent = system_memory.percent
+            system_available_gb = system_memory.available / 1024 / 1024 / 1024
 
     return {
         "process_memory_mb": memory_info.rss / 1024 / 1024,

--- a/packages/backend/src/utils/perf.py
+++ b/packages/backend/src/utils/perf.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import resource
 from pathlib import Path
 
@@ -111,3 +112,54 @@ async def memory_monitor_task(interval: int = 30) -> None:
     while True:
         log_memory_usage("Periodic Check")
         await asyncio.sleep(interval)
+
+
+def _log_top_processes(log: logging.Logger, *, top_n: int = 10) -> None:
+    """Log top memory-consuming processes for diagnostics."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["ps", "aux", "--sort=-%mem"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            lines = result.stdout.strip().split("\n")
+            header = lines[0] if lines else ""
+            top_lines = lines[1 : top_n + 1] if len(lines) > 1 else []
+            log.warning(
+                "Process memory snapshot (top %d by %%MEM):\n%s\n%s",
+                top_n,
+                header,
+                "\n".join(top_lines),
+            )
+    except Exception as exc:
+        log.debug("Could not get process list: %s", exc)
+
+
+def _log_browser_processes(log: logging.Logger) -> None:
+    """Log specifically browser-related processes."""
+    import subprocess
+
+    try:
+        for name in [
+            "firefox",
+            "chromium",
+            "chrome",
+            "playwright",
+            "camoufox",
+            "geckodriver",
+            "chromedriver",
+        ]:
+            result = subprocess.run(
+                ["pgrep", "-a", "-f", name],
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                log.warning("Found '%s' processes:\n%s", name, result.stdout.strip()[:500])
+    except Exception as exc:
+        log.debug("Could not check browser processes: %s", exc)

--- a/packages/backend/src/utils/perf.py
+++ b/packages/backend/src/utils/perf.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import resource
 from pathlib import Path
 
 import psutil
@@ -52,10 +51,12 @@ def _get_proc_self_memory_bytes() -> int | None:
 def _get_rlimit_memory_bytes() -> int | None:
     """Return RLIMIT_AS soft limit as a proxy for the container memory ceiling."""
     try:
+        import resource  # noqa: PLC0415 (Unix-only; import guarded by try/except)
+
         soft, _ = resource.getrlimit(resource.RLIMIT_AS)
         if soft != resource.RLIM_INFINITY and soft > 0:
             return soft
-    except Exception:
+    except (ImportError, Exception):
         pass
     return None
 
@@ -114,19 +115,23 @@ async def memory_monitor_task(interval: int = 30) -> None:
         await asyncio.sleep(interval)
 
 
-def _log_top_processes(log: logging.Logger, *, top_n: int = 10) -> None:
+async def _log_top_processes(log: logging.Logger, *, top_n: int = 10) -> None:
     """Log top memory-consuming processes for diagnostics."""
-    import subprocess
-
     try:
-        result = subprocess.run(
-            ["ps", "aux", "--sort=-%mem"],
-            capture_output=True,
-            text=True,
-            timeout=5,
+        proc = await asyncio.create_subprocess_exec(
+            "ps",
+            "aux",
+            "--sort=-%mem",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
         )
-        if result.returncode == 0:
-            lines = result.stdout.strip().split("\n")
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+        except TimeoutError:
+            proc.kill()
+            return
+        if proc.returncode == 0:
+            lines = stdout.decode().strip().split("\n")
             header = lines[0] if lines else ""
             top_lines = lines[1 : top_n + 1] if len(lines) > 1 else []
             log.warning(
@@ -139,10 +144,8 @@ def _log_top_processes(log: logging.Logger, *, top_n: int = 10) -> None:
         log.debug("Could not get process list: %s", exc)
 
 
-def _log_browser_processes(log: logging.Logger) -> None:
+async def _log_browser_processes(log: logging.Logger) -> None:
     """Log specifically browser-related processes."""
-    import subprocess
-
     try:
         for name in [
             "firefox",
@@ -153,13 +156,23 @@ def _log_browser_processes(log: logging.Logger) -> None:
             "geckodriver",
             "chromedriver",
         ]:
-            result = subprocess.run(
-                ["pgrep", "-a", "-f", name],
-                capture_output=True,
-                text=True,
-                timeout=3,
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                log.warning("Found '%s' processes:\n%s", name, result.stdout.strip()[:500])
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "pgrep",
+                    "-a",
+                    "-f",
+                    name,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                try:
+                    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3)
+                except TimeoutError:
+                    proc.kill()
+                    continue
+                if proc.returncode == 0 and stdout.strip():
+                    log.warning("Found '%s' processes:\n%s", name, stdout.decode().strip()[:500])
+            except Exception as exc:
+                log.debug("Could not check browser processes: %s", exc)
     except Exception as exc:
         log.debug("Could not check browser processes: %s", exc)


### PR DESCRIPTION
## Summary

Fixes a cluster of related issues that cause Firefox/Playwright processes to linger as zombies in Railway containers, inflating memory usage and eventually crashing the crawler.

- **Force-kill zombie Firefox/Playwright processes** when graceful browser close fails: `page.close()` is now wrapped in `asyncio.wait_for(timeout=10.0)`; on timeout or connection-closed error a warning is logged and `_cleanup_browser()` is called, which already holds the `pkill -TERM/-KILL firefox` fallback in `browser.py`.
- **Fix page-creation crash not triggering cleanup**: `context.new_page()` and `set_extra_http_headers()` are moved inside the `try` block (with `page = None` guard before it) so a browser crash during page creation now correctly calls `_cleanup_browser()` instead of leaking the context.
- **Accurate per-process memory reporting in Railway containers**: adds `_get_proc_self_memory_bytes()` (reads `VmRSS` from `/proc/self/status`) and `_get_rlimit_memory_bytes()` (reads `RLIMIT_AS`) as portable fallbacks for when `/sys/fs/cgroup` is absent; `get_memory_usage()` prefers these over the misleading host-wide `psutil.virtual_memory()`.
- **Process snapshot diagnostic logging on every browser crash**: `_log_top_processes()` and `_log_browser_processes()` are called in both `cleanup_browser()` (when graceful close failed) and in the browser-crash handler in `client.py`, so every crash produces a named-process snapshot to identify exact zombie names.
- **`_update_step` status typed as `Literal`** instead of bare `str` for stricter type safety.

## Test plan

- [ ] Deploy to Railway staging and trigger a crawler run that hits a page likely to hang (large JS-heavy doc).
- [ ] Confirm logs show `page.close() failed or timed out; triggering browser cleanup` when Playwright hangs, followed by the `pkill` fallback.
- [ ] Confirm memory metrics in logs now reflect per-process RSS rather than host memory (look for `VmRSS`-sourced values).
- [ ] Confirm `_log_browser_processes` output appears in logs on any browser crash.
- [ ] `uv run ty check` and `uv run ruff check` pass with no new errors.