### PR TITLE
Fix products page hiding backend fetch failures

### DIFF
--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -21,6 +21,7 @@ WHITELISTED_ROUTES = {
     "/health/startup",
     "/openapi.json",
     "/users/tier-limits",
+    "/products/stats",
     "/webhooks/paddle",
     "/contact",
     # Extension routes handle their own auth

--- a/packages/backend/tests/unit/core/middleware_test.py
+++ b/packages/backend/tests/unit/core/middleware_test.py
@@ -44,6 +44,7 @@ def _make_request(
 class TestWhitelisting:
     def test_whitelisted_routes_exist(self) -> None:
         assert "/health" in WHITELISTED_ROUTES
+        assert "/products/stats" in WHITELISTED_ROUTES
         assert "/docs" in WHITELISTED_ROUTES
         assert "/openapi.json" in WHITELISTED_ROUTES
         assert "/webhooks/paddle" in WHITELISTED_ROUTES
@@ -51,6 +52,10 @@ class TestWhitelisting:
 
     def test_whitelisted_route_detected(self, middleware: AuthMiddleware) -> None:
         request = _make_request(path="/health")
+        assert middleware._is_whitelisted(request) is True
+
+    def test_products_stats_whitelisted(self, middleware: AuthMiddleware) -> None:
+        request = _make_request(path="/products/stats")
         assert middleware._is_whitelisted(request) is True
 
     def test_non_whitelisted_route(self, middleware: AuthMiddleware) -> None:

--- a/packages/frontend/app/(dashboard)/products/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/page.tsx
@@ -1,23 +1,32 @@
-import { auth } from "@clerk/nextjs/server";
 import { getBackendUrl } from "@lib/config";
+import { httpJson } from "@lib/http";
 import { enrichLogos } from "@lib/logo";
+import { productsPageSchema } from "@lib/schemas";
 
 import { ProductsListClient, type ProductsPage } from "./products-list-client";
 
 const EMPTY_PAGE: ProductsPage = { items: [], total: 0, page: 1, pages: 1 };
 
-async function fetchInitialProducts(page: number): Promise<ProductsPage> {
+async function fetchInitialProducts(page: number): Promise<{
+  data: ProductsPage;
+  error: string | null;
+}> {
   try {
-    const { getToken } = await auth();
-    const token = await getToken();
     const params = new URLSearchParams({ page: String(page), limit: "20" });
-    const res = await fetch(getBackendUrl(`/products?${params.toString()}`), {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
-    if (!res.ok) return EMPTY_PAGE;
-    return enrichLogos((await res.json()) as ProductsPage);
-  } catch {
-    return EMPTY_PAGE;
+    const data = await httpJson(
+      getBackendUrl(`/products?${params.toString()}`),
+      {
+        method: "GET",
+        schema: productsPageSchema,
+      },
+    );
+    return { data: enrichLogos(data), error: null };
+  } catch (err) {
+    console.error("Failed to fetch initial products:", err);
+    return {
+      data: EMPTY_PAGE,
+      error: err instanceof Error ? err.message : "Failed to fetch products",
+    };
   }
 }
 
@@ -28,9 +37,15 @@ export default async function ProductsPage({
 }) {
   const { page } = await searchParams;
   const parsed = page ? Number.parseInt(page, 10) : 1;
-  const initialData = await fetchInitialProducts(
-    Number.isFinite(parsed) && parsed > 0 ? parsed : 1,
-  );
+  const { data: initialData, error: initialFetchError } =
+    await fetchInitialProducts(
+      Number.isFinite(parsed) && parsed > 0 ? parsed : 1,
+    );
 
-  return <ProductsListClient initialData={initialData} />;
+  return (
+    <ProductsListClient
+      initialData={initialData}
+      initialFetchError={initialFetchError}
+    />
+  );
 }

--- a/packages/frontend/app/(dashboard)/products/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/page.tsx
@@ -13,6 +13,7 @@ async function fetchInitialProducts(page: number): Promise<{
 }> {
   try {
     const params = new URLSearchParams({ page: String(page), limit: "20" });
+    // httpJson attaches the Clerk Bearer token server-side via lib/http.
     const data = await httpJson(
       getBackendUrl(`/products?${params.toString()}`),
       {
@@ -20,7 +21,7 @@ async function fetchInitialProducts(page: number): Promise<{
         schema: productsPageSchema,
       },
     );
-    return { data: enrichLogos(data), error: null };
+    return { data: enrichLogos(data) as ProductsPage, error: null };
   } catch (err) {
     console.error("Failed to fetch initial products:", err);
     return {

--- a/packages/frontend/app/(dashboard)/products/products-list-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/products-list-client.tsx
@@ -178,13 +178,15 @@ export function ProductsListClient({
   const { trackUserJourney, trackPageView } = useAnalytics();
 
   const [pageData, setPageData] = useState<ProductsPage>(initialData);
-  const [loading, setLoading] = useState(false);
-  const [initialLoad, setInitialLoad] = useState(false);
   const isFirstFetch = useRef(true);
-  const refetchEmptyCatalogOnMount = useRef(
-    !initialFetchError && initialData.total === 0,
+  const refetchOnMount = useRef(
+    initialData.total === 0 || Boolean(initialFetchError),
   );
-  const [error, setError] = useState<string | null>(initialFetchError);
+  const [loading, setLoading] = useState(refetchOnMount.current);
+  const [initialLoad, setInitialLoad] = useState(refetchOnMount.current);
+  const [error, setError] = useState<string | null>(
+    refetchOnMount.current ? null : initialFetchError,
+  );
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
 
@@ -227,11 +229,11 @@ export function ProductsListClient({
   }, [debouncedSearch, currentPage, searchParams, router]);
 
   // Fetch when page/search changes. Skip the first run when SSR already returned data;
-  // refetch immediately when the catalog is empty so client auth can recover from SSR misses.
+  // refetch on mount when the catalog is empty or SSR failed (client auth may recover).
   useEffect(() => {
     if (isFirstFetch.current) {
       isFirstFetch.current = false;
-      if (!refetchEmptyCatalogOnMount.current) return;
+      if (!refetchOnMount.current) return;
     }
     const controller = new AbortController();
     async function fetchProducts() {

--- a/packages/frontend/app/(dashboard)/products/products-list-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/products-list-client.tsx
@@ -166,8 +166,10 @@ export interface ProductsPage {
 
 export function ProductsListClient({
   initialData,
+  initialFetchError = null,
 }: {
   initialData: ProductsPage;
+  initialFetchError?: string | null;
 }) {
   const { user } = useUser();
   const router = useRouter();
@@ -179,7 +181,10 @@ export function ProductsListClient({
   const [loading, setLoading] = useState(false);
   const [initialLoad, setInitialLoad] = useState(false);
   const isFirstFetch = useRef(true);
-  const [error, setError] = useState<string | null>(null);
+  const refetchEmptyCatalogOnMount = useRef(
+    !initialFetchError && initialData.total === 0,
+  );
+  const [error, setError] = useState<string | null>(initialFetchError);
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
 
@@ -221,11 +226,12 @@ export function ProductsListClient({
     }
   }, [debouncedSearch, currentPage, searchParams, router]);
 
-  // Fetch when page/search changes; the initial page is server-rendered, so skip the first run.
+  // Fetch when page/search changes. Skip the first run when SSR already returned data;
+  // refetch immediately when the catalog is empty so client auth can recover from SSR misses.
   useEffect(() => {
     if (isFirstFetch.current) {
       isFirstFetch.current = false;
-      return;
+      if (!refetchEmptyCatalogOnMount.current) return;
     }
     const controller = new AbortController();
     async function fetchProducts() {


### PR DESCRIPTION
## Summary

- **Root cause**: Production backend (`https://api.clausea.co`) is returning **502**; the products SSR path treated any failed fetch as an empty catalog (`EMPTY_PAGE`), so logged-in users saw "Not analyzed yet" instead of an error. MongoDB has **130 products** — this is not a data/seed issue.
- **Frontend fix**: Use shared `httpJson` (Clerk `default` token template + schema validation) for SSR catalog load, propagate fetch errors to the client UI, and refetch on mount when SSR returns zero items (recovers SSR auth misses).
- **Backend fix**: Whitelist public `GET /products/stats` so the landing page hero count works without auth (was 401 when backend is healthy).

## Evidence

| Check | Result |
|-------|--------|
| `curl https://api.clausea.co/health` | **502** (Cloudflare) |
| `curl https://clausea.co/api/products` | **500** `{"error":"Failed to fetch products"}` |
| MongoDB `products` collection | **130 documents** (Spotify, Reddit, …) |
| Old `page.tsx` behavior | `if (!res.ok) return EMPTY_PAGE` — silent empty state |

## Ops steps (required for products to appear)

1. **Restore backend service** on Railway — `api.clausea.co` must respond to `/health` with 200.
2. Verify frontend env: `BACKEND_BASE_URL=https://api.clausea.co` (or `${{api.RAILWAY_PUBLIC_DOMAIN}}`).
3. After backend is healthy, redeploy frontend with this PR so failures surface clearly instead of masquerading as an empty catalog.

## Test plan

- [x] `uv run pytest tests/unit/core/middleware_test.py`
- [x] `bun run lint` (frontend)
- [ ] After backend restore: sign in at clausea.co → `/products` shows catalog (~130 services)
- [ ] With backend down: `/products` shows **Error Loading Products**, not empty state
- [ ] Landing page hero shows analyzed count once `/products/stats` is reachable