### PR TITLE
Allow unauthenticated access to public product pages

### DIFF
--- a/packages/backend/src/core/db_indexes.py
+++ b/packages/backend/src/core/db_indexes.py
@@ -501,4 +501,56 @@ async def ensure_all_indexes(db: AgnosticDatabase) -> None:
         else:
             logger.warning(f"Could not create unique index on extension_anonymous_usage.token: {e}")
 
+    # Product preview anonymous usage tracking
+    try:
+        await db.product_preview_usage.create_index(
+            "last_seen",
+            expireAfterSeconds=60 * 60 * 24 * 30,
+            name="ttl_product_preview_usage_30d",
+            background=True,
+        )
+        logger.info("Created TTL index on product_preview_usage.last_seen")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "already exists" in error_msg:
+            logger.debug("TTL index on product_preview_usage.last_seen already exists")
+        else:
+            logger.warning(f"Could not create TTL index on product_preview_usage.last_seen: {e}")
+
+    try:
+        await db.product_preview_usage.create_index(
+            "token",
+            unique=True,
+            sparse=True,
+            name="idx_product_preview_usage_token",
+            background=True,
+        )
+        logger.info("Created unique sparse index on product_preview_usage.token")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "already exists" in error_msg or "duplicate key" in error_msg:
+            logger.debug(
+                "Unique index on product_preview_usage.token already exists or has duplicate values"
+            )
+        else:
+            logger.warning(f"Could not create unique index on product_preview_usage.token: {e}")
+
+    try:
+        await db.product_preview_usage.create_index(
+            "ip",
+            unique=True,
+            partialFilterExpression={"token": {"$exists": False}},
+            name="idx_product_preview_usage_ip",
+            background=True,
+        )
+        logger.info("Created unique partial index on product_preview_usage.ip")
+    except Exception as e:
+        error_msg = str(e).lower()
+        if "already exists" in error_msg or "duplicate key" in error_msg:
+            logger.debug(
+                "Unique index on product_preview_usage.ip already exists or has duplicate values"
+            )
+        else:
+            logger.warning(f"Could not create unique index on product_preview_usage.ip: {e}")
+
     logger.info("Database indexes verified")

