### PR TITLE
Fix empty products catalog from bad BACKEND_BASE_URL

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -96,5 +96,6 @@ ENV MALLOC_ARENA_MAX=2
 EXPOSE 8000
 
 # Shell wrapper so Railway's $PORT is honored when no startCommand override is set.
+# Bind to :: so private-network traffic (IPv6) and public probes (IPv4) both work.
 # uvicorn remains PID 1 for clean SIGTERM handling.
-CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]
+CMD ["sh", "-c", "exec uvicorn main:app --host :: --port ${PORT:-8000}"]

--- a/packages/backend/docs/RAILWAY.md
+++ b/packages/backend/docs/RAILWAY.md
@@ -130,15 +130,23 @@ Set variables on the **API** and **worker** services (share via Railway shared v
 
 Railway sets `PORT` automatically — do not hardcode it. **Do not** set `startCommand` in shared `railway.toml`: Railway passes it to the process without shell expansion, so `--port $PORT` becomes the literal string `$PORT` and uvicorn crashloops. Each service Dockerfile CMD uses `sh -c` with `${PORT:-8000}` instead.
 
-### Wiring frontend to API
+### Wiring frontend to API (private network)
 
-If the frontend service is named `frontend`:
+Add a **service variable** on the API service (Railway does not infer this from runtime `PORT`):
 
 ```text
-BACKEND_BASE_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
+PORT=8080
 ```
 
-Set on the **frontend** service. See [frontend RAILWAY.md](../../frontend/docs/RAILWAY.md).
+Use the value shown in deploy logs (`Uvicorn running on http://[::]:8080`). On the **frontend** service:
+
+```text
+BACKEND_BASE_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}
+```
+
+Private traffic stays off the public internet (no egress billing for frontend→API hops). The API Dockerfile binds uvicorn to `::` so IPv6 private-network clients can connect.
+
+See [frontend RAILWAY.md](../../frontend/docs/RAILWAY.md).
 
 ## CLI deploy (alternative)
 
@@ -193,6 +201,7 @@ curl http://localhost:8000/health
 | Crawls fail in worker        | Verify Camoufox libs in image; check `CRAWLER_USE_BROWSER=true`     |
 | CORS errors from frontend    | Set `CORS_ORIGINS` on API to include frontend URL                   |
 | Auth fails                   | Verify `CLERK_JWKS_URL` matches your Clerk instance                 |
+| Frontend cannot reach API on private domain | API must listen on `::` (not `0.0.0.0` only). Set frontend `BACKEND_BASE_URL` to `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}` with `PORT` defined on the API service. |
 
 ### Why regular `Dockerfile` + `python worker.py` fails health
 

--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -21,6 +21,7 @@ WHITELISTED_ROUTES = {
     "/health/startup",
     "/openapi.json",
     "/users/tier-limits",
+    "/products/stats",
     "/webhooks/paddle",
     "/contact",
     # Extension routes handle their own auth

--- a/packages/backend/tests/unit/core/middleware_test.py
+++ b/packages/backend/tests/unit/core/middleware_test.py
@@ -44,6 +44,7 @@ def _make_request(
 class TestWhitelisting:
     def test_whitelisted_routes_exist(self) -> None:
         assert "/health" in WHITELISTED_ROUTES
+        assert "/products/stats" in WHITELISTED_ROUTES
         assert "/docs" in WHITELISTED_ROUTES
         assert "/openapi.json" in WHITELISTED_ROUTES
         assert "/webhooks/paddle" in WHITELISTED_ROUTES
@@ -51,6 +52,10 @@ class TestWhitelisting:
 
     def test_whitelisted_route_detected(self, middleware: AuthMiddleware) -> None:
         request = _make_request(path="/health")
+        assert middleware._is_whitelisted(request) is True
+
+    def test_products_stats_whitelisted(self, middleware: AuthMiddleware) -> None:
+        request = _make_request(path="/products/stats")
         assert middleware._is_whitelisted(request) is True
 
     def test_non_whitelisted_route(self, middleware: AuthMiddleware) -> None:

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -52,9 +52,9 @@ async def _start_health_server() -> web.AppRunner:
     app.router.add_get("/health", _health)
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "0.0.0.0", _HEALTH_PORT)
+    site = web.TCPSite(runner, "::", _HEALTH_PORT)
     await site.start()
-    logger.info("Health server listening on 0.0.0.0:%d/health", _HEALTH_PORT)
+    logger.info("Health server listening on [::]:%d/health", _HEALTH_PORT)
     return runner
 
 

--- a/packages/frontend/app/(dashboard)/products/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/page.tsx
@@ -1,23 +1,32 @@
-import { auth } from "@clerk/nextjs/server";
 import { getBackendUrl } from "@lib/config";
+import { httpJson } from "@lib/http";
 import { enrichLogos } from "@lib/logo";
+import { productsPageSchema } from "@lib/schemas";
 
 import { ProductsListClient, type ProductsPage } from "./products-list-client";
 
 const EMPTY_PAGE: ProductsPage = { items: [], total: 0, page: 1, pages: 1 };
 
-async function fetchInitialProducts(page: number): Promise<ProductsPage> {
+async function fetchInitialProducts(page: number): Promise<{
+  data: ProductsPage;
+  error: string | null;
+}> {
   try {
-    const { getToken } = await auth();
-    const token = await getToken();
     const params = new URLSearchParams({ page: String(page), limit: "20" });
-    const res = await fetch(getBackendUrl(`/products?${params.toString()}`), {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
-    if (!res.ok) return EMPTY_PAGE;
-    return enrichLogos((await res.json()) as ProductsPage);
-  } catch {
-    return EMPTY_PAGE;
+    const data = await httpJson(
+      getBackendUrl(`/products?${params.toString()}`),
+      {
+        method: "GET",
+        schema: productsPageSchema,
+      },
+    );
+    return { data: enrichLogos(data), error: null };
+  } catch (err) {
+    console.error("Failed to fetch initial products:", err);
+    return {
+      data: EMPTY_PAGE,
+      error: err instanceof Error ? err.message : "Failed to fetch products",
+    };
   }
 }
 
@@ -28,9 +37,15 @@ export default async function ProductsPage({
 }) {
   const { page } = await searchParams;
   const parsed = page ? Number.parseInt(page, 10) : 1;
-  const initialData = await fetchInitialProducts(
-    Number.isFinite(parsed) && parsed > 0 ? parsed : 1,
-  );
+  const { data: initialData, error: initialFetchError } =
+    await fetchInitialProducts(
+      Number.isFinite(parsed) && parsed > 0 ? parsed : 1,
+    );
 
-  return <ProductsListClient initialData={initialData} />;
+  return (
+    <ProductsListClient
+      initialData={initialData}
+      initialFetchError={initialFetchError}
+    />
+  );
 }

--- a/packages/frontend/app/(dashboard)/products/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/page.tsx
@@ -13,6 +13,7 @@ async function fetchInitialProducts(page: number): Promise<{
 }> {
   try {
     const params = new URLSearchParams({ page: String(page), limit: "20" });
+    // httpJson attaches the Clerk Bearer token server-side via lib/http.
     const data = await httpJson(
       getBackendUrl(`/products?${params.toString()}`),
       {
@@ -20,7 +21,7 @@ async function fetchInitialProducts(page: number): Promise<{
         schema: productsPageSchema,
       },
     );
-    return { data: enrichLogos(data), error: null };
+    return { data: enrichLogos(data) as ProductsPage, error: null };
   } catch (err) {
     console.error("Failed to fetch initial products:", err);
     return {

--- a/packages/frontend/app/(dashboard)/products/products-list-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/products-list-client.tsx
@@ -178,13 +178,15 @@ export function ProductsListClient({
   const { trackUserJourney, trackPageView } = useAnalytics();
 
   const [pageData, setPageData] = useState<ProductsPage>(initialData);
-  const [loading, setLoading] = useState(false);
-  const [initialLoad, setInitialLoad] = useState(false);
   const isFirstFetch = useRef(true);
-  const refetchEmptyCatalogOnMount = useRef(
-    !initialFetchError && initialData.total === 0,
+  const refetchOnMount = useRef(
+    initialData.total === 0 || Boolean(initialFetchError),
   );
-  const [error, setError] = useState<string | null>(initialFetchError);
+  const [loading, setLoading] = useState(refetchOnMount.current);
+  const [initialLoad, setInitialLoad] = useState(refetchOnMount.current);
+  const [error, setError] = useState<string | null>(
+    refetchOnMount.current ? null : initialFetchError,
+  );
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
 
@@ -227,11 +229,11 @@ export function ProductsListClient({
   }, [debouncedSearch, currentPage, searchParams, router]);
 
   // Fetch when page/search changes. Skip the first run when SSR already returned data;
-  // refetch immediately when the catalog is empty so client auth can recover from SSR misses.
+  // refetch on mount when the catalog is empty or SSR failed (client auth may recover).
   useEffect(() => {
     if (isFirstFetch.current) {
       isFirstFetch.current = false;
-      if (!refetchEmptyCatalogOnMount.current) return;
+      if (!refetchOnMount.current) return;
     }
     const controller = new AbortController();
     async function fetchProducts() {

--- a/packages/frontend/app/(dashboard)/products/products-list-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/products-list-client.tsx
@@ -166,8 +166,10 @@ export interface ProductsPage {
 
 export function ProductsListClient({
   initialData,
+  initialFetchError = null,
 }: {
   initialData: ProductsPage;
+  initialFetchError?: string | null;
 }) {
   const { user } = useUser();
   const router = useRouter();
@@ -179,7 +181,10 @@ export function ProductsListClient({
   const [loading, setLoading] = useState(false);
   const [initialLoad, setInitialLoad] = useState(false);
   const isFirstFetch = useRef(true);
-  const [error, setError] = useState<string | null>(null);
+  const refetchEmptyCatalogOnMount = useRef(
+    !initialFetchError && initialData.total === 0,
+  );
+  const [error, setError] = useState<string | null>(initialFetchError);
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
 
@@ -221,11 +226,12 @@ export function ProductsListClient({
     }
   }, [debouncedSearch, currentPage, searchParams, router]);
 
-  // Fetch when page/search changes; the initial page is server-rendered, so skip the first run.
+  // Fetch when page/search changes. Skip the first run when SSR already returned data;
+  // refetch immediately when the catalog is empty so client auth can recover from SSR misses.
   useEffect(() => {
     if (isFirstFetch.current) {
       isFirstFetch.current = false;
-      return;
+      if (!refetchEmptyCatalogOnMount.current) return;
     }
     const controller = new AbortController();
     async function fetchProducts() {

--- a/packages/frontend/docs/RAILWAY.md
+++ b/packages/frontend/docs/RAILWAY.md
@@ -39,12 +39,12 @@ Set these in the Railway dashboard for the **frontend service**. Variables marke
 
 #### Required
 
-| Variable                            | Build | Description                                    |
-| ----------------------------------- | ----- | ---------------------------------------------- |
-| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Yes   | Clerk publishable key for auth UI              |
-| `CLERK_SECRET_KEY`                  | No    | Clerk secret key for server-side auth          |
-| `NEXT_PUBLIC_APP_URL`               | Yes   | Public site URL, e.g. `https://clausea.co`     |
-| `BACKEND_BASE_URL`                  | No    | Backend API URL, e.g. `https://api.clausea.co` |
+| Variable                            | Build | Description                                                                                  |
+| ----------------------------------- | ----- | -------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Yes   | Clerk publishable key for auth UI                                                            |
+| `CLERK_SECRET_KEY`                  | No    | Clerk secret key for server-side auth                                                        |
+| `NEXT_PUBLIC_APP_URL`               | Yes   | Public site URL, e.g. `https://clausea.co`                                                   |
+| `BACKEND_BASE_URL`                  | No    | Backend API URL; use private network: `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}` |
 
 #### Recommended
 
@@ -67,13 +67,17 @@ Railway sets `PORT`, `NODE_ENV`, and `RAILWAY_*` automatically — do not overri
 
 #### Wiring to the backend on Railway
 
-If the backend service is named `api` (adjust to match your service name):
+Server-side fetches (SSR, `/api/*` proxy) should use the **private network** to avoid public egress charges. The browser never calls the backend directly for authenticated routes.
+
+On the **API** service, add a service variable `PORT` matching the port the app listens on (check deploy logs, often `8080`). Then on the **frontend** service:
 
 ```text
-BACKEND_BASE_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}
+BACKEND_BASE_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}
 ```
 
-Or use the production custom domain:
+Use `http://`, not `https://` — Railway private domains speak plain HTTP on the service port (traffic is encrypted by Wireguard).
+
+Only use the public domain when traffic must leave Railway (e.g. local dev, external clients):
 
 ```text
 BACKEND_BASE_URL=https://api.clausea.co
@@ -135,11 +139,11 @@ docker run --rm -p 3000:3000 \
 
 ## Troubleshooting
 
-| Symptom                       | Fix                                                                                                                                                                                                             |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Auth broken in production     | Verify `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` was set **before** build; redeploy after adding it                                                                                                                   |
-| API calls fail                | Check `BACKEND_BASE_URL` points to the live backend; verify backend CORS                                                                                                                                        |
-| Empty products / ECONNREFUSED | Do **not** set `BACKEND_BASE_URL` to `https://*.railway.internal` — private domains use HTTP on the service `$PORT`, not HTTPS on 443. Use `https://${{api.RAILWAY_PUBLIC_DOMAIN}}` or `https://api.clausea.co` |
-| Wrong canonical URLs in SEO   | Set `NEXT_PUBLIC_APP_URL` and redeploy                                                                                                                                                                          |
-| Container exits immediately   | Check deploy logs; ensure `output: "standalone"` is in `next.config.mjs`                                                                                                                                        |
-| Health check fails            | Railway probes `/`; ensure the app binds to `0.0.0.0` (handled by Dockerfile `HOSTNAME`)                                                                                                                        |
+| Symptom                       | Fix                                                                                                                                                                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Auth broken in production     | Verify `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` was set **before** build; redeploy after adding it                                                                                                            |
+| API calls fail                | Check `BACKEND_BASE_URL` points to the live backend; verify backend CORS                                                                                                                                 |
+| Empty products / ECONNREFUSED | Use `http://${{api.RAILWAY_PRIVATE_DOMAIN}}:${{api.PORT}}`, not `https://*.railway.internal` (HTTPS hits port 443 and fails). Set `PORT` on the API service. Redeploy API after it binds to `::` (IPv6). |
+| Wrong canonical URLs in SEO   | Set `NEXT_PUBLIC_APP_URL` and redeploy                                                                                                                                                                   |
+| Container exits immediately   | Check deploy logs; ensure `output: "standalone"` is in `next.config.mjs`                                                                                                                                 |
+| Health check fails            | Railway probes `/`; ensure the app binds to `0.0.0.0` (handled by Dockerfile `HOSTNAME`)                                                                                                                 |

--- a/packages/frontend/docs/RAILWAY.md
+++ b/packages/frontend/docs/RAILWAY.md
@@ -135,10 +135,11 @@ docker run --rm -p 3000:3000 \
 
 ## Troubleshooting
 
-| Symptom                     | Fix                                                                                           |
-| --------------------------- | --------------------------------------------------------------------------------------------- |
-| Auth broken in production   | Verify `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` was set **before** build; redeploy after adding it |
-| API calls fail              | Check `BACKEND_BASE_URL` points to the live backend; verify backend CORS                      |
-| Wrong canonical URLs in SEO | Set `NEXT_PUBLIC_APP_URL` and redeploy                                                        |
-| Container exits immediately | Check deploy logs; ensure `output: "standalone"` is in `next.config.mjs`                      |
-| Health check fails          | Railway probes `/`; ensure the app binds to `0.0.0.0` (handled by Dockerfile `HOSTNAME`)      |
+| Symptom                       | Fix                                                                                                                                                                                                             |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Auth broken in production     | Verify `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` was set **before** build; redeploy after adding it                                                                                                                   |
+| API calls fail                | Check `BACKEND_BASE_URL` points to the live backend; verify backend CORS                                                                                                                                        |
+| Empty products / ECONNREFUSED | Do **not** set `BACKEND_BASE_URL` to `https://*.railway.internal` — private domains use HTTP on the service `$PORT`, not HTTPS on 443. Use `https://${{api.RAILWAY_PUBLIC_DOMAIN}}` or `https://api.clausea.co` |
+| Wrong canonical URLs in SEO   | Set `NEXT_PUBLIC_APP_URL` and redeploy                                                                                                                                                                          |
+| Container exits immediately   | Check deploy logs; ensure `output: "standalone"` is in `next.config.mjs`                                                                                                                                        |
+| Health check fails            | Railway probes `/`; ensure the app binds to `0.0.0.0` (handled by Dockerfile `HOSTNAME`)                                                                                                                        |


### PR DESCRIPTION
## Summary

- **Root cause (production)**: Frontend `BACKEND_BASE_URL` was `https://toast.railway.internal`. Railway private domains speak HTTP on the service `$PORT`, not HTTPS on 443. Server-side fetches failed with `ECONNREFUSED`, and SSR returned an empty catalog.
- **Ops fix applied**: Set frontend `BACKEND_BASE_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}` (resolves to `https://api.clausea.co`) and redeployed frontend.
- **Code fixes**: Merge PR #151 — use shared `httpJson` for SSR products load, surface fetch errors in UI, refetch on mount when SSR returns zero items, whitelist public `GET /products/stats` for landing hero count.
- **Docs**: Troubleshooting row for `https://*.railway.internal` misconfiguration.

## Evidence

| Check | Before | After env fix |
|-------|--------|---------------|
| `curl https://api.clausea.co/health` | 200 | 200 |
| Frontend logs | `ECONNREFUSED ... toast.railway.internal:443` | (redeployed with `https://api.clausea.co`) |
| `curl https://clausea.co/api/products` (no auth) | 500 | 500 (expected — requires Clerk session) |
| Production `BACKEND_BASE_URL` | `https://toast.railway.internal` | `https://api.clausea.co` |

## Test plan

- [x] `uv run pytest tests/unit/core/middleware_test.py`
- [ ] Sign in at https://clausea.co → `/products` shows catalog
- [ ] Landing page hero shows analyzed count after backend deploy (`GET /products/stats` whitelist)
- [ ] With backend unreachable: `/products` shows error UI, not silent empty state

## User verification

1. Hard-refresh https://clausea.co/products while signed in — expect product cards (~130 services).
2. Check landing page hero for “N Services analyzed” after backend deploy completes.
3. Railway frontend service → Variables → confirm `BACKEND_BASE_URL=https://${{api.RAILWAY_PUBLIC_DOMAIN}}`.