### PR TITLE
fix(worker): fail build on partial Playwright patch

### DIFF
--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -53,6 +53,7 @@ def main() -> None:
 
     patched = src
     total_replaced = 0
+    found_patterns = 0
     for old, new in PATCHES:
         count = patched.count(old)
         if count == 0:
@@ -61,12 +62,20 @@ def main() -> None:
         patched = patched.replace(old, new)
         print(f"  Replaced {count}x: {old!r}")
         total_replaced += count
+        found_patterns += 1
 
     if total_replaced == 0:
         print(
             f"Playwright patch: nothing to do in {path} (all patterns absent — likely already applied)"
         )
         return
+
+    if 0 < found_patterns < len(PATCHES):
+        sys.exit(
+            "ERROR: Partial patch applied — some patterns were found but others were missing. "
+            "coreBundle.js will still crash at runtime on unpatched properties. "
+            "Check whether Playwright changed its formatting or variable names."
+        )
 
     with open(path, "w", encoding="utf-8") as f:
         f.write(patched)

--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -16,9 +16,10 @@ Fixed upstream in camoufox >0.4.11. This script patches the bundled file
 until the project upgrades to a fixed release.
 
 Run during Docker image build (after the venv is copied into the image).
-Exits non-zero if coreBundle.js is not found so the build fails loudly.
-Logs a warning (but does NOT fail) when a pattern is absent — this means the
-file was already patched by a prior layer or a fixed upstream was installed.
+Exits non-zero on any of:
+  - coreBundle.js not found
+  - partial patch (some patterns found, others missing) → runtime crash guaranteed
+  - zero patterns found AND zero patched forms confirmed → Playwright changed formatting
 """
 
 import glob
@@ -40,6 +41,10 @@ PATCHES: list[tuple[str, str]] = [
 ]
 
 
+def warn(msg: str) -> None:
+    print(f"WARNING: {msg}", file=sys.stderr)
+
+
 def main() -> None:
     matches = glob.glob(
         "/opt/venv/lib/python*/site-packages/playwright/driver/package/lib/coreBundle.js"
@@ -57,7 +62,7 @@ def main() -> None:
     for old, new in PATCHES:
         count = patched.count(old)
         if count == 0:
-            print(f"  WARNING: pattern not found (already patched or version changed): {old!r}")
+            warn(f"pattern not found: {old!r}")
             continue
         patched = patched.replace(old, new)
         print(f"  Replaced {count}x: {old!r}")
@@ -65,14 +70,24 @@ def main() -> None:
         found_patterns += 1
 
     if total_replaced == 0:
-        print(
-            f"Playwright patch: nothing to do in {path} (all patterns absent — likely already applied)"
+        # All "old" patterns were absent. Either the file was already patched by a
+        # prior Docker layer (benign) or Playwright changed its formatting so nothing
+        # matched (dangerous — unpatched file that will crash at runtime).
+        # Distinguish the two by checking whether the patched forms are present.
+        confirmed_patched = sum(1 for _, new in PATCHES if new in src)
+        if confirmed_patched == len(PATCHES):
+            warn(f"all patterns already patched in {path} — nothing to do")
+            return
+        sys.exit(
+            f"ERROR: None of the {len(PATCHES)} patterns were found, and only "
+            f"{confirmed_patched}/{len(PATCHES)} patched forms were confirmed present. "
+            "Playwright likely changed its property names or formatting. "
+            "Update PATCHES in patch_playwright.py."
         )
-        return
 
     if 0 < found_patterns < len(PATCHES):
         sys.exit(
-            "ERROR: Partial patch applied — some patterns were found but others were missing. "
+            f"ERROR: Partial patch — {found_patterns}/{len(PATCHES)} patterns matched. "
             "coreBundle.js will still crash at runtime on unpatched properties. "
             "Check whether Playwright changed its formatting or variable names."
         )
@@ -80,9 +95,7 @@ def main() -> None:
     with open(path, "w", encoding="utf-8") as f:
         f.write(patched)
 
-    print(
-        f"Playwright patch applied to {path} ({total_replaced} replacement(s) across {len(PATCHES)} pattern(s))"
-    )
+    print(f"Playwright patch applied to {path} ({total_replaced} replacement(s))")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The patch loop logged a WARNING for each missing pattern but exited 0. If Playwright changes formatting for one of the three properties (`url`, `lineNumber`, `columnNumber`) while the others still match, the script writes a **partially-patched file**, exits successfully, Docker caches the layer, and the worker crashes at runtime on the unguarded property.

The `total_replaced == 0` check correctly handles "already fully patched from cache", but the dangerous middle ground (`0 < found < len(PATCHES)`) was not guarded.

## Fix

Track `found_patterns` separately from `total_replaced`. After the loop, if at least one pattern was found but not all were, exit non-zero:

```python
if 0 < found_patterns < len(PATCHES):
    sys.exit("ERROR: Partial patch applied ...")
```

This fails the Docker build on a partial match, which is the correct behavior: a partial patch is worse than no patch because it masks the problem until runtime.