--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -34,7 +34,11 @@ WHITELISTED_ROUTES = {
 
 # Public GET routes for product detail pages (shared links, crawlers, incognito).
 _PUBLIC_PRODUCT_GET_RE = re.compile(
-    r"^/products/(?:sitemap|[A-Za-z0-9][A-Za-z0-9_-]*(?:/(?:overview|documents|explainer|topics))?)$"
+    r"^/products/(?:"
+    r"sitemap|"
+    r"[A-Za-z0-9][A-Za-z0-9_-]*"
+    r"(?:/(?:overview|explainer|topics|documents(?:/[A-Za-z0-9][A-Za-z0-9_-]*/(?:extraction|deep-analysis))?))?"
+    r")$"
 )
 
 # Localhost addresses that are considered safe for development

--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -30,6 +31,11 @@ WHITELISTED_ROUTES = {
     "/extension/subscribe",
     "/extension/domains",
 }
+
+# Public GET routes for product detail pages (shared links, crawlers, incognito).
+_PUBLIC_PRODUCT_GET_RE = re.compile(
+    r"^/products/(?:sitemap|[A-Za-z0-9][A-Za-z0-9_-]*(?:/(?:overview|documents|explainer|topics))?)$"
+)
 
 # Localhost addresses that are considered safe for development
 LOCALHOST_ADDRESSES = ("127.0.0.1", "localhost", "::1")
@@ -69,11 +75,13 @@ class AuthMiddleware(BaseHTTPMiddleware):
     def _is_whitelisted(self, request: Request) -> bool:
         """Check if the request path is whitelisted"""
         path = request.url.path
-        return (
-            path in WHITELISTED_ROUTES
-            or path.startswith("/extension/status/")
-            or request.method == "OPTIONS"
-        )
+        if path in WHITELISTED_ROUTES or path.startswith("/extension/status/"):
+            return True
+        if request.method == "OPTIONS":
+            return True
+        if request.method == "GET" and _PUBLIC_PRODUCT_GET_RE.match(path):
+            return True
+        return False
 
     async def _authenticate(self, request: Request) -> dict[str, Any] | None:
         """Try to authenticate the request using available methods"""

--- a/packages/backend/src/core/tier_deps.py
+++ b/packages/backend/src/core/tier_deps.py
@@ -43,12 +43,16 @@ async def check_usage_limit(
     request: Request,
     db: AgnosticDatabase = Depends(get_db),
 ) -> None:
-    """Dependency that enforces monthly usage limits per tier. Unauthenticated → HTTP 401."""
+    """Dependency that enforces monthly usage limits per tier for signed-in users.
+
+    Anonymous reads are allowed so public product pages work in incognito; the
+    frontend meters page views via the __pv cookie before prompting sign-in.
+    """
     user_id = _get_user_id(request)
     if user_id in _BYPASS_USER_IDS:
         return
     if user_id is None:
-        raise HTTPException(status_code=401, detail="Authentication required.")
+        return
 
     allowed, _ = await UsageService.check_usage_limit(db, user_id)
     if not allowed:

--- a/packages/backend/src/core/tier_deps.py
+++ b/packages/backend/src/core/tier_deps.py
@@ -20,7 +20,10 @@ _CRAWLER_UA_RE = re.compile(
     re.IGNORECASE,
 )
 _METERED_PRODUCT_GET_RE = re.compile(
-    r"^/products/(?:[A-Za-z0-9][A-Za-z0-9_-]*(?:/(?:overview|documents|explainer|topics))?)$"
+    r"^/products/(?:"
+    r"[A-Za-z0-9][A-Za-z0-9_-]*"
+    r"(?:/(?:overview|explainer|topics|documents(?:/[A-Za-z0-9][A-Za-z0-9_-]*/(?:extraction|deep-analysis))?))?"
+    r")$"
 )
 _preview_usage_svc = ProductPreviewUsageService()
 

--- a/packages/backend/src/core/tier_deps.py
+++ b/packages/backend/src/core/tier_deps.py
@@ -2,15 +2,27 @@
 
 from __future__ import annotations
 
+import re
+
 from fastapi import Depends, HTTPException, Request
 from motor.core import AgnosticDatabase
 
 from src.core.database import get_db
 from src.models.user import UserTier
+from src.services.product_preview_usage import ProductPreviewUsageService
 from src.services.service_factory import create_user_service
 from src.services.usage_service import UsageService
 
 _BYPASS_USER_IDS = {"localhost_dev", "service_account"}
+_CRAWLER_UA_RE = re.compile(
+    r"bot|crawl|spider|facebookexternalhit|Slackbot|Twitterbot|WhatsApp|"
+    r"TelegramBot|LinkedInBot|discordbot|Applebot|preview|embed",
+    re.IGNORECASE,
+)
+_METERED_PRODUCT_GET_RE = re.compile(
+    r"^/products/(?:[A-Za-z0-9][A-Za-z0-9_-]*(?:/(?:overview|documents|explainer|topics))?)$"
+)
+_preview_usage_svc = ProductPreviewUsageService()
 
 
 def _get_user_id(request: Request) -> str | None:
@@ -18,6 +30,24 @@ def _get_user_id(request: Request) -> str | None:
     if user and isinstance(user, dict):
         return user.get("user_id")
     return None
+
+
+def _get_client_ip(request: Request) -> str:
+    return request.client.host if request.client else "unknown"
+
+
+def _is_crawler_request(request: Request) -> bool:
+    user_agent = request.headers.get("user-agent", "")
+    return bool(_CRAWLER_UA_RE.search(user_agent))
+
+
+def _is_metered_product_get(request: Request) -> bool:
+    return request.method == "GET" and bool(_METERED_PRODUCT_GET_RE.match(request.url.path))
+
+
+def _should_increment_preview(request: Request) -> bool:
+    """Count one preview view per page load (overview is the primary content gate)."""
+    return request.url.path.endswith("/overview")
 
 
 async def require_pro(
@@ -43,15 +73,28 @@ async def check_usage_limit(
     request: Request,
     db: AgnosticDatabase = Depends(get_db),
 ) -> None:
-    """Dependency that enforces monthly usage limits per tier for signed-in users.
-
-    Anonymous reads are allowed so public product pages work in incognito; the
-    frontend meters page views via the __pv cookie before prompting sign-in.
-    """
+    """Dependency that enforces usage limits for signed-in and anonymous users."""
     user_id = _get_user_id(request)
     if user_id in _BYPASS_USER_IDS:
         return
+
     if user_id is None:
+        if not _is_metered_product_get(request) or _is_crawler_request(request):
+            return
+
+        preview_token = request.headers.get("X-Preview-Token", "").strip() or None
+        client_ip = _get_client_ip(request)
+        allowed, _ = await _preview_usage_svc.check_and_increment(
+            db,
+            token=preview_token,
+            ip=client_ip,
+            increment=_should_increment_preview(request),
+        )
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail="Free preview limit reached. Sign in for unlimited access.",
+            )
         return
 
     allowed, _ = await UsageService.check_usage_limit(db, user_id)

--- a/packages/backend/src/routes/products.py
+++ b/packages/backend/src/routes/products.py
@@ -276,6 +276,7 @@ async def get_product_analysis(
 @router.get("/{slug}/documents", response_model=list[DocumentSummary])
 async def get_product_documents(
     slug: str,
+    _usage: None = Depends(check_usage_limit),
     user_tier: UserTier = Depends(get_user_tier),
     db: AgnosticDatabase = Depends(get_db),
     service: ProductService = Depends(create_product_service),
@@ -414,6 +415,7 @@ async def get_document_deep_analysis_route(
 @router.get("/{slug}", response_model=Product)
 async def get_product_by_slug(
     slug: str,
+    _usage: None = Depends(check_usage_limit),
     db: AgnosticDatabase = Depends(get_db),
     service: ProductService = Depends(create_product_service),
 ) -> Product:

--- a/packages/backend/src/services/product_preview_usage.py
+++ b/packages/backend/src/services/product_preview_usage.py
@@ -1,0 +1,71 @@
+from datetime import UTC, datetime
+
+from motor.core import AgnosticDatabase
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+ANONYMOUS_LIMIT = 5
+
+
+class ProductPreviewUsageService:
+    COLLECTION = "product_preview_usage"
+
+    def _key_filter(self, *, token: str | None, ip: str) -> dict:
+        if token:
+            return {"token": token}
+        return {"ip": ip, "token": {"$exists": False}}
+
+    async def check_and_increment(
+        self,
+        db: AgnosticDatabase,
+        *,
+        token: str | None,
+        ip: str,
+        increment: bool = True,
+    ) -> tuple[bool, int]:
+        """Return (allowed, current_count).
+
+        Keyed by preview token when present; falls back to IP when token is missing.
+        IP is stored as metadata only when token is the primary key.
+        """
+        key_filter = self._key_filter(token=token, ip=ip)
+
+        if not increment:
+            doc = await db[self.COLLECTION].find_one(key_filter, {"count": 1})
+            current = doc["count"] if doc else 0
+            return current < ANONYMOUS_LIMIT, current
+
+        now = datetime.now(tz=UTC)
+        update_filter = {**key_filter, "count": {"$lt": ANONYMOUS_LIMIT}}
+        set_fields: dict = {"last_seen": now}
+        set_on_insert: dict = {"first_seen": now}
+        if token:
+            set_fields["ip"] = ip
+            set_on_insert["token"] = token
+        else:
+            set_on_insert["ip"] = ip
+
+        try:
+            doc = await db[self.COLLECTION].find_one_and_update(
+                update_filter,
+                {
+                    "$inc": {"count": 1},
+                    "$set": set_fields,
+                    "$setOnInsert": set_on_insert,
+                },
+                upsert=True,
+                return_document=ReturnDocument.AFTER,
+            )
+        except DuplicateKeyError:
+            doc = await db[self.COLLECTION].find_one_and_update(
+                update_filter,
+                {"$inc": {"count": 1}, "$set": set_fields},
+                return_document=ReturnDocument.AFTER,
+            )
+
+        if doc is not None:
+            return True, doc["count"]
+
+        existing = await db[self.COLLECTION].find_one(key_filter, {"count": 1})
+        current = existing["count"] if existing else ANONYMOUS_LIMIT
+        return False, current

--- a/packages/backend/tests/services/product_preview_usage_test.py
+++ b/packages/backend/tests/services/product_preview_usage_test.py
@@ -1,0 +1,109 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.services.product_preview_usage import (
+    ANONYMOUS_LIMIT,
+    ProductPreviewUsageService,
+)
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    collection = MagicMock()
+    collection.find_one_and_update = AsyncMock()
+    collection.find_one = AsyncMock()
+    db.product_preview_usage = collection
+    db.__getitem__ = MagicMock(return_value=collection)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_allows_first_use_with_token(mock_db):
+    mock_db.product_preview_usage.find_one_and_update.return_value = {
+        "token": "uuid-1",
+        "count": 1,
+    }
+    svc = ProductPreviewUsageService()
+    allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
+    assert allowed is True
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_allows_up_to_limit(mock_db):
+    mock_db.product_preview_usage.find_one_and_update.return_value = {
+        "token": "uuid-1",
+        "count": ANONYMOUS_LIMIT,
+    }
+    svc = ProductPreviewUsageService()
+    allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
+    assert allowed is True
+    assert count == ANONYMOUS_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_blocks_over_limit(mock_db):
+    mock_db.product_preview_usage.find_one_and_update.return_value = None
+    mock_db.product_preview_usage.find_one.return_value = {
+        "token": "uuid-1",
+        "count": ANONYMOUS_LIMIT,
+    }
+    svc = ProductPreviewUsageService()
+    allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
+    assert allowed is False
+    assert count == ANONYMOUS_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_different_tokens_are_independent_on_same_ip(mock_db):
+    mock_db.product_preview_usage.find_one_and_update.return_value = {
+        "token": "uuid-A",
+        "count": 1,
+    }
+    svc = ProductPreviewUsageService()
+    allowed_a, _ = await svc.check_and_increment(mock_db, token="uuid-A", ip="5.5.5.5")
+    allowed_b, _ = await svc.check_and_increment(mock_db, token="uuid-B", ip="5.5.5.5")
+    assert allowed_a is True
+    assert allowed_b is True
+
+
+@pytest.mark.asyncio
+async def test_ip_fallback_when_no_token(mock_db):
+    mock_db.product_preview_usage.find_one_and_update.return_value = {
+        "ip": "9.9.9.9",
+        "count": 1,
+    }
+    svc = ProductPreviewUsageService()
+    allowed, count = await svc.check_and_increment(mock_db, token=None, ip="9.9.9.9")
+    assert allowed is True
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_check_without_increment_allows_when_under_limit(mock_db):
+    mock_db.product_preview_usage.find_one.return_value = {
+        "token": "uuid-1",
+        "count": 2,
+    }
+    svc = ProductPreviewUsageService()
+    allowed, count = await svc.check_and_increment(
+        mock_db, token="uuid-1", ip="1.2.3.4", increment=False
+    )
+    assert allowed is True
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_check_without_increment_blocks_when_at_limit(mock_db):
+    mock_db.product_preview_usage.find_one.return_value = {
+        "token": "uuid-1",
+        "count": ANONYMOUS_LIMIT,
+    }
+    svc = ProductPreviewUsageService()
+    allowed, count = await svc.check_and_increment(
+        mock_db, token="uuid-1", ip="1.2.3.4", increment=False
+    )
+    assert allowed is False
+    assert count == ANONYMOUS_LIMIT

--- a/packages/backend/tests/unit/core/middleware_test.py
+++ b/packages/backend/tests/unit/core/middleware_test.py
@@ -85,12 +85,18 @@ class TestWhitelisting:
             "/products/clausea/documents",
             "/products/clausea/explainer",
             "/products/clausea/topics",
+            "/products/clausea/documents/doc123/extraction",
+            "/products/clausea/documents/doc123/deep-analysis",
         ]:
             request = _make_request(path=path, method="GET")
             assert middleware._is_whitelisted(request) is True, f"{path} should be public"
 
     def test_product_list_and_analysis_not_public(self, middleware: AuthMiddleware) -> None:
-        for path in ["/products", "/products/clausea/analysis"]:
+        for path in [
+            "/products",
+            "/products/clausea/analysis",
+            "/products/clausea/deep-analysis",
+        ]:
             request = _make_request(path=path, method="GET")
             assert middleware._is_whitelisted(request) is False, f"{path} should require auth"
 

--- a/packages/backend/tests/unit/core/middleware_test.py
+++ b/packages/backend/tests/unit/core/middleware_test.py
@@ -77,6 +77,23 @@ class TestWhitelisting:
             request = _make_request(path=path)
             assert middleware._is_whitelisted(request) is True, f"{path} should be whitelisted"
 
+    def test_public_product_detail_routes(self, middleware: AuthMiddleware) -> None:
+        for path in [
+            "/products/sitemap",
+            "/products/clausea",
+            "/products/clausea/overview",
+            "/products/clausea/documents",
+            "/products/clausea/explainer",
+            "/products/clausea/topics",
+        ]:
+            request = _make_request(path=path, method="GET")
+            assert middleware._is_whitelisted(request) is True, f"{path} should be public"
+
+    def test_product_list_and_analysis_not_public(self, middleware: AuthMiddleware) -> None:
+        for path in ["/products", "/products/clausea/analysis"]:
+            request = _make_request(path=path, method="GET")
+            assert middleware._is_whitelisted(request) is False, f"{path} should require auth"
+
 
 # ── Service API key auth ────────────────────────────────────────────
 

--- a/packages/backend/tests/unit/tier_access_test.py
+++ b/packages/backend/tests/unit/tier_access_test.py
@@ -125,8 +125,104 @@ async def test_require_pro_rejects_unauthenticated() -> None:
 
 
 @pytest.mark.asyncio
-async def test_check_usage_limit_allows_unauthenticated() -> None:
+async def test_check_usage_limit_allows_unauthenticated_non_product_route() -> None:
     request = _mock_request(None)
+    request.method = "GET"
+    request.url.path = "/users/tier-limits"
     db = AsyncMock()
     result = await check_usage_limit(request=request, db=db)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_check_usage_limit_allows_anonymous_product_preview() -> None:
+    request = _mock_request(None)
+    request.method = "GET"
+    request.url.path = "/products/acme/overview"
+    request.headers = {"X-Preview-Token": "preview-token-1"}
+    request.client = MagicMock(host="1.2.3.4")
+    db = AsyncMock()
+
+    with patch("src.core.tier_deps._preview_usage_svc") as mock_preview_svc:
+        mock_preview_svc.check_and_increment = AsyncMock(return_value=(True, 1))
+        result = await check_usage_limit(request=request, db=db)
+
+    assert result is None
+    mock_preview_svc.check_and_increment.assert_awaited_once_with(
+        db,
+        token="preview-token-1",
+        ip="1.2.3.4",
+        increment=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_usage_limit_blocks_anonymous_product_preview() -> None:
+    request = _mock_request(None)
+    request.method = "GET"
+    request.url.path = "/products/acme/overview"
+    request.headers = {}
+    request.client = MagicMock(host="9.9.9.9")
+    db = AsyncMock()
+
+    with patch("src.core.tier_deps._preview_usage_svc") as mock_preview_svc:
+        mock_preview_svc.check_and_increment = AsyncMock(return_value=(False, 5))
+        with pytest.raises(HTTPException) as exc_info:
+            await check_usage_limit(request=request, db=db)
+
+    assert exc_info.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_check_usage_limit_skips_crawler_user_agents() -> None:
+    request = _mock_request(None)
+    request.method = "GET"
+    request.url.path = "/products/acme/overview"
+    request.headers = {"user-agent": "Twitterbot/1.0"}
+    db = AsyncMock()
+
+    with patch("src.core.tier_deps._preview_usage_svc") as mock_preview_svc:
+        result = await check_usage_limit(request=request, db=db)
+
+    assert result is None
+    mock_preview_svc.check_and_increment.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_usage_limit_checks_without_increment_on_documents() -> None:
+    request = _mock_request(None)
+    request.method = "GET"
+    request.url.path = "/products/acme/documents"
+    request.headers = {"X-Preview-Token": "preview-token-1"}
+    request.client = MagicMock(host="1.2.3.4")
+    db = AsyncMock()
+
+    with patch("src.core.tier_deps._preview_usage_svc") as mock_preview_svc:
+        mock_preview_svc.check_and_increment = AsyncMock(return_value=(True, 3))
+        result = await check_usage_limit(request=request, db=db)
+
+    assert result is None
+    mock_preview_svc.check_and_increment.assert_awaited_once_with(
+        db,
+        token="preview-token-1",
+        ip="1.2.3.4",
+        increment=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_usage_limit_enforces_signed_in_monthly_limit() -> None:
+    request = _mock_request("free-user-123")
+    request.method = "GET"
+    request.url.path = "/products/acme/overview"
+    db = AsyncMock()
+
+    with patch(
+        "src.core.tier_deps.UsageService.check_usage_limit",
+        new=AsyncMock(return_value=(False, {})),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await check_usage_limit(request=request, db=db)
+
+    assert exc_info.value.status_code == 429
+    assert "Monthly usage limit" in exc_info.value.detail

--- a/packages/backend/tests/unit/tier_access_test.py
+++ b/packages/backend/tests/unit/tier_access_test.py
@@ -125,9 +125,8 @@ async def test_require_pro_rejects_unauthenticated() -> None:
 
 
 @pytest.mark.asyncio
-async def test_check_usage_limit_rejects_unauthenticated() -> None:
+async def test_check_usage_limit_allows_unauthenticated() -> None:
     request = _mock_request(None)
     db = AsyncMock()
-    with pytest.raises(HTTPException) as exc_info:
-        await check_usage_limit(request=request, db=db)
-    assert exc_info.value.status_code == 401
+    result = await check_usage_limit(request=request, db=db)
+    assert result is None

--- a/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
@@ -1,4 +1,10 @@
+import { cookies } from "next/headers";
+
 import type { ConsumerExplainer } from "@/components/dashboard/explainer/types";
+import {
+  PREVIEW_TOKEN_COOKIE,
+  PREVIEW_TOKEN_HEADER,
+} from "@/lib/preview-token";
 import type {
   DocumentSummary,
   Product,
@@ -36,9 +42,13 @@ export default async function ProductPage({
 
   const { getToken } = await auth();
   const token = await getToken();
+  const cookieStore = await cookies();
+  const previewToken = cookieStore.get(PREVIEW_TOKEN_COOKIE)?.value;
   const headers: HeadersInit = token
     ? { Authorization: `Bearer ${token}` }
-    : {};
+    : previewToken
+      ? { [PREVIEW_TOKEN_HEADER]: previewToken }
+      : {};
 
   const tag = `product-${slug}`;
   const [

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.test.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.test.tsx
@@ -30,6 +30,10 @@ vi.mock("@/app/actions/products", () => ({
   subscribeIndexationNotify: vi.fn(),
 }));
 
+vi.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({ isSignedIn: true }),
+}));
+
 function createJsonResponse(status: number, payload: unknown): Response {
   return new Response(JSON.stringify(payload), {
     status,

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -45,6 +45,7 @@ import type {
   ProductOverview,
   ProductTopicReport,
 } from "@/types";
+import { useAuth } from "@clerk/nextjs";
 
 import { deriveProductPageOverviewState } from "./product-page-fetch-state";
 
@@ -106,6 +107,7 @@ export default function CompanyPage({
 }: CompanyPageProps = {}) {
   const params = useParams();
   const slug = params.slug as string;
+  const { isSignedIn } = useAuth();
   const [product, setProduct] = useState<Product | null>(
     initialProduct ?? null,
   );
@@ -171,6 +173,8 @@ export default function CompanyPage({
           overviewStatus: overviewRes.status,
           explainerStatus: explainerRes.status,
           topicsStatus: topicsRes.status,
+          productStatus: prodRes.status,
+          documentsStatus: docsRes.status,
         });
 
         const prodJson = prodRes.ok
@@ -371,6 +375,62 @@ export default function CompanyPage({
 
   if (!data) {
     if (indexationMode === "limit_reached") {
+      if (!isSignedIn) {
+        return (
+          <div className="space-y-6">
+            <div className="border-b border-border pb-8">
+              <h1 className="text-4xl md:text-5xl font-display font-medium tracking-tight text-foreground">
+                {limitReachedDisplayName}
+              </h1>
+              <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-relaxed">
+                You&apos;ve used your free product previews. Sign in to continue
+                exploring policy reports.
+              </p>
+            </div>
+
+            <div className="border border-border bg-background">
+              <div className="p-6 border-b border-border bg-muted/5">
+                <div className="flex items-center gap-3">
+                  <ShieldBan
+                    className="h-5 w-5 text-amber-600"
+                    strokeWidth={1.5}
+                  />
+                  <h3 className="text-[10px] uppercase tracking-[0.2em] font-medium text-foreground">
+                    Free Preview Limit Reached
+                  </h3>
+                </div>
+              </div>
+              <div className="p-6 space-y-4">
+                <h2 className="text-xl font-display font-medium text-foreground">
+                  Sign in to keep reading
+                </h2>
+                <p className="text-sm text-muted-foreground leading-relaxed max-w-2xl">
+                  Anonymous visitors can preview a limited number of product
+                  reports. Create a free account to unlock more analyses.
+                </p>
+                <div className="pt-2 flex flex-col sm:flex-row gap-3">
+                  <Link
+                    href={`/sign-in?redirect_url=${encodeURIComponent(`/products/${slug}`)}`}
+                  >
+                    <Button className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold">
+                      Sign in
+                    </Button>
+                  </Link>
+                  <Link href="/pricing">
+                    <Button
+                      variant="outline"
+                      className="h-11 px-6 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+                    >
+                      View plans
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      }
+
       return (
         <div className="space-y-6">
           <div className="border-b border-border pb-8">

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.ts
@@ -9,6 +9,8 @@ interface ProductPageOverviewStateInput {
   overviewStatus: number;
   explainerStatus: number;
   topicsStatus: number;
+  productStatus?: number;
+  documentsStatus?: number;
 }
 
 const USAGE_LIMIT_HTTP_STATUS = 429;
@@ -19,6 +21,8 @@ export function deriveProductPageOverviewState({
   overviewStatus,
   explainerStatus,
   topicsStatus,
+  productStatus,
+  documentsStatus,
 }: ProductPageOverviewStateInput): ProductPageOverviewState {
   if (overviewOk) {
     return "ready";
@@ -32,6 +36,8 @@ export function deriveProductPageOverviewState({
     overviewStatus,
     explainerStatus,
     topicsStatus,
+    productStatus,
+    documentsStatus,
   ].some((status) => status === USAGE_LIMIT_HTTP_STATUS);
 
   if (hasUsageLimitResponse) {

--- a/packages/frontend/app/api/products/[slug]/documents/route.ts
+++ b/packages/frontend/app/api/products/[slug]/documents/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { apiEndpoints } from "@lib/config";
-import { httpJson } from "@lib/http";
+import { http } from "@lib/http";
 
 export async function GET(
   request: NextRequest,
@@ -9,11 +9,21 @@ export async function GET(
 ) {
   const { slug } = await params;
   try {
-    const documents = await httpJson(
+    const response = await http(
       `${apiEndpoints.products()}/${slug}/documents`,
-      { method: "GET" },
+      {
+        method: "GET",
+      },
     );
-    return NextResponse.json(documents);
+
+    const body = await response.text();
+    return new NextResponse(body, {
+      status: response.status,
+      headers: {
+        "Content-Type":
+          response.headers.get("content-type") || "application/json",
+      },
+    });
   } catch (error) {
     console.error("Error fetching product documents:", error);
     return NextResponse.json(

--- a/packages/frontend/lib/http.ts
+++ b/packages/frontend/lib/http.ts
@@ -1,5 +1,10 @@
+import { cookies } from "next/headers";
 import type { ZodType } from "zod";
 
+import {
+  PREVIEW_TOKEN_COOKIE,
+  PREVIEW_TOKEN_HEADER,
+} from "@/lib/preview-token";
 import { auth } from "@clerk/nextjs/server";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -57,6 +62,13 @@ export async function http(
   if (token) {
     (mergedHeaders as Record<string, string>)["Authorization"] =
       `Bearer ${token}`;
+  } else {
+    const cookieStore = await cookies();
+    const previewToken = cookieStore.get(PREVIEW_TOKEN_COOKIE)?.value;
+    if (previewToken) {
+      (mergedHeaders as Record<string, string>)[PREVIEW_TOKEN_HEADER] =
+        previewToken;
+    }
   }
 
   let attempt = 0;

--- a/packages/frontend/lib/preview-token.ts
+++ b/packages/frontend/lib/preview-token.ts
@@ -1,0 +1,2 @@
+export const PREVIEW_TOKEN_COOKIE = "__pt";
+export const PREVIEW_TOKEN_HEADER = "X-Preview-Token";

--- a/packages/frontend/proxy.ts
+++ b/packages/frontend/proxy.ts
@@ -1,6 +1,7 @@
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
+import { PREVIEW_TOKEN_COOKIE } from "@/lib/preview-token";
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
 const CRAWLER_UA =
@@ -67,6 +68,18 @@ const clerkProxy = clerkMiddleware(async (auth, request) => {
         path: "/",
         maxAge: 60 * 60 * 24 * 30,
       });
+
+      const existingPreviewToken =
+        request.cookies.get(PREVIEW_TOKEN_COOKIE)?.value;
+      if (!existingPreviewToken) {
+        response.cookies.set(PREVIEW_TOKEN_COOKIE, crypto.randomUUID(), {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          maxAge: 60 * 60 * 24 * 30,
+        });
+      }
+
       return response;
     }
   }


### PR DESCRIPTION
## Summary
- Whitelist public GET `/products/...` routes in auth middleware so shared links, crawlers, and incognito sessions can load product detail APIs without a session.
- Allow anonymous requests through `check_usage_limit` instead of returning 401; signed-in users still hit tier usage limits, and the frontend continues to meter page views via the `__pv` cookie before prompting sign-in.
- Fixes the root cause of incognito "Product Not Found": the backend rejected unauthenticated product API calls before the UI could render.

## Test plan
- [x] `uv run pytest tests/unit/core/middleware_test.py tests/unit/tier_access_test.py`
- [x] `uv run ruff check` on changed backend files
- [ ] Open a product page in an incognito window and confirm overview/documents load without sign-in
- [ ] Confirm `/products` list and `/products/{slug}/analysis` still require authentication