### PR TITLE
feat(frontend): Railway Docker deployment for Next.js

### DIFF
--- a/packages/frontend/.dockerignore
+++ b/packages/frontend/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.git
+.gitignore
+*.md
+.env
+.env.*
+!.env.example
+coverage
+.vscode
+.idea

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,13 +1,39 @@
+# Local development defaults. Copy to .env.local and fill in values.
+# For Railway production setup, see docs/RAILWAY.md
+
+# ── Backend API (server-side only) ───────────────────────────────────────────
+# Local: http://localhost:8000
+# Production (Railway backend public domain): https://api.clausea.co
 BACKEND_BASE_URL=http://localhost:8000
 
+# ── Clerk authentication ───────────────────────────────────────────────────────
+# Required. NEXT_PUBLIC_* is inlined at build time; CLERK_SECRET_KEY is runtime-only.
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
 
+# ── App URL (canonical site origin) ──────────────────────────────────────────
+# Required in production. Used for SEO, sitemap, OG tags, and Clerk redirects.
+# Local: http://localhost:3000
+# Production: https://clausea.co
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
+# ── Logo.dev (server-side only) ────────────────────────────────────────────────
 LOGO_DEV_API_KEY=
 
+# ── PostHog analytics ──────────────────────────────────────────────────────────
+# NEXT_PUBLIC_* vars are inlined at build time.
 NEXT_PUBLIC_POSTHOG_KEY=
-NEXT_PUBLIC_POSTHOG_HOST=https://app.posthog.com
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 
+# ── Paddle billing ─────────────────────────────────────────────────────────────
+# NEXT_PUBLIC_* price IDs are inlined at build time.
 NEXT_PUBLIC_PADDLE_PRICE_PRO_MONTHLY=
+# Legacy alias still supported in code:
+# NEXT_PUBLIC_PADDLE_PRICE_INDIVIDUAL_MONTHLY=
+
+# ── Search engine verification (optional) ──────────────────────────────────────
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
+NEXT_PUBLIC_BING_VERIFICATION=
+
+# ── Build tooling (optional) ───────────────────────────────────────────────────
+# ANALYZE=true enables @next/bundle-analyzer during `bun run build`

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+
+# ── Stage 1: install dependencies ─────────────────────────────────────────────
+FROM oven/bun:1 AS deps
+WORKDIR /app
+
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+# ── Stage 2: build Next.js (standalone output) ────────────────────────────────
+FROM oven/bun:1 AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# NEXT_PUBLIC_* and other build-time env vars are injected by Railway during build.
+RUN bun run build
+
+# ── Stage 3: production runtime ─────────────────────────────────────────────
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+# Railway sets PORT at runtime; Next.js standalone server reads it automatically.
+CMD ["node", "server.js"]

