### PR TITLE
fix(frontend): stop infinite Loading on header auth CTA

### DIFF
--- a/packages/frontend/components/clausea/Header.tsx
+++ b/packages/frontend/components/clausea/Header.tsx
@@ -2,19 +2,11 @@
 
 import { Menu, X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import {
-  type MouseEvent,
-  startTransition,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { startTransition, useEffect, useRef, useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@clerk/nextjs";
 
@@ -24,28 +16,16 @@ export function Header() {
   const { isSignedIn, isLoaded } = useAuth();
   const prevPathnameRef = useRef(pathname);
 
-  const ctaHref = isSignedIn
+  // Default to signed-out nav until Clerk confirms a session (safe for marketing pages).
+  const showSignedInCta = isLoaded && isSignedIn;
+  const ctaHref = showSignedInCta
     ? "/products"
     : "/sign-in?redirect_url=%2Fproducts";
-  const ctaLabel = !isLoaded
-    ? "Loading..."
-    : isSignedIn
-      ? "Dashboard"
-      : "Get Started";
-  const showSignIn = isLoaded && !isSignedIn;
+  const ctaLabel = showSignedInCta ? "Dashboard" : "Get Started";
+  const showSignIn = !showSignedInCta;
 
-  const handleAuthNavigation = (event: MouseEvent<HTMLAnchorElement>) => {
-    if (!isLoaded) {
-      event.preventDefault();
-    }
-  };
-
-  const ctaButtonClassName = cn(
-    "border border-foreground text-foreground transition-colors",
-    isLoaded
-      ? "hover:bg-foreground hover:text-background cursor-pointer"
-      : "opacity-50 cursor-not-allowed",
-  );
+  const ctaButtonClassName =
+    "border border-foreground text-foreground transition-colors hover:bg-foreground hover:text-background cursor-pointer";
 
   // Close mobile menu on route change
   useEffect(() => {
@@ -95,10 +75,9 @@ export function Header() {
             </Link>
           )}
 
-          <Link href={ctaHref} onClick={handleAuthNavigation}>
+          <Link href={ctaHref}>
             <button
               type="button"
-              disabled={!isLoaded}
               className={cn("px-5 py-2.5 md:px-7 md:py-3", ctaButtonClassName)}
             >
               {ctaLabel}
@@ -187,18 +166,9 @@ export function Header() {
               transition={{ delay: (navLinks.length + 1) * 0.1 }}
               className="mt-8 w-full max-w-xs"
             >
-              <Link
-                href={ctaHref}
-                onClick={(event) => {
-                  handleAuthNavigation(event);
-                  if (isLoaded) {
-                    setIsOpen(false);
-                  }
-                }}
-              >
+              <Link href={ctaHref} onClick={() => setIsOpen(false)}>
                 <button
                   type="button"
-                  disabled={!isLoaded}
                   className={cn(
                     "w-full py-4 text-sm uppercase tracking-widest font-medium",
                     ctaButtonClassName,


### PR DESCRIPTION
## Summary

- **Main after #147** still showed a disabled **Loading...** CTA while waiting on Clerk `isLoaded`, which could appear stuck forever (especially with client-only `ClerkProvider`).
- Default header auth UX to **signed-out** until Clerk confirms a session: **Sign In** and **Get Started** render immediately with working links.
- **Keeps** #147’s client-only `ClerkProvider`, bundled `@clerk/ui`, `prefetchUI={false}`, and `/products` proxy gate — only `Header.tsx` changes (does not revert the provider wrapper).

## Test plan

- [ ] Signed out: homepage shows **Sign In** + **Get Started** immediately (no perpetual Loading).
- [ ] Click **Get Started** → `/sign-in?redirect_url=%2Fproducts`.
- [ ] Sign in → CTA switches to **Dashboard** linking to `/products`.
- [ ] Sign-in page still mounts Clerk UI (regression check for #147 SSR/bundle fix).
- [ ] Mobile menu: same behavior as desktop.