### PR TITLE
fix(worker): patch all three pageError.location crash sites in coreBundle.js

### DIFF
--- a/packages/backend/Dockerfile.worker
+++ b/packages/backend/Dockerfile.worker
@@ -91,32 +91,9 @@ WORKDIR /app
 # Copy the compiled virtual environment (all external deps, no local package).
 COPY --from=builder /opt/venv /opt/venv
 
-# Patch Playwright's Node driver (coreBundle.js): Camoufox's Juggler can emit
-# Page.uncaughtError without a location field, causing an uncaught TypeError
-# ("Cannot read properties of undefined (reading 'url')") that crashes the
-# Node.js driver process and kills the container.
-# Fixed upstream in camoufox >0.4.11; patch the vendored bundle in the meantime.
-# Using Python for exact string replacement to avoid shell/sed escaping issues.
-# The build fails loudly if the pattern is not found (catches version drift).
-RUN python3 -c "
-import sys, glob
-# Locate coreBundle.js regardless of the exact Python version in the venv.
-matches = glob.glob('/opt/venv/lib/python*/site-packages/playwright/driver/package/lib/coreBundle.js')
-if not matches:
-    sys.exit('ERROR: coreBundle.js not found — update the patch path')
-path = matches[0]
-old = 'url: pageError.location.url,'
-new = 'url: pageError.location ? pageError.location.url : \"\",'
-with open(path) as f:
-    src = f.read()
-if old not in src:
-    sys.exit(f'ERROR: Playwright patch pattern not found in {path} — already fixed or version changed')
-patched = src.replace(old, new)
-with open(path, 'w') as f:
-    f.write(patched)
-count = patched.count(new)
-print(f'Playwright patch applied to {path} ({count} occurrence(s))')
-"
+# Patch Playwright's Node driver — see scripts/patch_playwright.py for details.
+COPY scripts/patch_playwright.py /tmp/patch_playwright.py
+RUN python3 /tmp/patch_playwright.py
 
 # Copy the pre-fetched Camoufox Firefox binary (stored under XDG_CACHE_HOME).
 COPY --from=builder /opt/camoufox-cache /opt/camoufox-cache

--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -27,14 +27,15 @@ def main() -> None:
     old = "url: pageError.location.url,"
     new = 'url: pageError.location ? pageError.location.url : "",'
 
-    src = path.read_text() if hasattr(path, "read_text") else open(path).read()
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
     if old not in src:
         sys.exit(
             f"ERROR: patch pattern not found in {path} — already fixed upstream or version changed"
         )
 
     patched = src.replace(old, new)
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(patched)
 
     count = patched.count(new)

--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -1,0 +1,45 @@
+"""
+Patch Playwright's vendored Node.js driver (coreBundle.js).
+
+Camoufox's Juggler can emit Page.uncaughtError without a location field,
+causing an uncaught TypeError in _Page.addPageError:
+    url: pageError.location.url,   # crashes when location is undefined
+
+Fixed upstream in camoufox >0.4.11. This script patches the bundled file
+until the project upgrades to a fixed release.
+
+Run during Docker image build (after the venv is copied into the image).
+Exits non-zero if the file or pattern is not found so the build fails loudly.
+"""
+
+import glob
+import sys
+
+
+def main() -> None:
+    matches = glob.glob(
+        "/opt/venv/lib/python*/site-packages/playwright/driver/package/lib/coreBundle.js"
+    )
+    if not matches:
+        sys.exit("ERROR: coreBundle.js not found — update the patch path")
+
+    path = matches[0]
+    old = "url: pageError.location.url,"
+    new = 'url: pageError.location ? pageError.location.url : "",'
+
+    src = path.read_text() if hasattr(path, "read_text") else open(path).read()
+    if old not in src:
+        sys.exit(
+            f"ERROR: patch pattern not found in {path} — already fixed upstream or version changed"
+        )
+
+    patched = src.replace(old, new)
+    with open(path, "w") as f:
+        f.write(patched)
+
+    count = patched.count(new)
+    print(f"Playwright patch applied to {path} ({count} occurrence(s))")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -2,18 +2,42 @@
 Patch Playwright's vendored Node.js driver (coreBundle.js).
 
 Camoufox's Juggler can emit Page.uncaughtError without a location field,
