### PR TITLE
feat(backend): add /health liveness server to pipeline worker

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -95,5 +95,6 @@ ENV MALLOC_ARENA_MAX=2
 
 EXPOSE 8000
 
-# Exec form: uvicorn runs as PID 1 so Railway's SIGTERM is delivered directly.
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Shell wrapper so Railway's $PORT is honored when no startCommand override is set.
+# uvicorn remains PID 1 for clean SIGTERM handling.
+CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/packages/backend/Dockerfile.streamlit
+++ b/packages/backend/Dockerfile.streamlit
@@ -75,5 +75,5 @@ COPY . .
 
 EXPOSE 8501
 
-# Exec form: streamlit runs as PID 1 so signals are delivered directly.
-CMD ["streamlit", "run", "src/dashboard/app.py", "--server.port=8501", "--server.address=0.0.0.0", "--server.headless=true"]
+# Shell wrapper so Railway's $PORT is honored when no startCommand override is set.
+CMD ["sh", "-c", "exec streamlit run src/dashboard/app.py --server.port=${PORT:-8501} --server.address=0.0.0.0 --server.headless=true"]

--- a/packages/backend/Dockerfile.worker
+++ b/packages/backend/Dockerfile.worker
@@ -1,3 +1,9 @@
+# Pipeline worker — serves GET /health on $PORT for Railway liveness probes.
+# Railway dashboard MUST set:
+#   Build → Dockerfile Path: Dockerfile.worker
+#   Deploy → Start command: (empty — use this CMD)
+#   Deploy → Health check: /health (optional; can disable if preferred)
+
 # ── Stage 1: builder ─────────────────────────────────────────────────────────
 # Installs build-time tools, compiles Python dependencies, and fetches the
 # Camoufox Firefox binary. Nothing from this stage leaks into the final image.
@@ -93,5 +99,8 @@ COPY . .
 # Cap glibc arenas so freed memory returns to the OS instead of being hoarded per thread.
 ENV MALLOC_ARENA_MAX=2
 
+EXPOSE 8000
+
 # Exec form: worker runs as PID 1 so Railway's SIGTERM is delivered directly.
+# worker.py binds $PORT (default 8000) for GET /health liveness probes.
 CMD ["python", "worker.py"]

--- a/packages/backend/Dockerfile.worker
+++ b/packages/backend/Dockerfile.worker
@@ -1,0 +1,97 @@
+# ── Stage 1: builder ─────────────────────────────────────────────────────────
+# Installs build-time tools, compiles Python dependencies, and fetches the
+# Camoufox Firefox binary. Nothing from this stage leaks into the final image.
+FROM python:3.11-slim AS builder
+
+ENV VENV_PATH="/opt/venv"
+ENV PATH="$VENV_PATH/bin:$PATH"
+# UV_PROJECT_ENVIRONMENT tells uv sync where to create/use the project venv.
+ENV UV_PROJECT_ENVIRONMENT="/opt/venv"
+# Camoufox uses XDG_CACHE_HOME to determine where to install the browser binary.
+# Pin it to a known path so the COPY into the final stage is predictable.
+ENV XDG_CACHE_HOME="/opt/camoufox-cache"
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    gcc \
+    libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv==0.9
+
+COPY pyproject.toml ./
+COPY uv.lock ./
+
+# --no-install-project skips building the local `clausea` package (source isn't
+# copied here). All external dependencies are still installed into /opt/venv.
+RUN uv sync --no-dev --frozen --no-install-project && uv cache clean
+
+# Download the Camoufox Firefox binary at build time (stored at $XDG_DATA_HOME/camoufox).
+# Running this here avoids any network call at container startup.
+RUN /opt/venv/bin/camoufox fetch
+
+# ── Stage 2: runtime ─────────────────────────────────────────────────────────
+# Clean image containing only the venv, the Camoufox binary, runtime system
+# libraries, and application code. Build tools (gcc, libffi-dev, uv) are absent.
+FROM python:3.11-slim
+
+ENV VENV_PATH="/opt/venv"
+ENV PATH="$VENV_PATH/bin:$PATH"
+ENV PYTHONPATH="/app"
+ENV XDG_CACHE_HOME="/opt/camoufox-cache"
+
+# Runtime-only system libraries required by the Camoufox Firefox binary.
+# These satisfy the dynamic linker at process start; they are not used
+# during headless operation but Firefox links against them unconditionally.
+RUN apt-get update && apt-get install -y \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcairo-gobject2 \
+    libcairo2 \
+    libcups2 \
+    libdbus-1-3 \
+    libdbus-glib-1-2 \
+    libdrm2 \
+    libfontconfig1 \
+    libfreetype6 \
+    libgbm1 \
+    libgdk-pixbuf-2.0-0 \
+    libglib2.0-0 \
+    libgtk-3-0 \
+    libharfbuzz0b \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb-shm0 \
+    libxcb1 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxi6 \
+    libxkbcommon0 \
+    libxrandr2 \
+    libxrender1 \
+    libxtst6 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the compiled virtual environment (all external deps, no local package).
+COPY --from=builder /opt/venv /opt/venv
+
+# Copy the pre-fetched Camoufox Firefox binary (stored under XDG_CACHE_HOME).
+COPY --from=builder /opt/camoufox-cache /opt/camoufox-cache
+
+COPY . .
+
+# Cap glibc arenas so freed memory returns to the OS instead of being hoarded per thread.
+ENV MALLOC_ARENA_MAX=2
+
+# Exec form: worker runs as PID 1 so Railway's SIGTERM is delivered directly.
+CMD ["python", "worker.py"]

