### PR TITLE
refactor(worker): extract Playwright patch to scripts/patch_playwright.py

### DIFF
--- a/packages/backend/Dockerfile.worker
+++ b/packages/backend/Dockerfile.worker
@@ -91,32 +91,9 @@ WORKDIR /app
 # Copy the compiled virtual environment (all external deps, no local package).
 COPY --from=builder /opt/venv /opt/venv
 
-# Patch Playwright's Node driver (coreBundle.js): Camoufox's Juggler can emit
-# Page.uncaughtError without a location field, causing an uncaught TypeError
-# ("Cannot read properties of undefined (reading 'url')") that crashes the
-# Node.js driver process and kills the container.
-# Fixed upstream in camoufox >0.4.11; patch the vendored bundle in the meantime.
-# Using Python for exact string replacement to avoid shell/sed escaping issues.
-# The build fails loudly if the pattern is not found (catches version drift).
-RUN python3 -c "
-import sys, glob
-# Locate coreBundle.js regardless of the exact Python version in the venv.
-matches = glob.glob('/opt/venv/lib/python*/site-packages/playwright/driver/package/lib/coreBundle.js')
-if not matches:
-    sys.exit('ERROR: coreBundle.js not found — update the patch path')
-path = matches[0]
-old = 'url: pageError.location.url,'
-new = 'url: pageError.location ? pageError.location.url : \"\",'
-with open(path) as f:
-    src = f.read()
-if old not in src:
-    sys.exit(f'ERROR: Playwright patch pattern not found in {path} — already fixed or version changed')
-patched = src.replace(old, new)
-with open(path, 'w') as f:
-    f.write(patched)
-count = patched.count(new)
-print(f'Playwright patch applied to {path} ({count} occurrence(s))')
-"
+# Patch Playwright's Node driver — see scripts/patch_playwright.py for details.
+COPY scripts/patch_playwright.py /tmp/patch_playwright.py
+RUN python3 /tmp/patch_playwright.py
 
 # Copy the pre-fetched Camoufox Firefox binary (stored under XDG_CACHE_HOME).
 COPY --from=builder /opt/camoufox-cache /opt/camoufox-cache

--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -27,14 +27,15 @@ def main() -> None:
     old = "url: pageError.location.url,"
     new = 'url: pageError.location ? pageError.location.url : "",'
 
-    src = path.read_text() if hasattr(path, "read_text") else open(path).read()
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
     if old not in src:
         sys.exit(
             f"ERROR: patch pattern not found in {path} — already fixed upstream or version changed"
         )
 
     patched = src.replace(old, new)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(patched)
 
     count = patched.count(new)

--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -1,0 +1,45 @@
+"""
+Patch Playwright's vendored Node.js driver (coreBundle.js).
+
+Camoufox's Juggler can emit Page.uncaughtError without a location field,
+causing an uncaught TypeError in _Page.addPageError:
+    url: pageError.location.url,   # crashes when location is undefined
+
+Fixed upstream in camoufox >0.4.11. This script patches the bundled file
+until the project upgrades to a fixed release.
+
+Run during Docker image build (after the venv is copied into the image).
+Exits non-zero if the file or pattern is not found so the build fails loudly.
+"""
+
+import glob
+import sys
+
+
+def main() -> None:
+    matches = glob.glob(
+        "/opt/venv/lib/python*/site-packages/playwright/driver/package/lib/coreBundle.js"
+    )
+    if not matches:
+        sys.exit("ERROR: coreBundle.js not found — update the patch path")
+
+    path = matches[0]
+    old = "url: pageError.location.url,"
+    new = 'url: pageError.location ? pageError.location.url : "",'
+
+    src = path.read_text() if hasattr(path, "read_text") else open(path).read()
+    if old not in src:
+        sys.exit(
+            f"ERROR: patch pattern not found in {path} — already fixed upstream or version changed"
+        )
+
+    patched = src.replace(old, new)
+    with open(path, "w") as f:
+        f.write(patched)
+
+    count = patched.count(new)
+    print(f"Playwright patch applied to {path} ({count} occurrence(s))")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Moves the inline Python one-liner from the Dockerfile into a proper script at `packages/backend/scripts/patch_playwright.py` so it's readable, commentable, and lintable.

The Dockerfile now just:
```dockerfile
COPY scripts/patch_playwright.py /tmp/patch_playwright.py
RUN python3 /tmp/patch_playwright.py
```