-causing an uncaught TypeError in _Page.addPageError:
-    url: pageError.location.url,   # crashes when location is undefined
+causing uncaught TypeErrors anywhere coreBundle.js accesses pageError.location:
+
+  url: pageError.location.url,           → crashes when location is undefined
+  line: pageError.location.lineNumber,   → same crash on the next property
+  column: pageError.location.columnNumber
+
+There are at least two independent call sites that build a location object
+from pageError (one in the tracing path, one in the dispatcher path), so all
+three properties are replaced at every occurrence.
 
 Fixed upstream in camoufox >0.4.11. This script patches the bundled file
 until the project upgrades to a fixed release.
 
 Run during Docker image build (after the venv is copied into the image).
-Exits non-zero if the file or pattern is not found so the build fails loudly.
+Exits non-zero if coreBundle.js is not found so the build fails loudly.
+Logs a warning (but does NOT fail) when a pattern is absent — this means the
+file was already patched by a prior layer or a fixed upstream was installed.
 """
 
 import glob
 import sys
+
+PATCHES: list[tuple[str, str]] = [
+    (
+        "url: pageError.location.url,",
+        'url: pageError.location ? pageError.location.url : "",',
+    ),
+    (
+        "line: pageError.location.lineNumber,",
+        "line: pageError.location ? pageError.location.lineNumber : 0,",
+    ),
+    (
+        "column: pageError.location.columnNumber",
+        "column: pageError.location ? pageError.location.columnNumber : 0",
+    ),
+]
 
 
 def main() -> None:
@@ -24,22 +48,32 @@ def main() -> None:
         sys.exit("ERROR: coreBundle.js not found — update the patch path")
 
     path = matches[0]
-    old = "url: pageError.location.url,"
-    new = 'url: pageError.location ? pageError.location.url : "",'
-
     with open(path, encoding="utf-8") as f:
         src = f.read()
-    if old not in src:
-        sys.exit(
-            f"ERROR: patch pattern not found in {path} — already fixed upstream or version changed"
-        )
 
-    patched = src.replace(old, new)
+    patched = src
+    total_replaced = 0
+    for old, new in PATCHES:
+        count = patched.count(old)
+        if count == 0:
+            print(f"  WARNING: pattern not found (already patched or version changed): {old!r}")
+            continue
+        patched = patched.replace(old, new)
+        print(f"  Replaced {count}x: {old!r}")
+        total_replaced += count
+
+    if total_replaced == 0:
+        print(
+            f"Playwright patch: nothing to do in {path} (all patterns absent — likely already applied)"
+        )
+        return
+
     with open(path, "w", encoding="utf-8") as f:
         f.write(patched)
 
-    count = patched.count(new)
-    print(f"Playwright patch applied to {path} ({count} occurrence(s))")
+    print(
+        f"Playwright patch applied to {path} ({total_replaced} replacement(s) across {len(PATCHES)} pattern(s))"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Root cause**: `coreBundle.js` has two independent call sites that build a `location` object from `pageError` — the tracing path (~line 25566/19951) and the dispatcher path (~line 49624). The previous patch replaced `url: pageError.location.url,` at all occurrences, but `lineNumber` and `columnNumber` on the same object literal would also crash.
- **Why the crash re-appeared at 49624**: The `url:` replacement ran via `str.replace()` which replaces all matches — both sites should have been covered. The crash at 49624 showing `reading 'url'` (not `lineNumber`) confirms the `url:` fix at that specific occurrence was NOT applied, most likely because the Docker build cache hit the `RUN python3 /tmp/patch_playwright.py` layer before our script was updated.
- **Fix**: Extend the patch to cover all three property accesses (`url`, `lineNumber`, `columnNumber`) at every occurrence. Changing the script content busts the Docker RUN layer cache, ensuring the patch always re-executes on the current venv. Removes the hard-failure guard for missing patterns (absent patterns = already patched).

## Changes

- `patch_playwright.py`: patches 6 replacements across 3 patterns × 2 call sites

## Test plan

- [ ] Deploy crawler — confirm build logs show `Replaced 2x` for each of the three patterns
- [ ] Trigger an uncaught page error with no location field — confirm no TypeError crash
- [ ] All three Railway services return to Online