### PR TITLE
Improve product evidence ergonomics

### DIFF
--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -27,7 +27,7 @@ import { ScoreBreakdown } from "@/components/dashboard/overview/score-breakdown"
 import { SharingMap } from "@/components/dashboard/overview/sharing-map";
 import { VerdictHero } from "@/components/dashboard/overview/verdict-hero";
 import { YourPower } from "@/components/dashboard/overview/your-power";
-import { SourcesList } from "@/components/dashboard/sources-list";
+import { EvidenceList } from "@/components/dashboard/sources-list";
 import { TopicEvidencePanel } from "@/components/dashboard/topics/topic-evidence-panel";
 import { PipelineProgress } from "@/components/pipeline/pipeline-progress";
 import { Badge } from "@/components/ui/badge";
@@ -800,11 +800,11 @@ export default function CompanyPage({
               Overview
             </TabsTrigger>
             <TabsTrigger
-              value="sources"
+              value="evidence"
               variant="underline"
               className="px-0 text-[10px] uppercase tracking-[0.2em] font-bold gap-2"
             >
-              Sources
+              Evidence
               {documents.length > 0 && (
                 <span className="px-1.5 py-0.5 border border-border text-[8px] font-bold">
                   {documents.length}
@@ -991,7 +991,7 @@ export default function CompanyPage({
           )}
         </TabsContent>
 
-        <TabsContent value="sources" className="mt-0">
+        <TabsContent value="evidence" className="mt-0">
           {documentsLoading ? (
             <div className="space-y-4">
               <Skeleton className="h-12 w-64 rounded-xl" />
@@ -1000,7 +1000,7 @@ export default function CompanyPage({
               <Skeleton className="h-32 rounded-2xl" />
             </div>
           ) : (
-            <SourcesList
+            <EvidenceList
               productSlug={slug}
               documents={documents}
               topicReport={topics}

--- a/packages/frontend/components/dashboard/sources-list.tsx
+++ b/packages/frontend/components/dashboard/sources-list.tsx
@@ -51,7 +51,7 @@ interface DocumentExtraction {
   benefits: ExtractedItem[];
 }
 
-interface SourcesListProps {
+interface EvidenceListProps {
   productSlug: string;
   documents: DocumentSummary[];
   topicReport?: ProductTopicReport | null;
@@ -126,11 +126,11 @@ const RISK_LEVEL_CONFIG = {
   },
 };
 
-export function SourcesList({
+export function EvidenceList({
   productSlug,
   documents,
   topicReport,
-}: SourcesListProps) {
+}: EvidenceListProps) {
   const [expandedDocs, setExpandedDocs] = useState<Set<string>>(new Set());
   const [expandedKeypoints, setExpandedKeypoints] = useState<
     Record<string, Set<number>>
@@ -204,9 +204,12 @@ export function SourcesList({
           <div className="w-14 h-14 rounded-none bg-muted/50 flex items-center justify-center mx-auto mb-3">
             <FolderOpen className="h-7 w-7 text-muted-foreground/50" />
           </div>
-          <h3 className="font-semibold text-base mb-1">No Source Documents</h3>
+          <h3 className="font-semibold text-base mb-1">
+            No Evidence Available
+          </h3>
           <p className="text-muted-foreground text-sm max-w-sm mx-auto">
-            No source documents are available for analysis yet.
+            We have not collected policy documents or supporting quotes for
+            this product yet.
           </p>
         </CardContent>
       </Card>
@@ -219,7 +222,7 @@ export function SourcesList({
         <TopicEvidencePanel
           topicStances={null}
           topicReport={topicReport}
-          title="Per-Topic Evidence (Primary)"
+          title="Evidence by Policy Topic"
           showCitations={true}
         />
       )}
@@ -230,17 +233,18 @@ export function SourcesList({
           className="border-border bg-background shadow-none overflow-hidden"
         >
           <CardHeader className="pb-4">
-            <div className="flex items-start justify-between">
+            <div className="flex items-start justify-between gap-4">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-none bg-muted flex items-center justify-center">
                   <FileText className="h-5 w-5 text-foreground" />
                 </div>
                 <div>
                   <CardTitle className="text-lg">
-                    Per-Document Drill-Down
+                    Policy Document Library
                   </CardTitle>
                   <p className="text-sm text-muted-foreground mt-0.5">
-                    Policy documents analyzed for this product
+                    Original policies we analyzed, with document-level findings
+                    and supporting quotes.
                   </p>
                 </div>
               </div>
@@ -374,10 +378,12 @@ export function SourcesList({
 
                           {/* Expand button */}
                           <button
+                            type="button"
                             onClick={(e) => {
                               e.stopPropagation();
                               handleToggleExpanded(doc);
                             }}
+                            aria-expanded={isExpanded}
                             className={cn(
                               "flex items-center gap-1.5 px-2.5 py-1.5 rounded-none text-xs font-medium transition-all shrink-0",
                               isExpanded
@@ -650,7 +656,7 @@ export function SourcesList({
                                             ? directEvidence
                                             : derivedEvidence;
 
-                                        const canShowSources =
+                                        const canShowEvidence =
                                           directEvidence.length > 0 ||
                                           !!extraction ||
                                           !!doc.url;
@@ -667,9 +673,12 @@ export function SourcesList({
                                                   <span className="text-sm text-foreground/80 leading-snug">
                                                     {point}
                                                   </span>
-                                                  {canShowSources && (
+                                                  {canShowEvidence && (
                                                     <button
                                                       type="button"
+                                                      aria-expanded={
+                                                        isKpExpanded
+                                                      }
                                                       onClick={async () => {
                                                         if (
                                                           !extractions[doc.id]
@@ -691,8 +700,8 @@ export function SourcesList({
                                                       )}
                                                     >
                                                       {isKpExpanded
-                                                        ? "Hide sources"
-                                                        : "Sources"}
+                                                        ? "Hide evidence"
+                                                        : "View evidence"}
                                                     </button>
                                                   )}
                                                 </div>
@@ -723,7 +732,7 @@ export function SourcesList({
                                                         ] &&
                                                         !extractions[doc.id] ? (
                                                           <div className="text-xs text-muted-foreground">
-                                                            Loading sources…
+                                                            Loading evidence…
                                                           </div>
                                                         ) : evidence.length >
                                                           0 ? (
@@ -732,14 +741,26 @@ export function SourcesList({
                                                             .map((ev, j) => (
                                                               <div
                                                                 key={j}
-                                                                className="rounded-none bg-muted/40 border border-border/50 p-2"
+                                                                className="rounded-none bg-muted/40 border border-border/60 p-3"
                                                               >
-                                                                <div className="text-xs text-muted-foreground mb-1 flex items-center justify-between gap-2">
-                                                                  <span className="truncate">
-                                                                    Source:{" "}
-                                                                    {doc.title ||
-                                                                      "Document"}
-                                                                  </span>
+                                                                <div className="text-xs text-muted-foreground mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                                                  <div className="min-w-0">
+                                                                    <div className="font-bold uppercase tracking-[0.18em] text-foreground">
+                                                                      Evidence
+                                                                      quote{" "}
+                                                                      {j + 1}
+                                                                    </div>
+                                                                    <div className="truncate">
+                                                                      From{" "}
+                                                                      <span className="text-foreground/80">
+                                                                        {doc.title ||
+                                                                          "Policy document"}
+                                                                      </span>
+                                                                      {ev.section_title
+                                                                        ? ` - ${ev.section_title}`
+                                                                        : ""}
+                                                                    </div>
+                                                                  </div>
                                                                   <a
                                                                     href={
                                                                       ev.url ||
@@ -747,22 +768,22 @@ export function SourcesList({
                                                                     }
                                                                     target="_blank"
                                                                     rel="noopener noreferrer"
-                                                                    className="inline-flex items-center gap-1 text-xs font-medium hover:text-foreground"
+                                                                    className="inline-flex w-fit items-center gap-1 border border-border px-2 py-1 text-xs font-semibold text-foreground hover:bg-background"
                                                                   >
-                                                                    Open
+                                                                    Open document
                                                                     <ExternalLink className="h-3 w-3 opacity-60" />
                                                                   </a>
                                                                 </div>
-                                                                <blockquote className="text-xs leading-relaxed text-foreground/85 border-l-2 border-foreground pl-2">
-                                                                  {ev.quote}
+                                                                <blockquote className="text-sm leading-relaxed text-foreground/90 border-l-2 border-foreground pl-3">
+                                                                  {`"${ev.quote}"`}
                                                                 </blockquote>
                                                               </div>
                                                             ))
                                                         ) : (
                                                           <div className="text-xs text-muted-foreground">
-                                                            No exact quote found
-                                                            for this keypoint
-                                                            yet.
+                                                            No exact supporting
+                                                            quote has been found
+                                                            for this insight yet.
                                                           </div>
                                                         )}
                                                       </div>
@@ -795,7 +816,7 @@ export function SourcesList({
           className="border-border bg-background shadow-none overflow-hidden"
         >
           <CardContent className="py-8 text-center text-sm text-muted-foreground">
-            No document-level drill-down is available yet.
+            No policy document library is available yet.
           </CardContent>
         </Card>
       )}

--- a/packages/frontend/components/dashboard/topics/topic-evidence-panel.tsx
+++ b/packages/frontend/components/dashboard/topics/topic-evidence-panel.tsx
@@ -10,7 +10,11 @@ import {
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import type { ProductTopicReport, TopicStanceBreakdown } from "@/types";
+import type {
+  ProductTopicReport,
+  TopicCitation,
+  TopicStanceBreakdown,
+} from "@/types";
 
 interface TopicEvidencePanelProps {
   topicStances?: TopicStanceBreakdown[] | null;
@@ -54,6 +58,64 @@ const stanceStyles: Record<
 
 function humanizeTopic(topic: string): string {
   return topic.replace(/_/g, " ");
+}
+
+function TopicCitationCard({
+  citation,
+  index,
+  total,
+  compact = false,
+}: {
+  citation: TopicCitation;
+  index: number;
+  total: number;
+  compact?: boolean;
+}) {
+  const documentLabel =
+    citation.document_title || citation.document_id || "Policy document";
+
+  return (
+    <figure
+      className={cn(
+        "rounded-none border border-border/60 bg-muted/30",
+        compact ? "p-3" : "p-4",
+      )}
+    >
+      <figcaption className="mb-2 flex flex-col gap-2 text-[11px] text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-bold uppercase tracking-[0.18em] text-foreground">
+              Evidence quote {index + 1}
+              {total > 1 ? ` of ${total}` : ""}
+            </span>
+            {citation.verified && (
+              <Badge variant="outline" size="sm" className="h-5 px-1.5">
+                Verified
+              </Badge>
+            )}
+          </div>
+          <div className="truncate">
+            From <span className="text-foreground/80">{documentLabel}</span>
+            {citation.section_title ? ` - ${citation.section_title}` : ""}
+          </div>
+        </div>
+        {citation.document_url && (
+          <a
+            href={citation.document_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex w-fit items-center gap-1 border border-border px-2 py-1 font-semibold text-foreground transition-colors hover:bg-background"
+          >
+            Open document
+            <ExternalLink className="h-3 w-3 opacity-60" />
+          </a>
+        )}
+      </figcaption>
+      <blockquote className="border-l-2 border-foreground pl-3 text-sm leading-relaxed text-foreground/90">
+        &ldquo;{citation.quote}&rdquo;
+      </blockquote>
+    </figure>
+  );
 }
 
 export function TopicEvidencePanel({
@@ -129,11 +191,20 @@ export function TopicEvidencePanel({
 
   return (
     <div className="border border-border bg-background">
-      <div className="p-6 border-b border-border flex items-center gap-3">
-        <Shield className="h-5 w-5 text-foreground" strokeWidth={1.5} />
-        <h3 className="text-[10px] uppercase tracking-[0.2em] font-medium text-foreground">
-          {title}
-        </h3>
+      <div className="p-6 border-b border-border flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <Shield className="mt-0.5 h-5 w-5 text-foreground" strokeWidth={1.5} />
+          <div>
+            <h3 className="text-[10px] uppercase tracking-[0.2em] font-medium text-foreground">
+              {title}
+            </h3>
+            <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+              {showCitations
+                ? "Trace each topic back to exact quotes from the policies we analyzed."
+                : "A quick topic summary with representative evidence where available."}
+            </p>
+          </div>
+        </div>
       </div>
 
       <div className="divide-y divide-border">
@@ -197,31 +268,13 @@ export function TopicEvidencePanel({
               {!showCitations && previewCitations.length > 0 && (
                 <div className="space-y-2">
                   {previewCitations.map((citation, idx) => (
-                    <div
+                    <TopicCitationCard
                       key={`${topic.topic}-overview-citation-${idx}`}
-                      className="rounded-none bg-muted/40 border border-border/50 p-2"
-                    >
-                      <div className="text-[11px] text-muted-foreground mb-1 flex items-center justify-between gap-2">
-                        <span className="truncate">
-                          Source:{" "}
-                          {citation.document_title || citation.document_id}
-                        </span>
-                        {citation.document_url && (
-                          <a
-                            href={citation.document_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 hover:text-foreground"
-                          >
-                            Open
-                            <ExternalLink className="h-3 w-3 opacity-60" />
-                          </a>
-                        )}
-                      </div>
-                      <blockquote className="text-xs text-foreground/85 border-l-2 border-foreground pl-2">
-                        {citation.quote}
-                      </blockquote>
-                    </div>
+                      citation={citation}
+                      index={idx}
+                      total={previewCitations.length}
+                      compact
+                    />
                   ))}
                 </div>
               )}
@@ -261,31 +314,12 @@ export function TopicEvidencePanel({
               {showCitations && previewCitations.length > 0 && (
                 <div className="space-y-2 pt-1">
                   {previewCitations.map((citation, idx) => (
-                    <div
+                    <TopicCitationCard
                       key={`${topic.topic}-quote-${idx}`}
-                      className="rounded-none bg-muted/40 border border-border/50 p-2"
-                    >
-                      <div className="text-[11px] text-muted-foreground mb-1 flex items-center justify-between gap-2">
-                        <span className="truncate">
-                          Source:{" "}
-                          {citation.document_title || citation.document_id}
-                        </span>
-                        {citation.document_url && (
-                          <a
-                            href={citation.document_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 hover:text-foreground"
-                          >
-                            Open
-                            <ExternalLink className="h-3 w-3 opacity-60" />
-                          </a>
-                        )}
-                      </div>
-                      <blockquote className="text-xs text-foreground/85 border-l-2 border-foreground pl-2">
-                        {citation.quote}
-                      </blockquote>
-                    </div>
+                      citation={citation}
+                      index={idx}
+                      total={previewCitations.length}
+                    />
                   ))}
                 </div>
               )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rename the product detail “Sources” tab to “Evidence” in the UI.
- Clarify evidence empty states and document library copy.
- Improve citation cards with explicit evidence quote labels, document context, verified badges, and clearer open-document actions.

## Testing
- Passed: `npx tsc --noEmit`
- Passed: `npx vitest run app/(dashboard)/products/[slug]/product-page-client.test.tsx`
- Passed: `npx eslint components/dashboard/sources-list.tsx components/dashboard/topics/topic-evidence-panel.tsx`
- Full `npx eslint .` currently fails on pre-existing React hook lint errors in unrelated files (`app/(dashboard)/onboarding/page.tsx`, `app/(dashboard)/products/products-list-client.tsx`, `app/(dashboard)/settings/page.tsx`, `components/pipeline/pipeline-progress.tsx`, `hooks/useUserData.ts`) plus an existing product-page effect warning at line 143.

## Environment note
- The cloud image does not have `bun`; checks were run via local `npm install --no-package-lock` and `npx` equivalents.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79d7919c-15c7-4a71-aaa6-7527337d5f47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79d7919c-15c7-4a71-aaa6-7527337d5f47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

