### PR TITLE
fix(billing): proxy subscription checkout through Next.js API

### DIFF
--- a/packages/frontend/app/(dashboard)/checkout/success/page.tsx
+++ b/packages/frontend/app/(dashboard)/checkout/success/page.tsx
@@ -8,10 +8,8 @@ import { useEffect, useRef, useState } from "react";
 
 import type { SubscriptionResponse } from "@/lib/api/subscriptions";
 import { subscriptionApi } from "@/lib/api/subscriptions";
-import { useAuth } from "@clerk/nextjs";
 
 export default function CheckoutSuccessPage() {
-  const { getToken } = useAuth();
   const [subscription, setSubscription] = useState<SubscriptionResponse | null>(
     null,
   );
@@ -21,11 +19,8 @@ export default function CheckoutSuccessPage() {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      let token = await getToken({ template: "default" });
-      if (!token) token = await getToken();
-      if (cancelled) return;
       try {
-        const sub = await subscriptionApi.getSubscription(token);
+        const sub = await subscriptionApi.getSubscription();
         if (cancelled) return;
         setSubscription(sub);
         // Track checkout completed event only once when subscription is loaded
@@ -49,7 +44,7 @@ export default function CheckoutSuccessPage() {
     return () => {
       cancelled = true;
     };
-  }, [getToken]);
+  }, []);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-white to-gray-50 px-4 dark:from-gray-950 dark:to-gray-900">

--- a/packages/frontend/app/(dashboard)/settings/page.tsx
+++ b/packages/frontend/app/(dashboard)/settings/page.tsx
@@ -22,11 +22,10 @@ import {
 } from "@/lib/api/subscriptions";
 import { type BillingInterval, getProDisplayPrice } from "@/lib/pricing";
 import { cn } from "@/lib/utils";
