### PR TITLE
fix(backend): bind API to Railway PORT to resolve 502

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -93,8 +93,9 @@ COPY . .
 # Cap glibc arenas so freed memory returns to the OS instead of being hoarded per thread.
 ENV MALLOC_ARENA_MAX=2
 
+# Informational for local `docker run -p 8000:8000`; Railway routes via $PORT (often 8080).
 EXPOSE 8000
 
 # Shell wrapper so Railway's $PORT is honored when no startCommand override is set.
 # uvicorn remains PID 1 for clean SIGTERM handling.
-CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "echo \"Binding uvicorn to 0.0.0.0:${PORT:-8000}\" && exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/packages/backend/Dockerfile.worker
+++ b/packages/backend/Dockerfile.worker
@@ -99,6 +99,7 @@ COPY . .
 # Cap glibc arenas so freed memory returns to the OS instead of being hoarded per thread.
 ENV MALLOC_ARENA_MAX=2
 
+# Informational for local smoke tests; Railway routes via $PORT (often 8080).
 EXPOSE 8000
 
 # Exec form: worker runs as PID 1 so Railway's SIGTERM is delivered directly.

--- a/packages/backend/docs/RAILWAY.md
+++ b/packages/backend/docs/RAILWAY.md
@@ -41,6 +41,9 @@ Only one `railway.toml` can live at the service root (`packages/backend`). **Eve
 | Builder        | Dockerfile (from `railway.toml`)                |
 | Start command  | *(empty — image CMD binds `${PORT}` via shell)* |
 | Health check   | `/health`                                       |
+| **Port**       | *(leave unset — Railway injects `$PORT` automatically)* |
+
+> **502 / port mismatch:** Railway assigns `$PORT` at runtime (commonly `8080`, not `8000`). The app **must** listen on that value. If deploy logs show `Uvicorn running on http://0.0.0.0:8000` while Railway sets `PORT=8080`, the public domain returns **502 Bad Gateway**. Fix: clear any dashboard **Start Command** override, redeploy the latest image (Dockerfile CMD uses `${PORT:-8000}`), and **do not** set a manual `PORT=8000` variable on the service.
 
 `railway.toml` sets `watchPatterns = ["packages/backend/**"]` so monorepo pushes only redeploy when backend files change.
 
@@ -128,7 +131,7 @@ Set variables on the **API** and **worker** services (share via Railway shared v
 | `SERVICE_API_KEY`  | Service-to-service auth (Streamlit → API)        |
 | `CRAWLER_*`        | Crawler tuning (see `src/core/config.py`)        |
 
-Railway sets `PORT` automatically — do not hardcode it. **Do not** set `startCommand` in shared `railway.toml`: Railway passes it to the process without shell expansion, so `--port $PORT` becomes the literal string `$PORT` and uvicorn crashloops. Each service Dockerfile CMD uses `sh -c` with `${PORT:-8000}` instead.
+Railway sets `PORT` automatically — do not hardcode it and **do not** override `PORT` in service variables unless debugging locally. **Do not** set `startCommand` in shared `railway.toml` or the Railway dashboard: Railway passes it to uvicorn without shell expansion, so `--port $PORT` becomes the literal string `$PORT` and uvicorn crashloops. A dashboard start command of `--port 8000` causes the same 502 when Railway assigns a different port. Each service Dockerfile CMD uses `sh -c` with `${PORT:-8000}` instead.
 
 ### Wiring frontend to API
 
@@ -185,6 +188,7 @@ curl http://localhost:8000/health
 
 | Symptom                      | Fix                                                                 |
 | ---------------------------- | ------------------------------------------------------------------- |
+| **502 Bad Gateway** on `api.clausea.co` | Deploy logs show uvicorn on `:8000` but Railway `PORT=8080` (or vice versa). Clear **Deploy → Start Command**, remove manual `PORT=8000` env var, redeploy. Confirm log line `Binding uvicorn to 0.0.0.0:8080` matches Railway's `$PORT`. |
 | **"N/N replicas never became healthy"** + `/health` + `service unavailable`, build uses `Dockerfile` not `Dockerfile.worker` | **Worker misconfiguration.** Set Dockerfile to `Dockerfile.worker`, clear start command (no uvicorn). Reduce replicas to 1 until deploy passes. Not a MongoDB issue. |
 | Worker deploy OK but runs API instead of crawls | Dockerfile path still `Dockerfile` (uvicorn CMD). Set `Dockerfile.worker` and clear start command. |
 | API health check fails       | Deploy logs show `Invalid value for '--port': '$PORT'` → remove `startCommand` from `railway.toml` / dashboard; use Dockerfile CMD with `${PORT}`. `/health` is liveness-only. Check `MONGO_URI` for `/health/ready`. |

--- a/packages/backend/docs/SERVICE_ARCHITECTURE.md
+++ b/packages/backend/docs/SERVICE_ARCHITECTURE.md
@@ -209,20 +209,15 @@
 ### FastAPI Service
 
 ```toml
-# railway.toml (or Railway dashboard settings)
+# railway.toml (API service — see docs/RAILWAY.md for worker/streamlit overrides)
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "uv run uvicorn main:app --host 0.0.0.0 --port $PORT"
+# Do NOT set startCommand — use Dockerfile CMD with ${PORT:-8000}
 healthcheckPath = "/health"
 healthcheckTimeout = 100
-
-# Resource limits
-[resources]
-memory = 512  # MB
-cpu = 0.5     # vCPU
 ```
 
 ### Streamlit Service

--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -161,4 +161,4 @@ for route in routes:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=config.app.port)


