### PR TITLE
fix(frontend): restore Clerk SignIn on /sign-in

### DIFF
--- a/packages/frontend/app/layout.tsx
+++ b/packages/frontend/app/layout.tsx
@@ -105,7 +105,7 @@ export const metadata = {
 };
 
 export default function Layout(props: { children: React.ReactNode }) {
-  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? "";
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
   return (
     <html

--- a/packages/frontend/app/layout.tsx
+++ b/packages/frontend/app/layout.tsx
@@ -105,6 +105,8 @@ export const metadata = {
 };
 
 export default function Layout(props: { children: React.ReactNode }) {
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? "";
+
   return (
     <html
       lang="en"
@@ -150,7 +152,7 @@ export default function Layout(props: { children: React.ReactNode }) {
       </head>
       <body className="antialiased selection:bg-secondary/30">
         <div className="noise-overlay" />
-        <Provider>{props.children}</Provider>
+        <Provider publishableKey={publishableKey}>{props.children}</Provider>
       </body>
     </html>
   );

--- a/packages/frontend/app/provider.tsx
+++ b/packages/frontend/app/provider.tsx
@@ -1,27 +1,21 @@
 "use client";
 
 import { ThemeProvider } from "next-themes";
-import dynamic from "next/dynamic";
 
 import { ClerkProvider } from "@clerk/nextjs";
 import { ui } from "@clerk/ui";
 
-function AuthProvider(props: { children: React.ReactNode }) {
+export function Provider(props: {
+  children: React.ReactNode;
+  publishableKey: string;
+}) {
   return (
-    <ClerkProvider afterSignOutUrl="/" prefetchUI={false} ui={ui}>
-      {props.children}
-    </ClerkProvider>
-  );
-}
-
-// Load Clerk client-only so React mounts bundled @clerk/ui before SSR-injected clerk-js.
-const ClientAuthProvider = dynamic(() => Promise.resolve(AuthProvider), {
-  ssr: false,
-});
-
-export function Provider(props: { children: React.ReactNode }) {
-  return (
-    <ClientAuthProvider>
+    <ClerkProvider
+      publishableKey={props.publishableKey}
+      afterSignOutUrl="/"
+      prefetchUI={false}
+      ui={ui}
+    >
       <ThemeProvider
         attribute="class"
         defaultTheme="system"
@@ -30,6 +24,6 @@ export function Provider(props: { children: React.ReactNode }) {
       >
         {props.children}
       </ThemeProvider>
-    </ClientAuthProvider>
+    </ClerkProvider>
   );
 }

--- a/packages/frontend/app/provider.tsx
+++ b/packages/frontend/app/provider.tsx
@@ -7,7 +7,7 @@ import { ui } from "@clerk/ui";
 
 export function Provider(props: {
   children: React.ReactNode;
-  publishableKey: string;
+  publishableKey?: string;
 }) {
   return (
     <ClerkProvider


### PR DESCRIPTION
## Summary

- **Root cause:** Production JS bundles contain an empty `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (Railway did not inject it at Docker build time). Without a publishable key, Clerk never loads `clerk-js` and `<SignIn />` renders an empty container. PR #147 also regressed by wrapping `ClerkProvider` in `dynamic(..., { ssr: false })`, causing `BAILOUT_TO_CLIENT_SIDE_RENDERING` for the entire app shell.
- Pass `publishableKey` from the server `layout.tsx` into `ClerkProvider` so Railway runtime env works even when the key was missing at build time.
- Remove the `ClientAuthProvider` dynamic wrapper; keep bundled `@clerk/ui` with `prefetchUI={false}`.

## Test plan

- [ ] Merge and deploy to Railway with `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` set on the frontend service
- [ ] Visit https://clausea.co/sign-in — Clerk sign-in form (email/password, OAuth) renders
- [ ] View page source: `data-clerk-publishable-key` present on clerk-js script tag (not empty)
- [ ] No `BAILOUT_TO_CLIENT_SIDE_RENDERING` in HTML for Provider
- [ ] Sign in completes and redirects to `/products`
- [ ] Header auth CTA still works (Get Started / Dashboard)

## Railway / Clerk dashboard (required after merge)

1. **Railway frontend service** — set or verify:
   - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` = your Clerk publishable key (`pk_live_...` for production)
   - `CLERK_SECRET_KEY` = your Clerk secret key
   - `NEXT_PUBLIC_APP_URL` = `https://clausea.co` (apex, not `www`)
2. **Redeploy** the frontend service after setting vars (rebuild recommended so build-time inlining also has the key).
3. **Clerk dashboard** — allowed origins: `https://clausea.co`, `https://www.clausea.co`