--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -1,1 +1,15 @@
-# Clausea Landing page
+# Clausea Frontend
+
+Next.js app for [clausea.co](https://clausea.co).
+
+## Development
+
+```bash
+bun install
+cp .env.example .env.local   # fill in Clerk keys and backend URL
+bun run dev
+```
+
+## Deploy to Railway
+
+See [docs/RAILWAY.md](./docs/RAILWAY.md) for environment variables, custom domains, and migration from Vercel.

--- a/packages/frontend/app/(site)/privacy/page.tsx
+++ b/packages/frontend/app/(site)/privacy/page.tsx
@@ -143,10 +143,11 @@ export default function PrivacyPolicyPage() {
                     Service Providers:
                   </strong>{" "}
                   We use third-party providers to run the Service, including
-                  MongoDB Atlas (database hosting), Railway (backend hosting),
-                  and Vercel (frontend hosting and delivery). We may also use
-                  providers for payments and analytics. Providers that process
-                  personal data on our behalf are required to protect it.
+                  MongoDB Atlas (database hosting), Railway (application
+                  hosting), and related infrastructure providers. We may also
+                  use providers for payments and analytics. Providers that
+                  process personal data on our behalf are required to protect
+                  it.
                 </li>
                 <li>
                   <strong className="text-foreground">

--- a/packages/frontend/docs/RAILWAY.md
+++ b/packages/frontend/docs/RAILWAY.md
@@ -1,0 +1,144 @@
+# Deploying the Frontend to Railway
+
+This guide covers deploying `packages/frontend` (Next.js) to Railway alongside the existing backend service.
+
+## Architecture
+
+| Service             | Path                | Builder                         | Port                       |
+| ------------------- | ------------------- | ------------------------------- | -------------------------- |
+| Frontend (this app) | `packages/frontend` | Dockerfile (standalone Next.js) | `$PORT` (Railway-assigned) |
+| Backend API         | `packages/backend`  | Dockerfile                      | `8000` or `$PORT`          |
+
+The frontend proxies API requests server-side via `BACKEND_BASE_URL`. Browser clients never call the backend directly for authenticated routes.
+
+## Railway setup (dashboard)
+
+### 1. Create or use an existing project
+
+If the backend is already on Railway, add a **new service** to the same project (recommended for shared networking and variables).
+
+### 2. Connect the GitHub repo
+
+1. **New Service** → **GitHub Repo** → select `clausea`
+2. Set **Root Directory** to `packages/frontend`
+3. Railway reads `railway.toml` and builds with the Dockerfile automatically
+
+### 3. Configure the service
+
+| Setting        | Value                              |
+| -------------- | ---------------------------------- |
+| Root Directory | `packages/frontend`                |
+| Builder        | Dockerfile (from `railway.toml`)   |
+| Watch paths    | Default (scoped to root directory) |
+
+No custom build or start command is needed — the Dockerfile handles install, build, and `node server.js`.
+
+### 4. Set environment variables
+
+Set these in the Railway dashboard for the **frontend service**. Variables marked **build** must be present before the first deploy (Next.js inlines `NEXT_PUBLIC_*` at build time).
+
+#### Required
+
+| Variable                            | Build | Description                                    |
+| ----------------------------------- | ----- | ---------------------------------------------- |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Yes   | Clerk publishable key for auth UI              |
+| `CLERK_SECRET_KEY`                  | No    | Clerk secret key for server-side auth          |
+| `NEXT_PUBLIC_APP_URL`               | Yes   | Public site URL, e.g. `https://clausea.co`     |
+| `BACKEND_BASE_URL`                  | No    | Backend API URL, e.g. `https://api.clausea.co` |
+
+#### Recommended
+
+| Variable                   | Build | Description                                   |
+| -------------------------- | ----- | --------------------------------------------- |
+| `NEXT_PUBLIC_POSTHOG_KEY`  | Yes   | PostHog project API key                       |
+| `NEXT_PUBLIC_POSTHOG_HOST` | Yes   | PostHog host, e.g. `https://eu.i.posthog.com` |
+| `LOGO_DEV_API_KEY`         | No    | Logo.dev token for product logos API route    |
+
+#### Optional
+
+| Variable                                      | Build | Description                    |
+| --------------------------------------------- | ----- | ------------------------------ |
+| `NEXT_PUBLIC_PADDLE_PRICE_PRO_MONTHLY`        | Yes   | Paddle price ID for Pro plan   |
+| `NEXT_PUBLIC_PADDLE_PRICE_INDIVIDUAL_MONTHLY` | Yes   | Legacy alias for Pro price ID  |
+| `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`        | Yes   | Google Search Console meta tag |
+| `NEXT_PUBLIC_BING_VERIFICATION`               | Yes   | Bing Webmaster meta tag        |
+
+Railway sets `PORT`, `NODE_ENV`, and `RAILWAY_*` automatically — do not override `PORT`.
+
+#### Wiring to the backend on Railway
+
+If the backend service is named `api` (adjust to match your service name):
+
+```text
+BACKEND_BASE_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
+```
+
+Or use the production custom domain:
+
+```text
+BACKEND_BASE_URL=https://api.clausea.co
+```
+
+### 5. Custom domain
+
+1. **Settings** → **Networking** → **Custom Domain**
+2. Add `clausea.co` and `www.clausea.co`
+3. Update DNS (CNAME to Railway's target)
+4. Set `NEXT_PUBLIC_APP_URL=https://clausea.co` and **redeploy** (build-time var)
+
+### 6. Clerk configuration
+
+In the [Clerk Dashboard](https://dashboard.clerk.com), add the Railway/production URLs:
+
+- Sign-in redirect: `https://clausea.co`
+- Allowed origins: `https://clausea.co`, `https://www.clausea.co`
+
+### 7. Backend CORS (if applicable)
+
+Ensure the backend `CORS_ORIGINS` includes the frontend origin:
+
+```text
+CORS_ORIGINS=https://clausea.co,https://www.clausea.co
+```
+
+## CLI deploy (alternative)
+
+From the frontend directory:
+
+```bash
+cd packages/frontend
+railway link          # link to project + service
+railway up --detach -m "Deploy frontend"
+```
+
+## Local Docker smoke test
+
+```bash
+cd packages/frontend
+docker build -t clausea-frontend .
+docker run --rm -p 3000:3000 \
+  -e PORT=3000 \
+  -e BACKEND_BASE_URL=http://host.docker.internal:8000 \
+  -e NEXT_PUBLIC_APP_URL=http://localhost:3000 \
+  -e NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_... \
+  -e CLERK_SECRET_KEY=sk_test_... \
+  clausea-frontend
+```
+
+## Migrating from Vercel
+
+1. Deploy to Railway and verify on the `*.up.railway.app` URL
+2. Point DNS for `clausea.co` from Vercel to Railway
+3. Update Clerk allowed origins if the domain changed during testing
+4. Remove or archive the Vercel project once traffic is stable
+5. Update the privacy policy (already references Railway for backend; frontend now on Railway too)
+
+## Troubleshooting
+
+| Symptom                     | Fix                                                                                           |
+| --------------------------- | --------------------------------------------------------------------------------------------- |
+| Auth broken in production   | Verify `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` was set **before** build; redeploy after adding it |
+| API calls fail              | Check `BACKEND_BASE_URL` points to the live backend; verify backend CORS                      |
+| Wrong canonical URLs in SEO | Set `NEXT_PUBLIC_APP_URL` and redeploy                                                        |
+| Container exits immediately | Check deploy logs; ensure `output: "standalone"` is in `next.config.mjs`                      |
+| Health check fails          | Railway probes `/`; ensure the app binds to `0.0.0.0` (handled by Dockerfile `HOSTNAME`)      |

--- a/packages/frontend/next.config.mjs
+++ b/packages/frontend/next.config.mjs
@@ -6,6 +6,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "standalone",
   reactStrictMode: true,
   poweredByHeader: false,
 

--- a/packages/frontend/railway.toml
+++ b/packages/frontend/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary

- Add a multi-stage Dockerfile and Railway config so the frontend can run on Railway with Next.js `standalone` output instead of Vercel-only hosting.
- Document production env vars and migration steps in `docs/RAILWAY.md`, expand `.env.example`, and update the README for local dev and deploy.
- Align the privacy policy hosting disclosure with Railway-based application hosting.

## Test plan

- [ ] `cd packages/frontend && bun run build` succeeds locally with `output: "standalone"`.
- [ ] `docker build -t clausea-frontend packages/frontend` completes and the container serves `/` on port 3000.
- [ ] Railway service builds from the Dockerfile with required build-time `NEXT_PUBLIC_*` and runtime secrets set per `docs/RAILWAY.md`.
- [ ] Privacy page copy reads correctly after the hosting provider update.