### PR TITLE
fix(worker): robust Playwright coreBundle.js patch

### DIFF
--- a/packages/backend/Dockerfile.worker
+++ b/packages/backend/Dockerfile.worker
@@ -96,9 +96,27 @@ COPY --from=builder /opt/venv /opt/venv
 # ("Cannot read properties of undefined (reading 'url')") that crashes the
 # Node.js driver process and kills the container.
 # Fixed upstream in camoufox >0.4.11; patch the vendored bundle in the meantime.
-RUN sed -i \
-    's/url: pageError\.location\.url,/url: pageError.location ? pageError.location.url : "",/' \
-    /opt/venv/lib/python3.11/site-packages/playwright/driver/package/lib/coreBundle.js
+# Using Python for exact string replacement to avoid shell/sed escaping issues.
+# The build fails loudly if the pattern is not found (catches version drift).
+RUN python3 -c "
+import sys, glob
+# Locate coreBundle.js regardless of the exact Python version in the venv.
+matches = glob.glob('/opt/venv/lib/python*/site-packages/playwright/driver/package/lib/coreBundle.js')
+if not matches:
+    sys.exit('ERROR: coreBundle.js not found — update the patch path')
+path = matches[0]
+old = 'url: pageError.location.url,'
+new = 'url: pageError.location ? pageError.location.url : \"\",'
+with open(path) as f:
+    src = f.read()
+if old not in src:
+    sys.exit(f'ERROR: Playwright patch pattern not found in {path} — already fixed or version changed')
+patched = src.replace(old, new)
+with open(path, 'w') as f:
+    f.write(patched)
+count = patched.count(new)
+print(f'Playwright patch applied to {path} ({count} occurrence(s))')
+"
 
 # Copy the pre-fetched Camoufox Firefox binary (stored under XDG_CACHE_HOME).
 COPY --from=builder /opt/camoufox-cache /opt/camoufox-cache


### PR DESCRIPTION
## Summary

- Replaces the `sed` one-liner for the Playwright Node.js driver patch with a Python script that performs exact string replacement
- The original `sed` command was silently failing (escaping/path issue), so the `pageError.location.url` TypeError was still crashing the Playwright driver during crawls
- The build now fails loudly if the target pattern is not found (guards against Playwright version drift)
- Uses a `glob` pattern to find `coreBundle.js` regardless of the Python minor version in the venv

## Test plan
- [ ] Railway build for the `crawler` service succeeds and logs `"Playwright patch applied to ... (N occurrence(s))"`
- [ ] `TypeError: Cannot read properties of undefined (reading 'url')` no longer appears in crawler logs after deploy