### PR TITLE
Fix Clerk auth form loading

### DIFF
--- a/packages/frontend/app/provider.tsx
+++ b/packages/frontend/app/provider.tsx
@@ -13,7 +13,6 @@ export function Provider(props: {
     <ClerkProvider
       publishableKey={props.publishableKey}
       afterSignOutUrl="/"
-      prefetchUI={false}
       ui={ui}
     >
       <ThemeProvider


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- allow Clerk to prefetch/load its UI bundle for the embedded sign-in and sign-up components
- keep the existing bundled `@clerk/ui` configuration and auth page behavior unchanged

## Testing
- `npm exec --yes --package=bun -- bun run lint` (passes with existing `@next/next/no-img-element` warning in `products-list-client.tsx`)
- `npm exec --yes --package=bun -- bun run type-check`
- `npm exec --yes --package=bun -- bun run build` (passes; logs existing sitemap backend fetch refusal during static generation)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec8af8e4-fdf6-44f6-b2b5-d29cf63aa66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec8af8e4-fdf6-44f6-b2b5-d29cf63aa66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

