### PR TITLE
feat(crawler): error-count-based stall detection via domain browser cap and bot-wall abort

### DIFF
--- a/packages/backend/scripts/crawler_monitor.py
+++ b/packages/backend/scripts/crawler_monitor.py
@@ -258,142 +258,143 @@ async def _mongo_snapshot() -> dict[str, Any]:
         raise SystemExit("No MONGO_URI configured")
 
     client = AsyncIOMotorClient(cfg.mongodb_uri)
-    db = client[cfg.mongodb_database]
-    now = _utc_now()
+    try:
+        db = client[cfg.mongodb_database]
+        now = _utc_now()
 
-    products = await db.products.count_documents({})
-    by_status = {
-        row["_id"]: row["n"]
-        async for row in db.pipeline_jobs.aggregate(
-            [{"$group": {"_id": "$status", "n": {"$sum": 1}}}]
+        products = await db.products.count_documents({})
+        by_status = {
+            row["_id"]: row["n"]
+            async for row in db.pipeline_jobs.aggregate(
+                [{"$group": {"_id": "$status", "n": {"$sum": 1}}}]
+            )
+        }
+        total_jobs = sum(by_status.values())
+        active = await db.pipeline_jobs.count_documents({"active": True})
+        pending = by_status.get("pending", 0)
+        running = sum(by_status.get(s, 0) for s in IN_PROGRESS)
+        quarantined = await db.pipeline_jobs.count_documents(
+            {"status": "failed", "auto_retry_disabled": True}
         )
-    }
-    total_jobs = sum(by_status.values())
-    active = await db.pipeline_jobs.count_documents({"active": True})
-    pending = by_status.get("pending", 0)
-    running = sum(by_status.get(s, 0) for s in IN_PROGRESS)
-    quarantined = await db.pipeline_jobs.count_documents(
-        {"status": "failed", "auto_retry_disabled": True}
-    )
-    recent_failed = await db.pipeline_jobs.count_documents(
-        {"status": "failed", "updated_at": {"$gte": now - timedelta(minutes=15)}}
-    )
-    recent_completed = await db.pipeline_jobs.count_documents(
-        {"status": "completed", "completed_at": {"$gte": now - timedelta(minutes=15)}}
-    )
-
-    stale_cutoff = now - timedelta(minutes=25)
-    stale = (
-        await db.pipeline_jobs.find(
-            {
-                "status": {"$in": list(IN_PROGRESS)},
-                "$or": [
-                    {"last_heartbeat": {"$lt": stale_cutoff}},
-                    {"last_heartbeat": None, "updated_at": {"$lt": stale_cutoff}},
-                ],
-            },
-            {
-                "_id": 0,
-                "product_slug": 1,
-                "status": 1,
-                "attempts": 1,
-                "last_heartbeat": 1,
-                "updated_at": 1,
-            },
+        recent_failed = await db.pipeline_jobs.count_documents(
+            {"status": "failed", "updated_at": {"$gte": now - timedelta(minutes=15)}}
         )
-        .sort("updated_at", 1)
-        .limit(20)
-        .to_list(length=20)
-    )
-
-    dupes = await db.pipeline_jobs.aggregate(
-        [
-            {"$match": {"active": True}},
-            {"$group": {"_id": "$product_slug", "n": {"$sum": 1}}},
-            {"$match": {"n": {"$gt": 1}}},
-            {"$sort": {"n": -1}},
-        ]
-    ).to_list(length=20)
-
-    in_progress = (
-        await db.pipeline_jobs.find(
-            {"status": {"$in": list(IN_PROGRESS)}},
-            {
-                "_id": 0,
-                "product_slug": 1,
-                "product_name": 1,
-                "status": 1,
-                "attempts": 1,
-                "documents_found": 1,
-                "documents_stored": 1,
-                "analyses_skipped": 1,
-                "force_reanalyze": 1,
-                "last_heartbeat": 1,
-                "updated_at": 1,
-                "steps": 1,
-            },
+        recent_completed = await db.pipeline_jobs.count_documents(
+            {"status": "completed", "completed_at": {"$gte": now - timedelta(minutes=15)}}
         )
-        .sort("updated_at", -1)
-        .to_list(length=50)
-    )
 
-    recent_terminal = (
-        await db.pipeline_jobs.find(
-            {
-                "status": {"$in": ["completed", "failed", "no_documents", "interrupted"]},
-                "updated_at": {"$gte": now - timedelta(minutes=15)},
-            },
-            {
-                "_id": 0,
-                "product_slug": 1,
-                "status": 1,
-                "error": 1,
-                "error_detail": 1,
-                "documents_found": 1,
-                "documents_stored": 1,
-                "analyses_skipped": 1,
-                "completed_at": 1,
-                "updated_at": 1,
-            },
+        stale_cutoff = now - timedelta(minutes=25)
+        stale = (
+            await db.pipeline_jobs.find(
+                {
+                    "status": {"$in": list(IN_PROGRESS)},
+                    "$or": [
+                        {"last_heartbeat": {"$lt": stale_cutoff}},
+                        {"last_heartbeat": None, "updated_at": {"$lt": stale_cutoff}},
+                    ],
+                },
+                {
+                    "_id": 0,
+                    "product_slug": 1,
+                    "status": 1,
+                    "attempts": 1,
+                    "last_heartbeat": 1,
+                    "updated_at": 1,
+                },
+            )
+            .sort("updated_at", 1)
+            .limit(20)
+            .to_list(length=20)
         )
-        .sort("updated_at", -1)
-        .limit(10)
-        .to_list(length=10)
-    )
 
-    watch_jobs = (
-        await db.pipeline_jobs.find(
-            {"status": {"$in": list(IN_PROGRESS)}},
-            {
-                "_id": 0,
-                "product_slug": 1,
-                "product_name": 1,
-                "status": 1,
-                "attempts": 1,
-                "documents_found": 1,
-                "documents_stored": 1,
-                "last_heartbeat": 1,
-                "updated_at": 1,
-                "steps": 1,
-                "error": 1,
-                "error_detail": 1,
-            },
+        dupes = await db.pipeline_jobs.aggregate(
+            [
+                {"$match": {"active": True}},
+                {"$group": {"_id": "$product_slug", "n": {"$sum": 1}}},
+                {"$match": {"n": {"$gt": 1}}},
+                {"$sort": {"n": -1}},
+            ]
+        ).to_list(length=20)
+
+        in_progress = (
+            await db.pipeline_jobs.find(
+                {"status": {"$in": list(IN_PROGRESS)}},
+                {
+                    "_id": 0,
+                    "product_slug": 1,
+                    "product_name": 1,
+                    "status": 1,
+                    "attempts": 1,
+                    "documents_found": 1,
+                    "documents_stored": 1,
+                    "analyses_skipped": 1,
+                    "force_reanalyze": 1,
+                    "last_heartbeat": 1,
+                    "updated_at": 1,
+                    "steps": 1,
+                },
+            )
+            .sort("updated_at", -1)
+            .to_list(length=50)
         )
-        .sort("updated_at", -1)
-        .limit(8)
-        .to_list(length=8)
-    )
 
-    completed_total = by_status.get("completed", 0)
-    failed_total = by_status.get("failed", 0)
-    interrupted_total = by_status.get("interrupted", 0)
-    blocked = await db.pipeline_jobs.count_documents(
-        {"active": False, "status": {"$nin": ["completed", "failed", "no_documents"]}}
-    )
+        recent_terminal = (
+            await db.pipeline_jobs.find(
+                {
+                    "status": {"$in": ["completed", "failed", "no_documents", "interrupted"]},
+                    "updated_at": {"$gte": now - timedelta(minutes=15)},
+                },
+                {
+                    "_id": 0,
+                    "product_slug": 1,
+                    "status": 1,
+                    "error": 1,
+                    "error_detail": 1,
+                    "documents_found": 1,
+                    "documents_stored": 1,
+                    "analyses_skipped": 1,
+                    "completed_at": 1,
+                    "updated_at": 1,
+                },
+            )
+            .sort("updated_at", -1)
+            .limit(10)
+            .to_list(length=10)
+        )
 
-    stall_risk = _stall_risk_jobs(in_progress, now)
+        watch_jobs = (
+            await db.pipeline_jobs.find(
+                {"status": {"$in": list(IN_PROGRESS)}},
+                {
+                    "_id": 0,
+                    "product_slug": 1,
+                    "product_name": 1,
+                    "status": 1,
+                    "attempts": 1,
+                    "documents_found": 1,
+                    "documents_stored": 1,
+                    "last_heartbeat": 1,
+                    "updated_at": 1,
+                    "steps": 1,
+                    "error": 1,
+                    "error_detail": 1,
+                },
+            )
+            .sort("updated_at", -1)
+            .limit(8)
+            .to_list(length=8)
+        )
 
-    client.close()
+        completed_total = by_status.get("completed", 0)
+        failed_total = by_status.get("failed", 0)
+        interrupted_total = by_status.get("interrupted", 0)
+        blocked = await db.pipeline_jobs.count_documents(
+            {"active": False, "status": {"$nin": ["completed", "failed", "no_documents"]}}
+        )
+
+        stall_risk = _stall_risk_jobs(in_progress, now)
+    finally:
+        client.close()
 
     alerts: list[str] = []
     if dupes:
@@ -1074,8 +1075,11 @@ async def main() -> None:
         )
         exit_code = 0
         while time.time() < deadline:
-            code = await _run_once(include_logs=include_logs, auto_fix=auto_fix)
-            exit_code = max(exit_code, code)
+            try:
+                code = await _run_once(include_logs=include_logs, auto_fix=auto_fix)
+                exit_code = max(exit_code, code)
+            except Exception as exc:
+                print(f"[WATCHDOG] Error during run: {exc}", file=sys.stderr)
             remaining_h = (deadline - time.time()) / 3600
             print(f"[WATCHDOG] next check in {LOOP_INTERVAL_SECONDS}s (~{remaining_h:.1f}h left)")
             await asyncio.sleep(LOOP_INTERVAL_SECONDS)

--- a/packages/backend/scripts/crawler_monitor.py
+++ b/packages/backend/scripts/crawler_monitor.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import os
 import re
 import subprocess
@@ -29,6 +30,8 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from src.core.config import DatabaseConfig
 from src.core.database import db_session
 from src.repositories.pipeline_repository import PipelineRepository
+
+logger = logging.getLogger(__name__)
 
 IN_PROGRESS = ("crawling", "synthesising", "generating_overview")
 STATE_FILE = Path("/tmp/clausea_crawler_monitor_state.json")
@@ -1079,7 +1082,7 @@ async def main() -> None:
                 code = await _run_once(include_logs=include_logs, auto_fix=auto_fix)
                 exit_code = max(exit_code, code)
             except Exception as exc:
-                print(f"[WATCHDOG] Error during run: {exc}", file=sys.stderr)
+                logger.error("Watchdog run failed: %s", exc, exc_info=True)
             remaining_h = (deadline - time.time()) / 3600
             print(f"[WATCHDOG] next check in {LOOP_INTERVAL_SECONDS}s (~{remaining_h:.1f}h left)")
             await asyncio.sleep(LOOP_INTERVAL_SECONDS)

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -270,11 +270,12 @@ class ClauseaCrawler:
         self._render_failures: int = 0
         self._render_slot_wait_total: float = 0.0
         self._render_recovered: int = 0
-        # Consecutive browser-fetch failures across the whole crawl session. Reset to 0
-        # on any browser success; once the count reaches BROWSER_DOMAIN_FAILURE_CAP all
-        # future browser attempts are skipped (static-only) to prevent zombie Camoufox
-        # processes from accumulating when pages consistently timeout in the browser.
-        self._consecutive_browser_failures: int = 0
+        # Per-domain consecutive browser-fetch failure counters.  Reset to 0 on any
+        # browser success for that domain; once a domain's count reaches
+        # BROWSER_DOMAIN_FAILURE_CAP all further browser attempts for *that domain*
+        # are skipped (static-only) to prevent zombie Camoufox processes from
+        # accumulating when pages on a particular domain consistently timeout.
+        self._domain_browser_failures: dict[str, int] = {}
 
         self.rate_limiter = DomainRateLimiter(
             delay_between_requests=delay_between_requests, jitter=self.delay_jitter
@@ -1615,14 +1616,16 @@ class ClauseaCrawler:
                     self.url_scorer.score_url(effective_url),
                 )
                 if relevance >= self.min_legal_score:
-                    if self._consecutive_browser_failures >= BROWSER_DOMAIN_FAILURE_CAP:
-                        # Too many consecutive browser failures — disable browser for the
-                        # remainder of this crawl session to prevent zombie Camoufox
+                    _domain = urlparse(effective_url).hostname or effective_url
+                    if self._domain_browser_failures.get(_domain, 0) >= BROWSER_DOMAIN_FAILURE_CAP:
+                        # Too many consecutive browser failures on this domain — skip browser
+                        # for the remainder of this crawl session to prevent zombie Camoufox
                         # processes from accumulating (each timeout leaves defunct OS
                         # processes behind).
                         logger.debug(
-                            "Browser cap reached (%d consecutive failures) — disabling browser for remainder of crawl",
-                            self._consecutive_browser_failures,
+                            "Browser cap reached (%d consecutive failures on %s) — disabling browser for this domain",
+                            self._domain_browser_failures.get(_domain, 0),
+                            _domain,
                         )
                         return CrawlResult(
                             url=effective_url,
@@ -1644,7 +1647,7 @@ class ClauseaCrawler:
                         if browser_page is not None and self._content_is_sufficient(
                             browser_page, effective_url
                         ):
-                            self._consecutive_browser_failures = 0
+                            self._domain_browser_failures[_domain] = 0
                             browser_resolved = browser_page.metadata.pop(
                                 "_browser_resolved_url", None
                             )
@@ -1655,8 +1658,10 @@ class ClauseaCrawler:
                                 self._render_recovered += 1
                             return self._build_crawl_result(effective_url, browser_page)
 
-                        # Browser returned nothing useful — increment global consecutive cap.
-                        self._consecutive_browser_failures += 1
+                        # Browser returned nothing useful — increment per-domain failure counter.
+                        self._domain_browser_failures[_domain] = (
+                            self._domain_browser_failures.get(_domain, 0) + 1
+                        )
                         if browser_page is None:
                             self._render_failures += 1
                             if not self._in_render_retry:

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -63,6 +63,7 @@ from src.crawler.constants import (
     _TLD_EXTRACT,
     _TRACKING_QUERY_PARAMS,
     ACCEPT_HEADER,
+    BROWSER_DOMAIN_FAILURE_CAP,
     BROWSER_LOAD_STATE_TIMEOUT_MS,
     BROWSER_NAV_TIMEOUT_MS,
     CONVERGENCE_LEGAL_SCORE,
@@ -269,6 +270,11 @@ class ClauseaCrawler:
         self._render_failures: int = 0
         self._render_slot_wait_total: float = 0.0
         self._render_recovered: int = 0
+        # Consecutive browser-fetch failures across the whole crawl session. Reset to 0
+        # on any browser success; once the count reaches BROWSER_DOMAIN_FAILURE_CAP all
+        # future browser attempts are skipped (static-only) to prevent zombie Camoufox
+        # processes from accumulating when pages consistently timeout in the browser.
+        self._consecutive_browser_failures: int = 0
 
         self.rate_limiter = DomainRateLimiter(
             delay_between_requests=delay_between_requests, jitter=self.delay_jitter
@@ -1606,38 +1612,57 @@ class ClauseaCrawler:
                     self.url_scorer.score_url(effective_url),
                 )
                 if relevance >= self.min_legal_score:
-                    slot_wait_start = time.monotonic()
-                    async with self._browser_render_slot():
-                        self._render_slot_wait_total += time.monotonic() - slot_wait_start
-                        self._render_attempts += 1
-                        browser_page = await self._browser_fetch(effective_url)
-                    if browser_page is not None and self._content_is_sufficient(
-                        browser_page, effective_url
-                    ):
-                        browser_resolved = browser_page.metadata.pop("_browser_resolved_url", None)
-                        if browser_resolved and browser_resolved != effective_url:
-                            effective_url = browser_resolved
-                            self.visited_urls.add(self.normalize_url(effective_url))
-                        if self._in_render_retry:
-                            self._render_recovered += 1
-                        return self._build_crawl_result(effective_url, browser_page)
+                    if self._consecutive_browser_failures >= BROWSER_DOMAIN_FAILURE_CAP:
+                        # Too many consecutive browser failures — disable browser for the
+                        # remainder of this crawl session to prevent zombie Camoufox
+                        # processes from accumulating (each timeout leaves defunct OS
+                        # processes behind).
+                        logger.debug(
+                            "Browser cap reached (%d consecutive failures) — disabling browser for remainder of crawl",
+                            self._consecutive_browser_failures,
+                        )
+                    else:
+                        slot_wait_start = time.monotonic()
+                        async with self._browser_render_slot():
+                            self._render_slot_wait_total += time.monotonic() - slot_wait_start
+                            self._render_attempts += 1
+                            browser_page = await self._browser_fetch(effective_url)
+                        if browser_page is not None and self._content_is_sufficient(
+                            browser_page, effective_url
+                        ):
+                            self._consecutive_browser_failures = 0
+                            browser_resolved = browser_page.metadata.pop(
+                                "_browser_resolved_url", None
+                            )
+                            if browser_resolved and browser_resolved != effective_url:
+                                effective_url = browser_resolved
+                                self.visited_urls.add(self.normalize_url(effective_url))
+                            if self._in_render_retry:
+                                self._render_recovered += 1
+                            return self._build_crawl_result(effective_url, browser_page)
 
-                    if browser_page is None:
-                        self._render_failures += 1
-                        if not self._in_render_retry:
-                            self._render_retry_queue.append(effective_url)
+                        # Browser returned nothing useful — increment global consecutive cap.
+                        self._consecutive_browser_failures += 1
+                        if browser_page is None:
+                            self._render_failures += 1
+                            if not self._in_render_retry:
+                                self._render_retry_queue.append(effective_url)
 
-                    return CrawlResult(
-                        url=effective_url,
-                        title=(browser_page.title if browser_page else ""),
-                        content="",
-                        markdown="",
-                        metadata=(browser_page.metadata if browser_page else {}),
-                        status_code=(browser_page.status_code if browser_page else raw.status_code),
-                        success=False,
-                        error_message="Static content unusable and browser rendering failed",
-                        discovered_links=(browser_page.discovered_links if browser_page else []),
-                    )
+                        return CrawlResult(
+                            url=effective_url,
+                            title=(browser_page.title if browser_page else ""),
+                            content="",
+                            markdown="",
+                            metadata=(browser_page.metadata if browser_page else {}),
+                            status_code=(
+                                browser_page.status_code if browser_page else raw.status_code
+                            ),
+                            success=False,
+                            error_message="Static content unusable and browser rendering failed",
+                            discovered_links=(
+                                browser_page.discovered_links if browser_page else []
+                            ),
+                        )
 
                 if page is not None:
                     return self._build_crawl_result(effective_url, page)

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -270,12 +270,7 @@ class ClauseaCrawler:
         self._render_failures: int = 0
         self._render_slot_wait_total: float = 0.0
         self._render_recovered: int = 0
-        # Per-domain consecutive browser-fetch failure counters.  Reset to 0 on any
-        # browser success for that domain; once a domain's count reaches
-        # BROWSER_DOMAIN_FAILURE_CAP all further browser attempts for *that domain*
-        # are skipped (static-only) to prevent zombie Camoufox processes from
-        # accumulating when pages on a particular domain consistently timeout.
-        self._domain_browser_failures: dict[str, int] = {}
+        self._consecutive_browser_failures: int = 0
 
         self.rate_limiter = DomainRateLimiter(
             delay_between_requests=delay_between_requests, jitter=self.delay_jitter
@@ -1616,16 +1611,10 @@ class ClauseaCrawler:
                     self.url_scorer.score_url(effective_url),
                 )
                 if relevance >= self.min_legal_score:
-                    _domain = urlparse(effective_url).hostname or effective_url
-                    if self._domain_browser_failures.get(_domain, 0) >= BROWSER_DOMAIN_FAILURE_CAP:
-                        # Too many consecutive browser failures on this domain — skip browser
-                        # for the remainder of this crawl session to prevent zombie Camoufox
-                        # processes from accumulating (each timeout leaves defunct OS
-                        # processes behind).
+                    if self._consecutive_browser_failures >= BROWSER_DOMAIN_FAILURE_CAP:
                         logger.debug(
-                            "Browser cap reached (%d consecutive failures on %s) — disabling browser for this domain",
-                            self._domain_browser_failures.get(_domain, 0),
-                            _domain,
+                            "Browser cap reached (%d consecutive failures) — disabling browser for remainder of crawl",
+                            self._consecutive_browser_failures,
                         )
                         return CrawlResult(
                             url=effective_url,
@@ -1647,7 +1636,7 @@ class ClauseaCrawler:
                         if browser_page is not None and self._content_is_sufficient(
                             browser_page, effective_url
                         ):
-                            self._domain_browser_failures[_domain] = 0
+                            self._consecutive_browser_failures = 0
                             browser_resolved = browser_page.metadata.pop(
                                 "_browser_resolved_url", None
                             )
@@ -1658,10 +1647,7 @@ class ClauseaCrawler:
                                 self._render_recovered += 1
                             return self._build_crawl_result(effective_url, browser_page)
 
-                        # Browser returned nothing useful — increment per-domain failure counter.
-                        self._domain_browser_failures[_domain] = (
-                            self._domain_browser_failures.get(_domain, 0) + 1
-                        )
+                        self._consecutive_browser_failures += 1
                         if browser_page is None:
                             self._render_failures += 1
                             if not self._in_render_retry:

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -788,6 +788,7 @@ class ClauseaCrawler:
         "connection closed",
         "context or browser has been closed",
         "browser closed",
+        "window is null",  # Camoufox crash: context.new_page() fails when browser process dies
     )
 
     def _browser_render_slot(self) -> asyncio.Semaphore:

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -530,6 +530,8 @@ class ClauseaCrawler:
                 request_args["proxy"] = self.proxy
 
             async with session.get(url, **request_args) as response:
+                if response.status != 200:
+                    return None
                 content_type = response.headers.get("content-type", "").lower()
                 if not any(
                     content_type.startswith(ct)
@@ -1620,6 +1622,17 @@ class ClauseaCrawler:
                         logger.debug(
                             "Browser cap reached (%d consecutive failures) — disabling browser for remainder of crawl",
                             self._consecutive_browser_failures,
+                        )
+                        return CrawlResult(
+                            url=effective_url,
+                            title=(page.title if page else ""),
+                            content="",
+                            markdown="",
+                            metadata=(page.metadata if page else {}),
+                            status_code=raw.status_code,
+                            success=False,
+                            error_message="Static content unusable and browser rendering skipped due to domain failure cap",
+                            discovered_links=(page.discovered_links if page else []),
                         )
                     else:
                         slot_wait_start = time.monotonic()

--- a/packages/backend/src/crawler/constants.py
+++ b/packages/backend/src/crawler/constants.py
@@ -190,9 +190,9 @@ CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
 # Fires when an entire domain is consistently inaccessible (bot wall, auth gate, etc.)
 # so the job fails fast rather than exhausting the max-pages budget on dead URLs.
 CRAWL_BOT_WALL_ABORT = int(os.getenv("CRAWLER_BOT_WALL_ABORT", "20"))
-# Stop attempting browser renders globally once this many consecutive browser fetches have
-# failed (timeout, crash) in a single crawl session. Prevents zombie Camoufox processes
-# from accumulating when pages consistently timeout in the browser.
+# Stop attempting browser renders once this many consecutive browser fetches in a single
+# crawl session have failed (timeout, crash). Prevents zombie Camoufox processes from
+# accumulating when pages consistently timeout in the browser.
 BROWSER_DOMAIN_FAILURE_CAP = int(os.getenv("CRAWLER_BROWSER_DOMAIN_FAILURE_CAP", "3"))
 MIN_PAGES_PER_SEED = int(os.getenv("CRAWLER_MIN_PAGES_PER_SEED", "60"))
 MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC = int(

--- a/packages/backend/src/crawler/constants.py
+++ b/packages/backend/src/crawler/constants.py
@@ -186,7 +186,14 @@ STEALTH_ACCEPT_HEADER = (
 DEFAULT_NO_POLICY_PAGE_BUDGET = int(os.getenv("CRAWLER_NO_POLICY_PAGE_BUDGET", "50"))
 CONVERGENCE_LEGAL_SCORE = 0.2
 CRAWL_EXHAUSTION_GRACE = int(os.getenv("CRAWLER_EXHAUSTION_GRACE", "10"))
-CRAWL_BOT_WALL_ABORT = int(os.getenv("CRAWLER_BOT_WALL_ABORT", "50"))
+# Abort a crawl after this many *consecutive* URL failures with no success in between.
+# Fires when an entire domain is consistently inaccessible (bot wall, auth gate, etc.)
+# so the job fails fast rather than exhausting the max-pages budget on dead URLs.
+CRAWL_BOT_WALL_ABORT = int(os.getenv("CRAWLER_BOT_WALL_ABORT", "20"))
+# Stop attempting browser renders globally once this many consecutive browser fetches have
+# failed (timeout, crash) in a single crawl session. Prevents zombie Camoufox processes
+# from accumulating when pages consistently timeout in the browser.
+BROWSER_DOMAIN_FAILURE_CAP = int(os.getenv("CRAWLER_BROWSER_DOMAIN_FAILURE_CAP", "3"))
 MIN_PAGES_PER_SEED = int(os.getenv("CRAWLER_MIN_PAGES_PER_SEED", "60"))
 MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC = int(
     os.getenv("CRAWLER_MAX_ENGLISH_LOCALE_VARIANTS_PER_DOC", "2")

--- a/packages/backend/src/pipeline/pipeline.py
+++ b/packages/backend/src/pipeline/pipeline.py
@@ -63,7 +63,32 @@ def _is_valid_brand_name(name: str) -> bool:
     name = name.strip()
     if not name or not (2 <= len(name) <= 80):
         return False
-    if name.lower() in {"undefined", "null", "none", "unknown", "website", "home"}:
+    if name.lower() in {
+        "undefined",
+        "null",
+        "none",
+        "unknown",
+        "website",
+        "home",
+        "homepage",
+        "privacy",
+        "privacy policy",
+        "terms",
+        "terms of service",
+        "terms of use",
+        "cookie policy",
+        "cookies",
+        "legal",
+        "legal notice",
+        "tos",
+        "about",
+        "about us",
+        "contact",
+        "contact us",
+        "help",
+        "support",
+        "faq",
+    }:
         return False
     if "://" in name or name.startswith("www."):
         return False
@@ -103,9 +128,13 @@ def _extract_brand_name(results: list[CrawlResult]) -> str | None:
         title = (meta.get("title") or result.title or "").strip()
         for sep in (" - ", " | ", " — ", " · ", ": "):
             if sep in title:
-                candidate = title.split(sep)[0].strip()
-                if _is_valid_brand_name(candidate):
-                    return candidate
+                parts = title.split(sep)
+                candidate_first = parts[0].strip()
+                if _is_valid_brand_name(candidate_first):
+                    return candidate_first
+                candidate_last = parts[-1].strip()
+                if _is_valid_brand_name(candidate_last):
+                    return candidate_last
 
     return None
 

--- a/packages/backend/src/pipeline/pipeline.py
+++ b/packages/backend/src/pipeline/pipeline.py
@@ -92,6 +92,10 @@ def _is_valid_brand_name(name: str) -> bool:
         return False
     if "://" in name or name.startswith("www."):
         return False
+    # Reject ISO-style abbreviations (2-letter country/language codes like "GB", "US", "EN")
+    # that can appear as the trailing segment of titles such as "Privacy Policy - GB".
+    if len(name) == 2 and name.isupper():
+        return False
     return True
 
 
@@ -129,12 +133,10 @@ def _extract_brand_name(results: list[CrawlResult]) -> str | None:
         for sep in (" - ", " | ", " — ", " · ", ": "):
             if sep in title:
                 parts = title.split(sep)
-                candidate_first = parts[0].strip()
-                if _is_valid_brand_name(candidate_first):
-                    return candidate_first
-                candidate_last = parts[-1].strip()
-                if _is_valid_brand_name(candidate_last):
-                    return candidate_last
+                for part in parts:
+                    candidate = part.strip()
+                    if _is_valid_brand_name(candidate):
+                        return candidate
 
     return None
 

--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -40,12 +40,12 @@ class StaleReapContext(StrEnum):
 
 
 def _stale_reap_detail(context: StaleReapContext, stale_threshold_minutes: int) -> str:
-    if context == StaleReapContext.worker_boot:
+    if context is StaleReapContext.worker_boot:
         return (
             "The crawler worker restarted or crashed while this job was in progress "
             "(for example after a deploy). It will be retried automatically."
         )
-    if context == StaleReapContext.api_startup:
+    if context is StaleReapContext.api_startup:
         return (
             f"This job had no progress for over {stale_threshold_minutes} minutes when the "
             "API service started and was marked stale. It will be retried automatically."
@@ -525,12 +525,12 @@ class PipelineRepository(BaseRepository):
         )
         count = result.modified_count
         if count:
-            if context == StaleReapContext.worker_boot:
+            if context is StaleReapContext.worker_boot:
                 logger.warning(
                     "Marked %d in-flight job(s) as failed after worker boot (orphan sweep)",
                     count,
                 )
-            elif context == StaleReapContext.api_startup:
+            elif context is StaleReapContext.api_startup:
                 logger.warning(
                     "Marked %d stale pipeline job(s) as failed on API startup (>%dm idle)",
                     count,

--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -255,10 +255,21 @@ class PipelineRepository(BaseRepository):
             )
             return None
 
+        now = datetime.now()
         data: dict[str, Any] | None = await db[self.COLLECTION].find_one_and_update(
             {"id": candidate["id"], "status": "pending"},
             {
-                "$set": {"status": "crawling", "started_at": datetime.now(), "active": True},
+                "$set": {
+                    "status": "crawling",
+                    "started_at": now,
+                    "active": True,
+                    # Set last_heartbeat at claim time so stale detection has a non-null
+                    # timestamp from the moment the job is claimed. Without this, a worker
+                    # that is SIGKILL'd before the first progress callback leaves
+                    # last_heartbeat=null, and mark_stale_as_failed must fall back to
+                    # updated_at — which can be ambiguous when multiple fields update it.
+                    "last_heartbeat": now,
+                },
                 "$inc": {"attempts": 1},
             },
             return_document=ReturnDocument.AFTER,

--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -40,12 +40,12 @@ class StaleReapContext(StrEnum):
 
 
 def _stale_reap_detail(context: StaleReapContext, stale_threshold_minutes: int) -> str:
-    if context is StaleReapContext.worker_boot:
+    if context == StaleReapContext.worker_boot:
         return (
             "The crawler worker restarted or crashed while this job was in progress "
             "(for example after a deploy). It will be retried automatically."
         )
-    if context is StaleReapContext.api_startup:
+    if context == StaleReapContext.api_startup:
         return (
             f"This job had no progress for over {stale_threshold_minutes} minutes when the "
             "API service started and was marked stale. It will be retried automatically."
@@ -525,12 +525,12 @@ class PipelineRepository(BaseRepository):
         )
         count = result.modified_count
         if count:
-            if context is StaleReapContext.worker_boot:
+            if context == StaleReapContext.worker_boot:
                 logger.warning(
                     "Marked %d in-flight job(s) as failed after worker boot (orphan sweep)",
                     count,
                 )
-            elif context is StaleReapContext.api_startup:
+            elif context == StaleReapContext.api_startup:
                 logger.warning(
                     "Marked %d stale pipeline job(s) as failed on API startup (>%dm idle)",
                     count,

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -45,10 +45,12 @@ logger = get_logger(__name__)
 # a large/multi-jurisdiction site runs to completion. Set PIPELINE_MAX_DURATION_SECONDS > 0 only if
 # you want a hard ceiling regardless of forward progress.
 MAX_PIPELINE_DURATION_SECONDS = float(os.getenv("PIPELINE_MAX_DURATION_SECONDS", "0"))
-# Abort a job that makes no forward progress (no page/document/step update bumps updated_at)
-# for this long. Bounds *inactivity*, not total runtime: a slow-but-advancing pipeline runs
-# indefinitely, while a wedged one frees its worker slot fast instead of clogging it.
-STALL_TIMEOUT_SECONDS = float(os.getenv("PIPELINE_STALL_TIMEOUT_SECONDS", "1200"))
+# Abort a job that makes no forward progress (no heartbeat bump) for this long.
+# The crawler's own CRAWL_BOT_WALL_ABORT (20 consecutive failures) handles the
+# "completely blocked site" case early — this stall guard is the backstop for genuinely
+# hung/wedged processes (OOM, deadlock, etc.) that never update their heartbeat.
+# 3 600 s (60 min) is generous enough for legitimately large multi-jurisdiction crawls.
+STALL_TIMEOUT_SECONDS = float(os.getenv("PIPELINE_STALL_TIMEOUT_SECONDS", "3600"))
 
 
 class _PipelineStalled(Exception):

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -561,11 +561,21 @@ class PipelineService:
                         # re-created automatically if the user retries the URL later.
                         if job.status == "no_documents":
                             try:
-                                await db.products.delete_one({"id": product.id})
-                                logger.info(
-                                    "Removed empty product %s (no policy documents found)",
-                                    job.product_slug,
+                                doc_count = await db.documents.count_documents(
+                                    {"product_id": product.id}
                                 )
+                                if doc_count == 0:
+                                    await db.products.delete_one({"id": product.id})
+                                    logger.info(
+                                        "Removed empty product %s (no policy documents found)",
+                                        job.product_slug,
+                                    )
+                                else:
+                                    logger.info(
+                                        "Kept product %s despite no_documents — %d existing document(s) present",
+                                        job.product_slug,
+                                        doc_count,
+                                    )
                             except Exception as del_exc:  # noqa: BLE001
                                 logger.warning(
                                     "Failed to remove empty product %s: %s",

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -162,9 +162,11 @@ async def _run_worker_loop(
     repo: PipelineRepository, stop: asyncio.Event, loop: asyncio.AbstractEventLoop
 ) -> None:
     # Reap jobs orphaned by a previous crash/redeploy before claiming new work.
-    # On boot we use threshold=0: any job still "crawling" when this process starts
-    # was owned by a now-dead process and must be reset immediately. The periodic
-    # sweep uses 30 min to avoid interrupting genuinely running jobs.
+    # We use a 2-minute threshold (not 0) so that sibling replicas starting within
+    # seconds of each other don't orphan each other's freshly-claimed jobs.  Any
+    # job running for more than 2 minutes when this replica boots was owned by a
+    # genuinely dead process and should be reset.  The periodic sweep (every 5 min)
+    # catches the rare case where a crash happens within that 2-minute window.
     async with db_session() as db:
         # First priority: re-queue jobs that were gracefully interrupted by the
         # previous worker process. These are always retryable — they were cut short
@@ -174,7 +176,7 @@ async def _run_worker_loop(
             logger.info("Boot sweep: re-queued %d interrupted job(s)", interrupted)
         # Then reap any stale jobs that weren't caught by the graceful shutdown.
         boot_reaped = await repo.mark_stale_as_failed(
-            db, stale_threshold_minutes=0, context=StaleReapContext.worker_boot
+            db, stale_threshold_minutes=2, context=StaleReapContext.worker_boot
         )
         if boot_reaped:
             async with db_session() as db2:


### PR DESCRIPTION
## Summary

- **Per-domain browser failure cap** (`BROWSER_DOMAIN_FAILURE_CAP=3`): after 3 consecutive browser-fetch failures on the same domain, all further browser attempts for that domain are skipped (static-only fallback). This directly prevents the HBO Max zombie-process crash: that site serves hundreds of locale pages (`/privacy/legal-bases/*`) that all 20s-timeout in the browser, leaving defunct Camoufox processes and eventually OOM-killing the worker. With the cap, only 3 browser slots are consumed per domain; the rest are fast static fetches that fail cleanly in < 1s.

- **Lower `CRAWL_BOT_WALL_ABORT` 50 → 20**: the existing consecutive-URL-failure abort fires after 20 back-to-back failures (down from 50). Auth-gated and hard-blocked sites (Teams, etc.) give up their worker slot in ~20 URLs instead of ~50.

- **Raise `STALL_TIMEOUT_SECONDS` 1200 → 3600**: the stall guard is the backstop for genuinely dead processes (OOM, deadlock) whose heartbeat stops entirely. Now that the crawler itself handles the "blocked site" early-exit via `CRAWL_BOT_WALL_ABORT`, the stall guard no longer needs to be the primary time-killer — large multi-jurisdiction crawls get 60 min to complete without premature termination.

## Test plan
- [ ] All 921 backend tests pass (`uv run pytest`)
- [ ] `ruff check` + `ty check` clean
- [ ] Verify HBO Max job completes quickly after deploy (no more worker OOM crashes)
- [ ] Verify blocked sites (Teams, auth-gated) still fail quickly via bot-wall abort