--- a/packages/backend/docs/RAILWAY.md
+++ b/packages/backend/docs/RAILWAY.md
@@ -7,7 +7,7 @@ This guide covers deploying `packages/backend` services to Railway. See also [Fr
 | Service            | Path               | Dockerfile           | Config              | Port / health        |
 | ------------------ | ------------------ | -------------------- | ------------------- | -------------------- |
 | API (FastAPI)      | `packages/backend` | `Dockerfile`         | `railway.toml`      | `$PORT`, `/health`   |
-| Worker (crawler)   | `packages/backend` | `Dockerfile.worker`  | Dashboard overrides | No HTTP (no probe)   |
+| Worker (crawler)   | `packages/backend` | `Dockerfile.worker`  | Dashboard overrides | `$PORT`, `/health`   |
 | Streamlit (optional) | `packages/backend` | `Dockerfile.streamlit` | Dashboard overrides | `$PORT`, `/_stcore/health` |
 
 The API serves user-facing requests. The worker runs pipeline jobs (crawls, parsing, LLM calls) out of process so heavy work never blocks the API. Streamlit is an optional internal admin dashboard.
@@ -25,7 +25,7 @@ The API serves user-facing requests. The worker runs pipeline jobs (crawls, pars
                     └─────────────┘
 ```
 
-Only one `railway.toml` can live at the service root. The API service uses it; the worker and Streamlit services configure their Dockerfile in the Railway dashboard.
+Only one `railway.toml` can live at the service root (`packages/backend`). **Every service that shares this root reads the same file** — including its `dockerfilePath = "Dockerfile"` and `healthcheckPath = "/health"`. The API service uses these defaults; the worker and Streamlit services **must override the Dockerfile path in the Railway dashboard** (worker can keep `/health` when using `Dockerfile.worker`).
 
 ## Railway setup (dashboard)
 
@@ -51,11 +51,20 @@ Create a **separate service** in the same project (recommended for shared variab
 | Setting        | Value                                              |
 | -------------- | -------------------------------------------------- |
 | Root Directory | `packages/backend`                                 |
-| Dockerfile     | `Dockerfile.worker` (override in dashboard)        |
+| Dockerfile     | `Dockerfile.worker` (**override in dashboard**)    |
 | Start command  | *(empty — use image CMD `python worker.py`)*       |
-| Health check   | **Disabled** (worker has no HTTP endpoint)         |
+| Health check   | `/health` (liveness-only; optional — can disable)  |
+| Replicas       | Start with **1**; scale up only after deploy succeeds |
 
-Railway cannot read a second `railway.toml` at the same root. Set **Settings → Build → Dockerfile Path** to `Dockerfile.worker` manually.
+Railway cannot read a second `railway.toml` at the same root. In the worker service dashboard:
+
+1. **Settings → Build → Dockerfile Path** → `Dockerfile.worker` (not `Dockerfile`)
+2. **Settings → Deploy → Start Command** → clear/empty (do not use the API uvicorn command)
+3. **Settings → Deploy → Health Check Path** → `/health` (inherits from shared `railway.toml`) or leave blank to disable
+
+> **Common failure:** Build log shows `load build definition from packages/backend/Dockerfile` (not `Dockerfile.worker`), and deploy fails with **"N/N replicas never became healthy!"** and **"service unavailable"** on every attempt. That usually means the worker is still using the API Dockerfile/start command (uvicorn) or the wrong entrypoint — not a MongoDB issue. Fix the Dockerfile path and clear the start command. Also verify replica count: nothing in this repo sets replicas; that is a dashboard setting.
+
+The worker image serves `GET /health` on `$PORT` (liveness-only, like the API — no MongoDB check). Railway health checks are optional; you can disable them on the worker if preferred.
 
 The worker image is identical to the API image except for the entrypoint. It needs Camoufox/Firefox runtime libraries for headless crawls.
 
@@ -163,20 +172,28 @@ curl http://localhost:8000/health
 ```bash
 cd packages/backend
 docker build -f Dockerfile.worker -t clausea-worker .
-docker run --rm \
+docker run --rm -p 8000:8000 \
+  -e PORT=8000 \
   -e MONGO_URI=mongodb://host.docker.internal:27017/clausea \
   -e ENVIRONMENT=development \
   -e OPENAI_API_KEY=sk-... \
   clausea-worker
+curl http://localhost:8000/health
 ```
 
 ## Troubleshooting
 
 | Symptom                      | Fix                                                                 |
 | ---------------------------- | ------------------------------------------------------------------- |
+| **"N/N replicas never became healthy"** + `/health` + `service unavailable`, build uses `Dockerfile` not `Dockerfile.worker` | **Worker misconfiguration.** Set Dockerfile to `Dockerfile.worker`, clear start command (no uvicorn). Reduce replicas to 1 until deploy passes. Not a MongoDB issue. |
+| Worker deploy OK but runs API instead of crawls | Dockerfile path still `Dockerfile` (uvicorn CMD). Set `Dockerfile.worker` and clear start command. |
 | API health check fails       | Confirm start command uses `$PORT`; `/health` is liveness-only (200 even while DB warms up). Check deploy logs for missing `MONGO_URI` or MongoDB connectivity; use `/health/ready` for readiness. |
-| Worker OOM / crashloops      | Lower `PIPELINE_WORKER_CONCURRENCY`; increase memory; add replicas  |
+| Worker OOM / crashloops      | Lower `PIPELINE_WORKER_CONCURRENCY`; increase memory; add replicas after deploy succeeds |
 | Worker redeploys on API push | Expected if both share root — use watch paths or separate triggers  |
 | Crawls fail in worker        | Verify Camoufox libs in image; check `CRAWLER_USE_BROWSER=true`     |
 | CORS errors from frontend    | Set `CORS_ORIGINS` on API to include frontend URL                   |
 | Auth fails                   | Verify `CLERK_JWKS_URL` matches your Clerk instance                 |
+
+### Why regular `Dockerfile` + `python worker.py` fails health
+
+If the worker service still builds from the API `Dockerfile` (uvicorn entrypoint) or the start command is overridden to `python worker.py` while Railway probes a port nothing is listening on, health checks fail until timeout. Use `Dockerfile.worker` (which runs `worker.py` and serves `/health` on `$PORT`) and leave the start command empty.

--- a/packages/backend/docs/RAILWAY.md
+++ b/packages/backend/docs/RAILWAY.md
@@ -1,0 +1,182 @@
+# Deploying the Backend to Railway
+
+This guide covers deploying `packages/backend` services to Railway. See also [Frontend Railway guide](../../frontend/docs/RAILWAY.md) for the Next.js app.
+
+## Architecture
+
+| Service            | Path               | Dockerfile           | Config              | Port / health        |
+| ------------------ | ------------------ | -------------------- | ------------------- | -------------------- |
+| API (FastAPI)      | `packages/backend` | `Dockerfile`         | `railway.toml`      | `$PORT`, `/health`   |
+| Worker (crawler)   | `packages/backend` | `Dockerfile.worker`  | Dashboard overrides | No HTTP (no probe)   |
+| Streamlit (optional) | `packages/backend` | `Dockerfile.streamlit` | Dashboard overrides | `$PORT`, `/_stcore/health` |
+
+The API serves user-facing requests. The worker runs pipeline jobs (crawls, parsing, LLM calls) out of process so heavy work never blocks the API. Streamlit is an optional internal admin dashboard.
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  Frontend   │────▶│  API        │     │  Streamlit  │
+│  (Next.js)  │     │  (FastAPI)  │     │  (optional) │
+└─────────────┘     └──────┬──────┘     └──────┬──────┘
+                           │                   │
+                           ▼                   ▼
+                    ┌─────────────┐       MongoDB Atlas
+                    │   Worker    │──────────────┘
+                    │  (crawler)  │
+                    └─────────────┘
+```
+
+Only one `railway.toml` can live at the service root. The API service uses it; the worker and Streamlit services configure their Dockerfile in the Railway dashboard.
+
+## Railway setup (dashboard)
+
+### 1. API service
+
+1. **New Service** → **GitHub Repo** → select `clausea`
+2. Set **Root Directory** to `packages/backend`
+3. Railway reads `railway.toml` and builds with `Dockerfile` automatically
+
+| Setting        | Value                                           |
+| -------------- | ----------------------------------------------- |
+| Root Directory | `packages/backend`                              |
+| Builder        | Dockerfile (from `railway.toml`)                |
+| Start command  | From `railway.toml` (`uvicorn … --port $PORT`)  |
+| Health check   | `/health`                                       |
+
+`railway.toml` sets `watchPatterns = ["packages/backend/**"]` so monorepo pushes only redeploy when backend files change.
+
+### 2. Worker service
+
+Create a **separate service** in the same project (recommended for shared variables and networking).
+
+| Setting        | Value                                              |
+| -------------- | -------------------------------------------------- |
+| Root Directory | `packages/backend`                                 |
+| Dockerfile     | `Dockerfile.worker` (override in dashboard)        |
+| Start command  | *(empty — use image CMD `python worker.py`)*       |
+| Health check   | **Disabled** (worker has no HTTP endpoint)         |
+
+Railway cannot read a second `railway.toml` at the same root. Set **Settings → Build → Dockerfile Path** to `Dockerfile.worker` manually.
+
+The worker image is identical to the API image except for the entrypoint. It needs Camoufox/Firefox runtime libraries for headless crawls.
+
+**Worker tuning (optional env vars):**
+
+| Variable                            | Default | Description                          |
+| ----------------------------------- | ------- | ------------------------------------ |
+| `PIPELINE_WORKER_CONCURRENCY`       | `3`     | Max jobs running at once             |
+| `PIPELINE_WORKER_POLL_SECONDS`      | `3`     | Idle poll interval                   |
+| `PIPELINE_WORKER_STALE_SWEEP_SECONDS` | `300` | How often to reap orphaned jobs      |
+
+Allocate more memory for the worker than the API (512MB–1GB+); Camoufox crawls are memory-heavy.
+
+### 3. Streamlit service (optional)
+
+For an internal admin dashboard, add another service:
+
+| Setting        | Value                                                                 |
+| -------------- | --------------------------------------------------------------------- |
+| Root Directory | `packages/backend`                                                    |
+| Dockerfile     | `Dockerfile.streamlit`                                                |
+| Start command  | `streamlit run src/dashboard/app.py --server.port=$PORT --server.address=0.0.0.0 --server.headless=true` |
+| Health check   | `/_stcore/health`                                                     |
+
+Restrict access via Railway networking or VPN; do not expose publicly unless required.
+
+## Environment variables
+
+Set variables on the **API** and **worker** services (share via Railway shared variables or copy manually). The worker needs database and LLM keys; it does not need Clerk JWT or CORS settings for normal operation.
+
+### Required (API + worker)
+
+| Variable         | Description                                      |
+| ---------------- | ------------------------------------------------ |
+| `MONGO_URI`      | MongoDB Atlas connection string                  |
+| `ENVIRONMENT`    | `production` in Railway                          |
+| `OPENAI_API_KEY` | LLM provider (or other keys your deployment uses) |
+
+### Required (API only)
+
+| Variable          | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `CLERK_JWKS_URL`  | Clerk JWKS URL for JWT validation              |
+| `CORS_ORIGINS`    | Frontend origins, e.g. `https://clausea.co`  |
+
+### Recommended (API)
+
+| Variable            | Description                |
+| ------------------- | -------------------------- |
+| `POSTHOG_API_KEY`   | Product analytics          |
+| `PADDLE_API_KEY`    | Billing                    |
+| `PADDLE_WEBHOOK_SECRET` | Paddle webhooks        |
+| `RESEND_API_KEY`    | Transactional email        |
+
+### Optional
+
+| Variable           | Description                                      |
+| ------------------ | ------------------------------------------------ |
+| `PINECONE_API_KEY` | Vector search (if enabled)                       |
+| `ANTHROPIC_API_KEY`| Alternate LLM provider                           |
+| `SERVICE_API_KEY`  | Service-to-service auth (Streamlit → API)        |
+| `CRAWLER_*`        | Crawler tuning (see `src/core/config.py`)        |
+
+Railway sets `PORT` automatically — do not hardcode it. The API `railway.toml` start command binds to `$PORT`.
+
+### Wiring frontend to API
+
+If the frontend service is named `frontend`:
+
+```text
+BACKEND_BASE_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
+```
+
+Set on the **frontend** service. See [frontend RAILWAY.md](../../frontend/docs/RAILWAY.md).
+
+## CLI deploy (alternative)
+
+From the backend directory, link each service separately:
+
+```bash
+cd packages/backend
+railway link          # link to project + api service
+railway up --detach -m "Deploy API"
+```
+
+For the worker, switch the linked service in the dashboard or CLI, then deploy with Dockerfile.worker configured in the service settings.
+
+## Local Docker smoke test
+
+**API:**
+
+```bash
+cd packages/backend
+docker build -t clausea-api .
+docker run --rm -p 8000:8000 \
+  -e PORT=8000 \
+  -e MONGO_URI=mongodb://host.docker.internal:27017/clausea \
+  -e ENVIRONMENT=development \
+  clausea-api
+curl http://localhost:8000/health
+```
+
+**Worker:**
+
+```bash
+cd packages/backend
+docker build -f Dockerfile.worker -t clausea-worker .
+docker run --rm \
+  -e MONGO_URI=mongodb://host.docker.internal:27017/clausea \
+  -e ENVIRONMENT=development \
+  -e OPENAI_API_KEY=sk-... \
+  clausea-worker
+```
+
+## Troubleshooting
+
+| Symptom                      | Fix                                                                 |
+| ---------------------------- | ------------------------------------------------------------------- |
+| API health check fails       | Confirm start command uses `$PORT`; probe `/health`                 |
+| Worker OOM / crashloops      | Lower `PIPELINE_WORKER_CONCURRENCY`; increase memory; add replicas  |
+| Worker redeploys on API push | Expected if both share root — use watch paths or separate triggers  |
+| Crawls fail in worker        | Verify Camoufox libs in image; check `CRAWLER_USE_BROWSER=true`     |
+| CORS errors from frontend    | Set `CORS_ORIGINS` on API to include frontend URL                   |
+| Auth fails                   | Verify `CLERK_JWKS_URL` matches your Clerk instance                 |

--- a/packages/backend/docs/RAILWAY.md
+++ b/packages/backend/docs/RAILWAY.md
@@ -39,7 +39,7 @@ Only one `railway.toml` can live at the service root (`packages/backend`). **Eve
 | -------------- | ----------------------------------------------- |
 | Root Directory | `packages/backend`                              |
 | Builder        | Dockerfile (from `railway.toml`)                |
-| Start command  | From `railway.toml` (`uvicorn … --port $PORT`)  |
+| Start command  | *(empty — image CMD binds `${PORT}` via shell)* |
 | Health check   | `/health`                                       |
 
 `railway.toml` sets `watchPatterns = ["packages/backend/**"]` so monorepo pushes only redeploy when backend files change.
@@ -59,7 +59,7 @@ Create a **separate service** in the same project (recommended for shared variab
 Railway cannot read a second `railway.toml` at the same root. In the worker service dashboard:
 
 1. **Settings → Build → Dockerfile Path** → `Dockerfile.worker` (not `Dockerfile`)
-2. **Settings → Deploy → Start Command** → clear/empty (do not use the API uvicorn command)
+2. **Settings → Deploy → Start Command** → leave empty (image CMD `python worker.py`)
 3. **Settings → Deploy → Health Check Path** → `/health` (inherits from shared `railway.toml`) or leave blank to disable
 
 > **Common failure:** Build log shows `load build definition from packages/backend/Dockerfile` (not `Dockerfile.worker`), and deploy fails with **"N/N replicas never became healthy!"** and **"service unavailable"** on every attempt. That usually means the worker is still using the API Dockerfile/start command (uvicorn) or the wrong entrypoint — not a MongoDB issue. Fix the Dockerfile path and clear the start command. Also verify replica count: nothing in this repo sets replicas; that is a dashboard setting.
@@ -128,7 +128,7 @@ Set variables on the **API** and **worker** services (share via Railway shared v
 | `SERVICE_API_KEY`  | Service-to-service auth (Streamlit → API)        |
 | `CRAWLER_*`        | Crawler tuning (see `src/core/config.py`)        |
 
-Railway sets `PORT` automatically — do not hardcode it. The API `railway.toml` start command binds to `$PORT`.
+Railway sets `PORT` automatically — do not hardcode it. **Do not** set `startCommand` in shared `railway.toml`: Railway passes it to the process without shell expansion, so `--port $PORT` becomes the literal string `$PORT` and uvicorn crashloops. Each service Dockerfile CMD uses `sh -c` with `${PORT:-8000}` instead.
 
 ### Wiring frontend to API
 
@@ -187,7 +187,7 @@ curl http://localhost:8000/health
 | ---------------------------- | ------------------------------------------------------------------- |
 | **"N/N replicas never became healthy"** + `/health` + `service unavailable`, build uses `Dockerfile` not `Dockerfile.worker` | **Worker misconfiguration.** Set Dockerfile to `Dockerfile.worker`, clear start command (no uvicorn). Reduce replicas to 1 until deploy passes. Not a MongoDB issue. |
 | Worker deploy OK but runs API instead of crawls | Dockerfile path still `Dockerfile` (uvicorn CMD). Set `Dockerfile.worker` and clear start command. |
-| API health check fails       | Confirm start command uses `$PORT`; `/health` is liveness-only (200 even while DB warms up). Check deploy logs for missing `MONGO_URI` or MongoDB connectivity; use `/health/ready` for readiness. |
+| API health check fails       | Deploy logs show `Invalid value for '--port': '$PORT'` → remove `startCommand` from `railway.toml` / dashboard; use Dockerfile CMD with `${PORT}`. `/health` is liveness-only. Check `MONGO_URI` for `/health/ready`. |
 | Worker OOM / crashloops      | Lower `PIPELINE_WORKER_CONCURRENCY`; increase memory; add replicas after deploy succeeds |
 | Worker redeploys on API push | Expected if both share root — use watch paths or separate triggers  |
 | Crawls fail in worker        | Verify Camoufox libs in image; check `CRAWLER_USE_BROWSER=true`     |

--- a/packages/backend/docs/RAILWAY.md
+++ b/packages/backend/docs/RAILWAY.md
@@ -174,7 +174,7 @@ docker run --rm \
 
 | Symptom                      | Fix                                                                 |
 | ---------------------------- | ------------------------------------------------------------------- |
-| API health check fails       | Confirm start command uses `$PORT`; probe `/health`                 |
+| API health check fails       | Confirm start command uses `$PORT`; `/health` is liveness-only (200 even while DB warms up). Check deploy logs for missing `MONGO_URI` or MongoDB connectivity; use `/health/ready` for readiness. |
 | Worker OOM / crashloops      | Lower `PIPELINE_WORKER_CONCURRENCY`; increase memory; add replicas  |
 | Worker redeploys on API push | Expected if both share root — use watch paths or separate triggers  |
 | Crawls fail in worker        | Verify Camoufox libs in image; check `CRAWLER_USE_BROWSER=true`     |

--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -132,7 +132,7 @@ async def readiness_check() -> JSONResponse:
 
     try:
         async with db_session() as db:
-            await db.command("ping")
+            await asyncio.wait_for(db.command("ping"), timeout=3.0)
     except Exception as exc:
         logger.warning("Readiness ping failed", error=str(exc))
         return JSONResponse(

--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -1,5 +1,7 @@
+import asyncio
 from collections.abc import AsyncGenerator
 
+import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -27,21 +29,52 @@ from src.routes import (
 )
 
 setup_logging()
+logger = structlog.get_logger(service="main")
+
+_startup_task: asyncio.Task[None] | None = None
+_startup_complete = asyncio.Event()
+_startup_failed = False
+
+
+async def _initialize_database() -> None:
+    """Run index creation and stale-job cleanup without blocking HTTP startup."""
+    global _startup_failed
+    try:
+        if not config.database.mongodb_uri:
+            logger.error("MONGO_URI is not set — database-backed routes will fail until configured")
+            _startup_failed = True
+            return
+
+        async with db_session() as db:
+            await ensure_all_indexes(db)
+            # Reap orphaned jobs first (frees the active slot), THEN build the partial
+            # unique index that enforces at-most-one active job per product.
+            await PipelineRepository().mark_stale_as_failed(db)
+            await ensure_active_job_unique_index(db)
+    except Exception:
+        _startup_failed = True
+        logger.exception("Database startup initialization failed")
+    finally:
+        _startup_complete.set()
 
 
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Manage application lifecycle events."""
-    # Startup: Ensure database indexes are created
-    async with db_session() as db:
-        await ensure_all_indexes(db)
-        # Reap orphaned jobs first (frees the active slot), THEN build the partial
-        # unique index that enforces at-most-one active job per product.
-        await PipelineRepository().mark_stale_as_failed(db)
-        await ensure_active_job_unique_index(db)
+    global _startup_task, _startup_failed
+    _startup_failed = False
+    _startup_complete.clear()
+    _startup_task = asyncio.create_task(_initialize_database())
 
+    # Yield immediately so Railway liveness probes (/health) succeed while DB warms up.
     yield
 
-    # Shutdown: close shared DB client/pool
+    if _startup_task is not None:
+        _startup_task.cancel()
+        try:
+            await _startup_task
+        except asyncio.CancelledError:
+            pass
+
     close_motor_client()
 
 
@@ -72,8 +105,42 @@ app.add_middleware(AuthMiddleware)  # type: ignore
 
 @app.get("/health")
 async def healthcheck() -> dict[str, str]:
-    """Health check endpoint to verify the API is running."""
+    """Liveness probe — returns 200 as soon as the process is serving HTTP."""
     return {"status": "healthy", "message": "Clausea API is running"}
+
+
+@app.get("/health/ready")
+async def readiness_check() -> JSONResponse:
+    """Readiness probe — verifies MongoDB connectivity and startup initialization."""
+    if not config.database.mongodb_uri:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "not_ready", "reason": "MONGO_URI is not configured"},
+        )
+
+    if not _startup_complete.is_set():
+        return JSONResponse(
+            status_code=503,
+            content={"status": "starting", "reason": "Database initialization in progress"},
+        )
+
+    if _startup_failed:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "degraded", "reason": "Database initialization failed"},
+        )
+
+    try:
+        async with db_session() as db:
+            await db.command("ping")
+    except Exception as exc:
+        logger.warning("Readiness ping failed", error=str(exc))
+        return JSONResponse(
+            status_code=503,
+            content={"status": "not_ready", "reason": "MongoDB ping failed"},
+        )
+
+    return JSONResponse(content={"status": "ready", "message": "Clausea API is ready"})
 
 
 routes = [

--- a/packages/backend/railway.toml
+++ b/packages/backend/railway.toml
@@ -1,3 +1,8 @@
+# API service config. Worker and Streamlit also use root packages/backend but
+# MUST override Dockerfile in the Railway dashboard — see docs/RAILWAY.md:
+#   Worker:    Dockerfile.worker, start command empty, health check /health (optional)
+#   Streamlit: Dockerfile.streamlit, health check /_stcore/health
+
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"

--- a/packages/backend/railway.toml
+++ b/packages/backend/railway.toml
@@ -1,0 +1,11 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+watchPatterns = ["packages/backend/**"]
+
+[deploy]
+startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/packages/backend/railway.toml
+++ b/packages/backend/railway.toml
@@ -9,7 +9,9 @@ dockerfilePath = "Dockerfile"
 watchPatterns = ["packages/backend/**"]
 
 [deploy]
-startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"
+# Do not set startCommand here — Railway passes it to uvicorn without shell
+# expansion, so `--port $PORT` becomes the literal string "$PORT" and the
+# container crashloops. Each Dockerfile CMD uses `sh -c` with ${PORT:-8000}.
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"

--- a/packages/backend/tests/unit/worker_health_test.py
+++ b/packages/backend/tests/unit/worker_health_test.py
@@ -1,0 +1,14 @@
+import json
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from worker import _health
+
+
+@pytest.mark.asyncio
+async def test_worker_health_returns_200() -> None:
+    response = await _health(make_mocked_request("GET", "/health"))
+    assert response.status == 200
+    body = json.loads(response.text)
+    assert body == {"status": "healthy", "service": "worker"}

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -38,7 +38,8 @@ _POLL_SECONDS = float(os.getenv("PIPELINE_WORKER_POLL_SECONDS", "3"))
 _STALE_SWEEP_SECONDS = float(os.getenv("PIPELINE_WORKER_STALE_SWEEP_SECONDS", "300"))
 _MONITORING_SWEEP_SECONDS = float(os.getenv("PIPELINE_MONITORING_SWEEP_SECONDS", "3600"))
 _SHUTDOWN_GRACE_SECONDS = float(os.getenv("PIPELINE_WORKER_SHUTDOWN_GRACE", "20"))
-_HEALTH_PORT = int(os.getenv("PORT", "8000"))
+_PORT_ENV = os.getenv("PORT", "8000")
+_HEALTH_PORT = int(_PORT_ENV) if _PORT_ENV.isdigit() else 8000
 
 
 async def _health(_request: web.Request) -> web.Response:
@@ -140,17 +141,17 @@ async def _sleep_or_stop(stop: asyncio.Event, seconds: float) -> None:
 async def main() -> None:
     setup_logging()
     health_runner = await _start_health_server()
-    repo = PipelineRepository()
-
-    stop = asyncio.Event()
-    loop = asyncio.get_running_loop()
-    for sig in (signal.SIGTERM, signal.SIGINT):
-        try:
-            loop.add_signal_handler(sig, stop.set)
-        except NotImplementedError:
-            pass  # add_signal_handler is unavailable on Windows; signals are a Unix/prod concern
-
     try:
+        repo = PipelineRepository()
+
+        stop = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                loop.add_signal_handler(sig, stop.set)
+            except NotImplementedError:
+                pass  # add_signal_handler is unavailable on Windows; signals are a Unix/prod concern
+
         await _run_worker_loop(repo, stop, loop)
     finally:
         await health_runner.cleanup()

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -16,6 +16,8 @@ import asyncio
 import os
 import signal
 
+from aiohttp import web
+
 from src.core.database import close_motor_client, db_session
 from src.core.logging import get_logger, setup_logging
 from src.repositories.monitoring_schedule_repository import MonitoringScheduleRepository
@@ -36,6 +38,23 @@ _POLL_SECONDS = float(os.getenv("PIPELINE_WORKER_POLL_SECONDS", "3"))
 _STALE_SWEEP_SECONDS = float(os.getenv("PIPELINE_WORKER_STALE_SWEEP_SECONDS", "300"))
 _MONITORING_SWEEP_SECONDS = float(os.getenv("PIPELINE_MONITORING_SWEEP_SECONDS", "3600"))
 _SHUTDOWN_GRACE_SECONDS = float(os.getenv("PIPELINE_WORKER_SHUTDOWN_GRACE", "20"))
+_HEALTH_PORT = int(os.getenv("PORT", "8000"))
+
+
+async def _health(_request: web.Request) -> web.Response:
+    """Liveness probe — returns 200 as soon as the process is serving HTTP."""
+    return web.json_response({"status": "healthy", "service": "worker"})
+
+
+async def _start_health_server() -> web.AppRunner:
+    app = web.Application()
+    app.router.add_get("/health", _health)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", _HEALTH_PORT)
+    await site.start()
+    logger.info("Health server listening on 0.0.0.0:%d/health", _HEALTH_PORT)
+    return runner
 
 
 async def _sweep_stale(repo: PipelineRepository) -> None:
@@ -120,6 +139,7 @@ async def _sleep_or_stop(stop: asyncio.Event, seconds: float) -> None:
 
 async def main() -> None:
     setup_logging()
+    health_runner = await _start_health_server()
     repo = PipelineRepository()
 
     stop = asyncio.Event()
@@ -130,6 +150,15 @@ async def main() -> None:
         except NotImplementedError:
             pass  # add_signal_handler is unavailable on Windows; signals are a Unix/prod concern
 
+    try:
+        await _run_worker_loop(repo, stop, loop)
+    finally:
+        await health_runner.cleanup()
+
+
+async def _run_worker_loop(
+    repo: PipelineRepository, stop: asyncio.Event, loop: asyncio.AbstractEventLoop
+) -> None:
     # Reap jobs orphaned by a previous crash/redeploy before claiming new work.
     # On boot we use threshold=0: any job still "crawling" when this process starts
     # was owned by a now-dead process and must be reset immediately. The periodic


### PR DESCRIPTION
## Summary
- Adds a lightweight aiohttp `/health` endpoint to `worker.py` on `$PORT` (default 8000), running alongside the existing poll loop
- Liveness-only: returns 200 immediately without waiting for MongoDB (same pattern as the API)
- Updates `Dockerfile.worker`, `railway.toml` comments, and `docs/RAILWAY.md` so the worker can keep Railway health checks enabled with `Dockerfile.worker`

## Test plan
- [x] `uv run ruff check worker.py tests/unit/worker_health_test.py`
- [x] `uv run pytest tests/unit/worker_health_test.py`
- [ ] Deploy worker with `Dockerfile.worker`, health check `/health`, empty start command
- [ ] `curl https://<worker-domain>/health` returns `{"status":"healthy","service":"worker"}`