### PR DESCRIPTION
## What this PR does

Hardens backend deployment so the API listens on Railway's dynamically assigned `$PORT` (commonly `8080`) instead of a hardcoded `8000`, which was causing **502 Bad Gateway** on `api.clausea.co`.

## Why

Railway injects `$PORT` at runtime and routes public traffic to that port. The original API Dockerfile used `--port 8000` in CMD, and `railway.toml` had a `startCommand` with unexpanded `$PORT`. When Railway assigned `PORT=8080`, the proxy could not reach the app on the expected port.

PR #146 already moved binding to `${PORT:-8000}` in the Dockerfile CMD and removed `startCommand` from `railway.toml`. This PR adds deploy-log visibility, fixes the remaining hardcoded port in `main.py`, and documents the Railway dashboard cleanup required after deploy.

## Changes made

- `packages/backend/Dockerfile` — log the bind port at startup for deploy log verification
- `packages/backend/main.py` — use `config.app.port` (reads `PORT` env) for local `python main.py` runs
- `packages/backend/docs/RAILWAY.md` — 502/port mismatch troubleshooting and dashboard checklist
- `packages/backend/docs/SERVICE_ARCHITECTURE.md` — remove outdated `startCommand` example
- `packages/backend/Dockerfile.worker` — clarify EXPOSE is local-only

## Railway ops (after merge)

On the **API** service in Railway dashboard:

1. **Deploy → Start Command** — clear/empty (must not override Dockerfile CMD)
2. **Variables** — remove any manual `PORT=8000` override (Railway sets `$PORT` automatically)
3. Redeploy and confirm deploy logs show: `Binding uvicorn to 0.0.0.0:8080` (or whatever `$PORT` Railway assigns)
4. Verify: `curl https://api.clausea.co/health`

No manual "target port" setting is needed in Railway networking — it follows `$PORT`.

## Frontend

`BACKEND_BASE_URL=https://api.clausea.co` is correct and unrelated to container port binding (public URL, not internal port).

## How to test

- [ ] `docker build -t clausea-api packages/backend && docker run --rm -p 8080:8080 -e PORT=8080 clausea-api` → `curl http://localhost:8080/health` returns 200
- [ ] Deploy logs show bind port matches `$PORT`
- [ ] `https://api.clausea.co/health` returns 200 after Railway redeploy + dashboard cleanup
- [ ] Edge case: dashboard start command `--port 8000` still causes 502 — confirm it is cleared