### PR TITLE
fix(frontend): align OG image grade with overview letter grade

### DIFF
--- a/packages/frontend/app/(dashboard)/products/[slug]/layout.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/layout.tsx
@@ -14,6 +14,7 @@ interface ProductMetadata {
   slug: string;
   company_name?: string | null;
   one_line_summary?: string;
+  grade?: "A" | "B" | "C" | "D" | "E" | null;
   risk_score?: number;
   verdict?:
     | "very_user_friendly"
@@ -26,11 +27,11 @@ interface ProductMetadata {
 function buildOgUrl(
   base: string,
   name: string,
-  score?: number | null,
+  grade?: ProductMetadata["grade"],
   verdict?: string | null,
 ): string {
   const params = new URLSearchParams({ name });
-  if (score != null) params.set("score", String(score));
+  if (grade) params.set("grade", grade);
   if (verdict) params.set("verdict", verdict);
   return `${base}/og?${params.toString()}`;
 }
@@ -107,9 +108,11 @@ const fetchProductForMetadata = cache(async function (
     if (overviewRes?.ok) {
       try {
         const overview = (await overviewRes.json()) as {
+          grade?: ProductMetadata["grade"];
           risk_score?: number;
           verdict?: ProductMetadata["verdict"];
         };
+        if (overview.grade) product.grade = overview.grade;
         if (overview.risk_score != null)
           product.risk_score = overview.risk_score;
         if (overview.verdict) product.verdict = overview.verdict;
@@ -223,12 +226,7 @@ export async function generateMetadata({
       siteName: "Clausea AI",
       images: [
         {
-          url: buildOgUrl(
-            siteUrl,
-            productName,
-            product.risk_score,
-            product.verdict,
-          ),
+          url: buildOgUrl(siteUrl, productName, product.grade, product.verdict),
           width: 1200,
           height: 630,
           alt: `${productName} policy overview`,
@@ -242,7 +240,7 @@ export async function generateMetadata({
       title: `${productName} - Policy overview | Clausea AI`,
       description: fullDescription,
       images: [
-        buildOgUrl(siteUrl, productName, product.risk_score, product.verdict),
+        buildOgUrl(siteUrl, productName, product.grade, product.verdict),
       ],
     },
     alternates: {

--- a/packages/frontend/app/og/route.tsx
+++ b/packages/frontend/app/og/route.tsx
@@ -1,6 +1,8 @@
 import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
 
+import { letterGradeToTone } from "@/lib/grade";
+
 export const contentType = "image/png";
 
 // Colors matching lib/grade.ts tone palette
@@ -20,29 +22,11 @@ const VERDICT_LABELS: Record<string, { label: string; tone: string }> = {
   very_pervasive: { label: "Alarming", tone: "bad" },
 };
 
-// Grade bands: risk_score is higher = worse, invert to get letter
-const GRADE_BANDS = [
-  { min: 9.5, letter: "A+" },
-  { min: 8.5, letter: "A" },
-  { min: 8.0, letter: "A-" },
-  { min: 7.5, letter: "B+" },
-  { min: 6.5, letter: "B" },
-  { min: 6.0, letter: "B-" },
-  { min: 5.5, letter: "C+" },
-  { min: 4.5, letter: "C" },
-  { min: 4.0, letter: "C-" },
-  { min: 3.5, letter: "D+" },
-  { min: 2.5, letter: "D" },
-  { min: 1.0, letter: "D-" },
-  { min: -Infinity, letter: "E" },
-];
-
-function riskScoreToGrade(score: number): string {
-  const effective = 10 - Math.max(0, Math.min(10, score));
-  return (
-    GRADE_BANDS.find((b) => effective >= b.min)?.letter ??
-    GRADE_BANDS[GRADE_BANDS.length - 1].letter
-  );
+function normalizeOgGrade(raw: string | null): string | null {
+  if (!raw) return null;
+  const letter = raw.trim().toUpperCase().charAt(0);
+  if (!["A", "B", "C", "D", "E"].includes(letter)) return null;
+  return letter;
 }
 
 async function loadFont(
@@ -65,7 +49,7 @@ async function loadFont(
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const name = searchParams.get("name");
-  const scoreRaw = searchParams.get("score");
+  const gradeRaw = searchParams.get("grade");
   const verdict = searchParams.get("verdict") ?? "";
 
   const isProduct = Boolean(name);
@@ -103,13 +87,13 @@ export async function GET(request: NextRequest) {
 
   // ─── Product OG ──────────────────────────────────────────────────────────────
   if (isProduct) {
-    const score = scoreRaw ? parseFloat(scoreRaw) : null;
-    const gradeLetter =
-      score !== null && !isNaN(score) ? riskScoreToGrade(score) : null;
+    const gradeLetter = normalizeOgGrade(gradeRaw);
     const verdictInfo = VERDICT_LABELS[verdict] ?? null;
     const gradeColor = verdictInfo
       ? TONE_COLORS[verdictInfo.tone]
-      : "rgba(250,249,246,0.4)";
+      : gradeLetter
+        ? TONE_COLORS[letterGradeToTone(gradeLetter)]
+        : "rgba(250,249,246,0.4)";
 
     return new ImageResponse(
       <div


### PR DESCRIPTION
## What this PR does
Uses the stored overview letter grade (`A`–`E`) in product OG images instead of deriving a finer grade from `risk_score`.

## Why
Shared product links (e.g. Discord) showed **D−** in the OG card while the product page showed **D**. OG metadata passed `risk_score`, which the `/og` route converted through a 13-step scale; privacy signal floors can push `risk_score` above the coarse letter band without updating `grade`.

## How to test
- Open `/products/discord` and confirm the overview grade is **D**
- Inspect page metadata or visit `/og?name=Discord&grade=D&verdict=pervasive` and confirm the image shows **D** (not D−)
- Share a product URL and verify the preview grade matches the page (may require re-scraping cached OG images in social debuggers)
- Open a product without a grade and confirm the OG image still renders without a grade letter