-import { useAuth, useUser } from "@clerk/nextjs";
+import { useUser } from "@clerk/nextjs";
 
 export default function SettingsPage() {
   const { user } = useUser();
-  const { getToken } = useAuth();
   const {
     startCheckout,
     isLoading: checkoutLoading,
@@ -56,12 +55,7 @@ export default function SettingsPage() {
   const fetchSubscription = useCallback(async () => {
     try {
       setLoading(true);
-      // Get Clerk token - try template first, then default
-      let token = await getToken({ template: "default" });
-      if (!token) {
-        token = await getToken();
-      }
-      const data = await subscriptionApi.getSubscription(token);
+      const data = await subscriptionApi.getSubscription();
       setSubscription(data);
     } catch {
       // User might not have a subscription yet
@@ -69,7 +63,7 @@ export default function SettingsPage() {
     } finally {
       setLoading(false);
     }
-  }, [getToken]);
+  }, []);
 
   useEffect(() => {
     fetchSubscription();
@@ -86,11 +80,7 @@ export default function SettingsPage() {
     setActionLoading("cancel");
     setError(null);
     try {
-      let token = await getToken({ template: "default" });
-      if (!token) {
-        token = await getToken();
-      }
-      await subscriptionApi.cancelSubscription(token);
+      await subscriptionApi.cancelSubscription();
       await fetchSubscription();
     } catch (err) {
       setError(
@@ -105,11 +95,7 @@ export default function SettingsPage() {
     setActionLoading("resume");
     setError(null);
     try {
-      let token = await getToken({ template: "default" });
-      if (!token) {
-        token = await getToken();
-      }
-      await subscriptionApi.resumeSubscription(token);
+      await subscriptionApi.resumeSubscription();
       await fetchSubscription();
     } catch (err) {
       setError(
@@ -124,11 +110,7 @@ export default function SettingsPage() {
     setActionLoading("portal");
     setError(null);
     try {
-      let token = await getToken({ template: "default" });
-      if (!token) {
-        token = await getToken();
-      }
-      const data = await subscriptionApi.getBillingPortal(token);
+      const data = await subscriptionApi.getBillingPortal();
       window.open(data.portal_url, "_blank");
     } catch (err) {
       setError(

--- a/packages/frontend/app/api/subscriptions/cancel/route.ts
+++ b/packages/frontend/app/api/subscriptions/cancel/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { subscriptionProxyError } from "@/lib/api/subscription-proxy";
+import { getBackendUrl } from "@/lib/config";
+import { httpJson } from "@/lib/http";
+
+export async function POST() {
+  try {
+    const data = await httpJson(getBackendUrl("/subscriptions/cancel"), {
+      method: "POST",
+    });
+    return NextResponse.json(data);
+  } catch (error) {
+    return subscriptionProxyError(error);
+  }
+}

--- a/packages/frontend/app/api/subscriptions/checkout/route.ts
+++ b/packages/frontend/app/api/subscriptions/checkout/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { subscriptionProxyError } from "@/lib/api/subscription-proxy";
+import { getBackendUrl } from "@/lib/config";
+import { httpJson } from "@/lib/http";
+
+interface CheckoutResponse {
+  checkout_url: string;
+  session_id: string;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const data = await httpJson<CheckoutResponse>(
+      getBackendUrl("/subscriptions/checkout"),
+      {
+        method: "POST",
+        body,
+      },
+    );
+
+    return NextResponse.json(data, { status: 201 });
+  } catch (error) {
+    return subscriptionProxyError(error);
+  }
+}

--- a/packages/frontend/app/api/subscriptions/me/route.ts
+++ b/packages/frontend/app/api/subscriptions/me/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { subscriptionProxyError } from "@/lib/api/subscription-proxy";
+import { getBackendUrl } from "@/lib/config";
+import { httpJson } from "@/lib/http";
+
+export async function GET() {
+  try {
+    const data = await httpJson(getBackendUrl("/subscriptions/me"), {
+      method: "GET",
+    });
+    return NextResponse.json(data);
+  } catch (error) {
+    return subscriptionProxyError(error);
+  }
+}

--- a/packages/frontend/app/api/subscriptions/pause/route.ts
+++ b/packages/frontend/app/api/subscriptions/pause/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { subscriptionProxyError } from "@/lib/api/subscription-proxy";
+import { getBackendUrl } from "@/lib/config";
+import { httpJson } from "@/lib/http";
+
+export async function POST() {
+  try {
+    const data = await httpJson(getBackendUrl("/subscriptions/pause"), {
+      method: "POST",
+    });
+    return NextResponse.json(data);
+  } catch (error) {
+    return subscriptionProxyError(error);
+  }
+}

--- a/packages/frontend/app/api/subscriptions/portal/route.ts
+++ b/packages/frontend/app/api/subscriptions/portal/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { subscriptionProxyError } from "@/lib/api/subscription-proxy";
+import { getBackendUrl } from "@/lib/config";
+import { httpJson } from "@/lib/http";
+
+export async function GET() {
+  try {
+    const data = await httpJson(getBackendUrl("/subscriptions/portal"), {
+      method: "GET",
+    });
+    return NextResponse.json(data);
+  } catch (error) {
+    return subscriptionProxyError(error);
+  }
+}

--- a/packages/frontend/app/api/subscriptions/resume/route.ts
+++ b/packages/frontend/app/api/subscriptions/resume/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { subscriptionProxyError } from "@/lib/api/subscription-proxy";
+import { getBackendUrl } from "@/lib/config";
+import { httpJson } from "@/lib/http";
+
+export async function POST() {
+  try {
+    const data = await httpJson(getBackendUrl("/subscriptions/resume"), {
+      method: "POST",
+    });
+    return NextResponse.json(data);
+  } catch (error) {
+    return subscriptionProxyError(error);
+  }
+}

--- a/packages/frontend/hooks/useCheckout.ts
+++ b/packages/frontend/hooks/useCheckout.ts
@@ -8,45 +8,60 @@ import { useState } from "react";
 import { type CheckoutRequest, subscriptionApi } from "@/lib/api/subscriptions";
 import { useAuth } from "@clerk/nextjs";
 
-// Custom hook for checkout flow
+function getSignInRedirectUrl(): string {
+  if (typeof window === "undefined") {
+    return "/sign-in?redirect_url=%2Fpricing";
+  }
+
+  return `/sign-in?redirect_url=${encodeURIComponent(
+    `${window.location.pathname}${window.location.search}`,
+  )}`;
+}
 
 export function useCheckout() {
-  const { getToken } = useAuth();
+  const { isSignedIn, isLoaded } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const startCheckout = async (priceId: string) => {
+    if (!isLoaded) {
+      return;
+    }
+
+    if (!isSignedIn) {
+      window.location.assign(getSignInRedirectUrl());
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
 
-    // Track checkout started event
     posthog.capture("checkout_started", {
       price_id: priceId,
       source: "pricing_page",
     });
 
     try {
-      // Get Clerk token - try template first, then default
-      let token = await getToken({ template: "default" });
-      if (!token) {
-        token = await getToken();
-      }
-
       const request: CheckoutRequest = {
         price_id: priceId,
       };
 
-      const response = await subscriptionApi.createCheckout(request, token);
+      const response = await subscriptionApi.createCheckout(request);
+      const checkoutUrl = response.checkout_url?.trim();
 
-      // Redirect to Paddle checkout
-      window.location.href = response.checkout_url;
+      if (!checkoutUrl) {
+        throw new Error(
+          "We couldn't start checkout. Please try again in a moment.",
+        );
+      }
+
+      window.location.assign(checkoutUrl);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : "Failed to start checkout";
       setError(errorMessage);
       setIsLoading(false);
 
-      // Track checkout error
       posthog.capture("checkout_error", {
         price_id: priceId,
         error: errorMessage,

--- a/packages/frontend/lib/api/subscription-proxy.ts
+++ b/packages/frontend/lib/api/subscription-proxy.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+function parseBackendErrorMessage(error: unknown): {
+  status: number;
+  detail: string;
+} {
+  if (!(error instanceof Error)) {
+    return { status: 500, detail: "Request failed" };
+  }
+
+  const match = error.message.match(/^Client HTTP (\d+) [^:]*: (.*)$/s);
+  if (!match) {
+    return { status: 500, detail: error.message || "Request failed" };
+  }
+
+  const status = Number.parseInt(match[1], 10);
+  const rawBody = match[2]?.trim() ?? "";
+
+  try {
+    const parsed = JSON.parse(rawBody) as { detail?: string; error?: string };
+    const detail = parsed.detail || parsed.error;
+    if (detail) {
+      return { status, detail };
+    }
+  } catch {
+    // Fall through to raw body
+  }
+
+  return {
+    status,
+    detail: rawBody || error.message || "Request failed",
+  };
+}
+
+export function subscriptionProxyError(error: unknown): NextResponse {
+  const { status, detail } = parseBackendErrorMessage(error);
+  console.error("Subscription proxy error:", error);
+  return NextResponse.json({ detail }, { status });
+}

--- a/packages/frontend/lib/api/subscriptions.ts
+++ b/packages/frontend/lib/api/subscriptions.ts
@@ -1,5 +1,4 @@
-// API client for subscription management
-import { getBackendUrl } from "@/lib/config";
+// API client for subscription management (browser → Next.js /api proxy → backend)
 
 export interface CheckoutRequest {
   price_id: string;
@@ -24,20 +23,15 @@ interface BillingPortalResponse {
 }
 
 class SubscriptionAPI {
-  private async fetchWithAuth(
+  private async fetchApi<T>(
     endpoint: string,
-    token: string | null,
     options: RequestInit = {},
-  ) {
-    const url = getBackendUrl(endpoint);
+  ): Promise<T> {
+    const url = `/api/subscriptions${endpoint}`;
     const headers: HeadersInit = {
       "Content-Type": "application/json",
       ...options.headers,
     };
-
-    if (token) {
-      (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
-    }
 
     const response = await fetch(url, {
       ...options,
@@ -49,52 +43,41 @@ class SubscriptionAPI {
       const error = await response
         .json()
         .catch(() => ({ detail: "Unknown error" }));
-      throw new Error(error.detail || `HTTP ${response.status}`);
+      throw new Error(
+        (error as { detail?: string; error?: string }).detail ||
+          (error as { detail?: string; error?: string }).error ||
+          `HTTP ${response.status}`,
+      );
     }
 
-    return response.json();
+    return response.json() as Promise<T>;
   }
 
-  async createCheckout(
-    request: CheckoutRequest,
-    token: string | null,
-  ): Promise<CheckoutResponse> {
-    return this.fetchWithAuth("/subscriptions/checkout", token, {
+  async createCheckout(request: CheckoutRequest): Promise<CheckoutResponse> {
+    return this.fetchApi("/checkout", {
       method: "POST",
       body: JSON.stringify(request),
     });
   }
 
-  async getSubscription(token: string | null): Promise<SubscriptionResponse> {
-    return this.fetchWithAuth("/subscriptions/me", token);
+  async getSubscription(): Promise<SubscriptionResponse> {
+    return this.fetchApi("/me");
   }
 
-  async cancelSubscription(
-    token: string | null,
-  ): Promise<{ success: boolean; message: string }> {
-    return this.fetchWithAuth("/subscriptions/cancel", token, {
-      method: "POST",
-    });
+  async cancelSubscription(): Promise<{ success: boolean; message: string }> {
+    return this.fetchApi("/cancel", { method: "POST" });
   }
 
-  async pauseSubscription(
-    token: string | null,
-  ): Promise<{ success: boolean; message: string }> {
-    return this.fetchWithAuth("/subscriptions/pause", token, {
-      method: "POST",
-    });
+  async pauseSubscription(): Promise<{ success: boolean; message: string }> {
+    return this.fetchApi("/pause", { method: "POST" });
   }
 
-  async resumeSubscription(
-    token: string | null,
-  ): Promise<{ success: boolean; message: string }> {
-    return this.fetchWithAuth("/subscriptions/resume", token, {
-      method: "POST",
-    });
+  async resumeSubscription(): Promise<{ success: boolean; message: string }> {
+    return this.fetchApi("/resume", { method: "POST" });
   }
 
-  async getBillingPortal(token: string | null): Promise<BillingPortalResponse> {
-    return this.fetchWithAuth("/subscriptions/portal", token);
+  async getBillingPortal(): Promise<BillingPortalResponse> {
+    return this.fetchApi("/portal");
   }
 }
 


### PR DESCRIPTION
## Summary

PR #162 merged runtime Pro pricing to `main`, but the follow-up commit that routes subscription checkout through Next.js API routes (`6ac2726`) was left on `fix/runtime-pro-pricing-railway` only.

In production, the browser still called the backend via `getBackendUrl()`, which resolves to `localhost`, so **Upgrade to Pro** stayed in an infinite loading state.

This PR cherry-picks that fix onto `main`:

- Adds authenticated `/api/subscriptions/*` proxy routes (checkout, me, cancel, pause, resume, portal)
- Updates client subscription helpers and `useCheckout` to use same-origin API instead of direct backend URL
- Improves checkout error handling on settings and success pages

**Not included:** `d92a60a` (rename `sources-list` → `evidence-list`) — unrelated to billing.

## Test plan

- [ ] On production/staging (non-localhost), click **Upgrade to Pro** — checkout should start without infinite loading
- [ ] Verify checkout session is created via `/api/subscriptions/checkout` (Network tab), not `localhost`
- [ ] Settings subscription actions (portal, pause, cancel) still work when logged in
- [ ] Checkout success page loads after Paddle redirect