### PR TITLE
fix(pipeline): stop storing other-type docs and remove text field duplication

### DIFF
--- a/packages/backend/scripts/cleanup_documents.py
+++ b/packages/backend/scripts/cleanup_documents.py
@@ -26,16 +26,20 @@ import sys
 
 from dotenv import load_dotenv
 
+# Import shared constants from the storer so the truncation suffix stays in
+# sync — the cleanup script's idempotency check relies on the same string.
+from src.pipeline.document_storer import _MARKDOWN_TRUNCATION_SUFFIX, _MAX_MARKDOWN_LENGTH
+
 load_dotenv()
 
-MAX_MARKDOWN_LENGTH = 150_000
-TRUNCATION_SUFFIX = "\n\n[Content truncated at 150,000 characters]"
 ATLAS_QUOTA_ERROR_CODE = 8000
+_BULK_BATCH_SIZE = 500
 
 
 async def run_cleanup() -> None:
     import certifi
     from motor.motor_asyncio import AsyncIOMotorClient
+    from pymongo import UpdateOne
     from pymongo.errors import OperationFailure
 
     from src.core.config import config
@@ -98,6 +102,7 @@ async def run_cleanup() -> None:
 
     print(f"      Found {text_count} documents with non-empty text field.")
     unset_count = 0
+    avg_text_bytes = 0.0
     if text_count > 0:
         # Sample a few docs to estimate average text size before removing.
         sample = (
@@ -111,7 +116,7 @@ async def run_cleanup() -> None:
         avg_text_bytes = (
             sum(len((doc.get("text") or "").encode()) for doc in sample) / len(sample)
             if sample
-            else 0
+            else 0.0
         )
         estimated_mb = (avg_text_bytes * text_count) / (1024 * 1024)
         print(
@@ -133,49 +138,61 @@ async def run_cleanup() -> None:
         print("      No documents have a text field (idempotent).")
 
     # ------------------------------------------------------------------
-    # Step 3: Truncate oversized markdown
+    # Step 3: Truncate oversized markdown (streamed, bulk-write batches)
     # ------------------------------------------------------------------
-    print(f"\n[3/3] Finding documents with markdown > {MAX_MARKDOWN_LENGTH:,} chars …")
+    print(f"\n[3/3] Finding documents with markdown > {_MAX_MARKDOWN_LENGTH:,} chars …")
     try:
-        # MongoDB can't filter on string length directly without $where; use a
-        # JS expression via $expr + $strLenCP for an indexed-compatible query.
+        # $strLenCP counts Unicode code points; $ifNull guards documents where
+        # markdown is absent (returns 0 length so they are excluded).
         oversized_cursor = db.documents.find(
             {
                 "$expr": {
-                    "$gt": [{"$strLenCP": {"$ifNull": ["$markdown", ""]}}, MAX_MARKDOWN_LENGTH]
+                    "$gt": [
+                        {"$strLenCP": {"$ifNull": ["$markdown", ""]}},
+                        _MAX_MARKDOWN_LENGTH,
+                    ]
                 }
             },
             {"id": 1, "url": 1, "markdown": 1},
         )
-        oversized_docs = await oversized_cursor.to_list(length=None)
     except OperationFailure as e:
         _handle_quota_error(e)
         return
 
-    print(f"      Found {len(oversized_docs)} oversized documents.")
     truncated_count = 0
     truncated_mb_freed = 0.0
+    bulk_updates: list[UpdateOne] = []
 
-    for doc in oversized_docs:
-        original_markdown: str = doc.get("markdown") or ""
-        if len(original_markdown) <= MAX_MARKDOWN_LENGTH:
-            continue  # Already within limits (idempotent).
-        if original_markdown.endswith(TRUNCATION_SUFFIX):
-            continue  # Already truncated in a previous run.
+    try:
+        async for doc in oversized_cursor:
+            original_markdown: str = doc.get("markdown") or ""
+            if len(original_markdown) <= _MAX_MARKDOWN_LENGTH:
+                continue  # Already within limits (idempotent).
+            if original_markdown.endswith(_MARKDOWN_TRUNCATION_SUFFIX):
+                continue  # Already truncated in a previous run.
 
-        truncated_markdown = original_markdown[:MAX_MARKDOWN_LENGTH] + TRUNCATION_SUFFIX
-        bytes_freed = len(original_markdown.encode()) - len(truncated_markdown.encode())
-        truncated_mb_freed += bytes_freed / (1024 * 1024)
-
-        try:
-            await db.documents.update_one(
-                {"id": doc["id"]},
-                {"$set": {"markdown": truncated_markdown}},
+            truncated_markdown = (
+                original_markdown[:_MAX_MARKDOWN_LENGTH] + _MARKDOWN_TRUNCATION_SUFFIX
             )
-            truncated_count += 1
-        except OperationFailure as e:
-            _handle_quota_error(e)
-            return
+            bytes_freed = len(original_markdown.encode()) - len(truncated_markdown.encode())
+            truncated_mb_freed += bytes_freed / (1024 * 1024)
+
+            bulk_updates.append(
+                UpdateOne({"id": doc["id"]}, {"$set": {"markdown": truncated_markdown}})
+            )
+
+            if len(bulk_updates) >= _BULK_BATCH_SIZE:
+                await db.documents.bulk_write(bulk_updates, ordered=False)
+                truncated_count += len(bulk_updates)
+                bulk_updates = []
+
+        if bulk_updates:
+            await db.documents.bulk_write(bulk_updates, ordered=False)
+            truncated_count += len(bulk_updates)
+
+    except OperationFailure as e:
+        _handle_quota_error(e)
+        return
 
     if truncated_count:
         print(f"      Truncated {truncated_count} documents, freed ~{truncated_mb_freed:.1f} MB.")
@@ -193,9 +210,7 @@ async def run_cleanup() -> None:
     print(f"  oversized markdown truncated : {truncated_count} documents")
 
     if unset_count > 0:
-        estimated_total_text_mb: float = (
-            (avg_text_bytes * text_count) / (1024 * 1024) if text_count > 0 else 0.0
-        )
+        estimated_total_text_mb = (avg_text_bytes * text_count) / (1024 * 1024)
         print(f"  estimated MB freed (text)    : ~{estimated_total_text_mb:.1f} MB")
     if truncated_mb_freed > 0:
         print(f"  estimated MB freed (markdown): ~{truncated_mb_freed:.1f} MB")

--- a/packages/backend/scripts/cleanup_documents.py
+++ b/packages/backend/scripts/cleanup_documents.py
@@ -1,0 +1,207 @@
+"""One-time cleanup script to recover MongoDB storage space.
+
+Performs three idempotent operations in order:
+1. Deletes all documents where ``doc_type == "other"`` (not policy docs).
+2. Removes the ``text`` field from all remaining documents via ``$unset``
+   (``markdown`` is the canonical representation; ``text`` was a 47 MB duplicate).
+3. Truncates ``markdown`` to 150 KB on oversized documents, appending a note.
+
+Prints a human-readable summary of changes and estimated MB freed.
+
+Usage:
+    uv run python scripts/cleanup_documents.py
+
+The script is safe to run multiple times (idempotent for all three steps).
+
+IMPORTANT: MongoDB Atlas writes are currently blocked when the cluster exceeds its
+storage quota. Run this script ONLY after the cluster has been resized or after
+manually freeing space via the Atlas UI.  If writes are still blocked the script
+will print a clear message and exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MAX_MARKDOWN_LENGTH = 150_000
+TRUNCATION_SUFFIX = "\n\n[Content truncated at 150,000 characters]"
+ATLAS_QUOTA_ERROR_CODE = 8000
+
+
+async def run_cleanup() -> None:
+    import certifi
+    from motor.motor_asyncio import AsyncIOMotorClient
+    from pymongo.errors import OperationFailure
+
+    from src.core.config import config
+
+    uri = config.database.mongodb_uri
+    if "+srv" in uri:
+        client: AsyncIOMotorClient = AsyncIOMotorClient(uri, tls=True, tlsCAFile=certifi.where())
+    else:
+        client = AsyncIOMotorClient(uri)
+
+    db = client["clausea"]
+
+    print("=" * 60)
+    print("Clausea document cleanup")
+    print("=" * 60)
+
+    def _handle_quota_error(e: OperationFailure) -> None:
+        if e.code == ATLAS_QUOTA_ERROR_CODE:
+            print(
+                "\n[ERROR] Atlas storage quota exceeded — upgrade cluster tier "
+                "before running cleanup.\n"
+                "Visit https://cloud.mongodb.com to resize your cluster."
+            )
+            sys.exit(1)
+        raise
+
+    # ------------------------------------------------------------------
+    # Step 1: Delete other-type documents
+    # ------------------------------------------------------------------
+    print("\n[1/3] Counting 'other'-type documents …")
+    try:
+        other_count = await db.documents.count_documents({"doc_type": "other"})
+    except OperationFailure as e:
+        _handle_quota_error(e)
+        return
+
+    print(f"      Found {other_count} other-type documents.")
+    deleted_count = 0
+    if other_count > 0:
+        print(f"      Deleting {other_count} other-type documents …")
+        try:
+            result = await db.documents.delete_many({"doc_type": "other"})
+            deleted_count = result.deleted_count
+            print(f"      Deleted {deleted_count} documents.")
+        except OperationFailure as e:
+            _handle_quota_error(e)
+            return
+    else:
+        print("      Nothing to delete (idempotent).")
+
+    # ------------------------------------------------------------------
+    # Step 2: Remove text field from all remaining documents
+    # ------------------------------------------------------------------
+    print("\n[2/3] Counting documents that still have a 'text' field …")
+    try:
+        text_count = await db.documents.count_documents({"text": {"$exists": True, "$ne": ""}})
+    except OperationFailure as e:
+        _handle_quota_error(e)
+        return
+
+    print(f"      Found {text_count} documents with non-empty text field.")
+    unset_count = 0
+    if text_count > 0:
+        # Sample a few docs to estimate average text size before removing.
+        sample = (
+            await db.documents.find(
+                {"text": {"$exists": True, "$ne": ""}},
+                {"text": 1},
+            )
+            .limit(200)
+            .to_list(length=200)
+        )
+        avg_text_bytes = (
+            sum(len((doc.get("text") or "").encode()) for doc in sample) / len(sample)
+            if sample
+            else 0
+        )
+        estimated_mb = (avg_text_bytes * text_count) / (1024 * 1024)
+        print(
+            f"      Estimated text field size: {estimated_mb:.1f} MB "
+            f"(avg {avg_text_bytes / 1024:.1f} KB per doc)."
+        )
+        print("      Removing 'text' field via $unset …")
+        try:
+            result = await db.documents.update_many(
+                {"text": {"$exists": True}},
+                {"$unset": {"text": ""}},
+            )
+            unset_count = result.modified_count
+            print(f"      Removed 'text' from {unset_count} documents.")
+        except OperationFailure as e:
+            _handle_quota_error(e)
+            return
+    else:
+        print("      No documents have a text field (idempotent).")
+
+    # ------------------------------------------------------------------
+    # Step 3: Truncate oversized markdown
+    # ------------------------------------------------------------------
+    print(f"\n[3/3] Finding documents with markdown > {MAX_MARKDOWN_LENGTH:,} chars …")
+    try:
+        # MongoDB can't filter on string length directly without $where; use a
+        # JS expression via $expr + $strLenCP for an indexed-compatible query.
+        oversized_cursor = db.documents.find(
+            {
+                "$expr": {
+                    "$gt": [{"$strLenCP": {"$ifNull": ["$markdown", ""]}}, MAX_MARKDOWN_LENGTH]
+                }
+            },
+            {"id": 1, "url": 1, "markdown": 1},
+        )
+        oversized_docs = await oversized_cursor.to_list(length=None)
+    except OperationFailure as e:
+        _handle_quota_error(e)
+        return
+
+    print(f"      Found {len(oversized_docs)} oversized documents.")
+    truncated_count = 0
+    truncated_mb_freed = 0.0
+
+    for doc in oversized_docs:
+        original_markdown: str = doc.get("markdown") or ""
+        if len(original_markdown) <= MAX_MARKDOWN_LENGTH:
+            continue  # Already within limits (idempotent).
+        if original_markdown.endswith(TRUNCATION_SUFFIX):
+            continue  # Already truncated in a previous run.
+
+        truncated_markdown = original_markdown[:MAX_MARKDOWN_LENGTH] + TRUNCATION_SUFFIX
+        bytes_freed = len(original_markdown.encode()) - len(truncated_markdown.encode())
+        truncated_mb_freed += bytes_freed / (1024 * 1024)
+
+        try:
+            await db.documents.update_one(
+                {"id": doc["id"]},
+                {"$set": {"markdown": truncated_markdown}},
+            )
+            truncated_count += 1
+        except OperationFailure as e:
+            _handle_quota_error(e)
+            return
+
+    if truncated_count:
+        print(f"      Truncated {truncated_count} documents, freed ~{truncated_mb_freed:.1f} MB.")
+    else:
+        print("      No documents exceed the size limit (idempotent).")
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("Summary")
+    print("=" * 60)
+    print(f"  other-type documents deleted : {deleted_count}")
+    print(f"  'text' field removed from    : {unset_count} documents")
+    print(f"  oversized markdown truncated : {truncated_count} documents")
+
+    if unset_count > 0:
+        estimated_total_text_mb: float = (
+            (avg_text_bytes * text_count) / (1024 * 1024) if text_count > 0 else 0.0
+        )
+        print(f"  estimated MB freed (text)    : ~{estimated_total_text_mb:.1f} MB")
+    if truncated_mb_freed > 0:
+        print(f"  estimated MB freed (markdown): ~{truncated_mb_freed:.1f} MB")
+
+    client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_cleanup())

--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -53,6 +53,7 @@ def main() -> None:
 
     patched = src
     total_replaced = 0
+    found_patterns = 0
     for old, new in PATCHES:
         count = patched.count(old)
         if count == 0:
@@ -61,12 +62,20 @@ def main() -> None:
         patched = patched.replace(old, new)
         print(f"  Replaced {count}x: {old!r}")
         total_replaced += count
+        found_patterns += 1
 
     if total_replaced == 0:
         print(
             f"Playwright patch: nothing to do in {path} (all patterns absent — likely already applied)"
         )
         return
+
+    if 0 < found_patterns < len(PATCHES):
+        sys.exit(
+            "ERROR: Partial patch applied — some patterns were found but others were missing. "
+            "coreBundle.js will still crash at runtime on unpatched properties. "
+            "Check whether Playwright changed its formatting or variable names."
+        )
 
     with open(path, "w", encoding="utf-8") as f:
         f.write(patched)

--- a/packages/backend/scripts/patch_playwright.py
+++ b/packages/backend/scripts/patch_playwright.py
@@ -16,9 +16,10 @@ Fixed upstream in camoufox >0.4.11. This script patches the bundled file
 until the project upgrades to a fixed release.
 
 Run during Docker image build (after the venv is copied into the image).
-Exits non-zero if coreBundle.js is not found so the build fails loudly.
-Logs a warning (but does NOT fail) when a pattern is absent — this means the
-file was already patched by a prior layer or a fixed upstream was installed.
+Exits non-zero on any of:
+  - coreBundle.js not found
+  - partial patch (some patterns found, others missing) → runtime crash guaranteed
+  - zero patterns found AND zero patched forms confirmed → Playwright changed formatting
 """
 
 import glob
@@ -40,6 +41,10 @@ PATCHES: list[tuple[str, str]] = [
 ]
 
 
+def warn(msg: str) -> None:
+    print(f"WARNING: {msg}", file=sys.stderr)
+
+
 def main() -> None:
     matches = glob.glob(
         "/opt/venv/lib/python*/site-packages/playwright/driver/package/lib/coreBundle.js"
@@ -57,7 +62,7 @@ def main() -> None:
     for old, new in PATCHES:
         count = patched.count(old)
         if count == 0:
-            print(f"  WARNING: pattern not found (already patched or version changed): {old!r}")
+            warn(f"pattern not found: {old!r}")
             continue
         patched = patched.replace(old, new)
         print(f"  Replaced {count}x: {old!r}")
@@ -65,14 +70,24 @@ def main() -> None:
         found_patterns += 1
 
     if total_replaced == 0:
-        print(
-            f"Playwright patch: nothing to do in {path} (all patterns absent — likely already applied)"
+        # All "old" patterns were absent. Either the file was already patched by a
+        # prior Docker layer (benign) or Playwright changed its formatting so nothing
+        # matched (dangerous — unpatched file that will crash at runtime).
+        # Distinguish the two by checking whether the patched forms are present.
+        confirmed_patched = sum(1 for _, new in PATCHES if new in src)
+        if confirmed_patched == len(PATCHES):
+            warn(f"all patterns already patched in {path} — nothing to do")
+            return
+        sys.exit(
+            f"ERROR: None of the {len(PATCHES)} patterns were found, and only "
+            f"{confirmed_patched}/{len(PATCHES)} patched forms were confirmed present. "
+            "Playwright likely changed its property names or formatting. "
+            "Update PATCHES in patch_playwright.py."
         )
-        return
 
     if 0 < found_patterns < len(PATCHES):
         sys.exit(
-            "ERROR: Partial patch applied — some patterns were found but others were missing. "
+            f"ERROR: Partial patch — {found_patterns}/{len(PATCHES)} patterns matched. "
             "coreBundle.js will still crash at runtime on unpatched properties. "
             "Check whether Playwright changed its formatting or variable names."
         )
@@ -80,9 +95,7 @@ def main() -> None:
     with open(path, "w", encoding="utf-8") as f:
         f.write(patched)
 
-    print(
-        f"Playwright patch applied to {path} ({total_replaced} replacement(s) across {len(PATCHES)} pattern(s))"
-    )
+    print(f"Playwright patch applied to {path} ({total_replaced} replacement(s))")
 
 
 if __name__ == "__main__":

--- a/packages/backend/src/models/document.py
+++ b/packages/backend/src/models/document.py
@@ -1669,7 +1669,10 @@ class Document(BaseModel):
     product_ids: list[str] = Field(default_factory=list)
     doc_type: DocType = "other"
     markdown: str
-    text: str
+    # text is a transient derived field — not persisted to MongoDB.
+    # It is auto-populated from markdown when empty (e.g. after a DB load)
+    # so downstream analysis code that reads document.text continues to work.
+    text: str = ""
     metadata: dict[str, Any] = Field(default_factory=dict)
     versions: list[dict[str, Any]] = Field(default_factory=list)
     analysis: DocumentAnalysis | None = None
@@ -1686,6 +1689,15 @@ class Document(BaseModel):
     tier_relevance: TierRelevance = "extended"
     content_hash: str | None = None
     analysis_error: str | None = None
+
+    @model_validator(mode="after")
+    def _populate_text_from_markdown(self) -> "Document":
+        """Back-fill text from markdown when absent (e.g. loaded from DB after cleanup)."""
+        if not self.text and self.markdown:
+            from src.utils.markdown import markdown_to_text
+
+            self.text = markdown_to_text(self.markdown)
+        return self
 
     @model_validator(mode="after")
     def _ensure_product_membership(self) -> "Document":

--- a/packages/backend/src/pipeline/document_storer.py
+++ b/packages/backend/src/pipeline/document_storer.py
@@ -37,8 +37,10 @@ from src.pipeline.models import ProcessingStats
 from src.repositories.document_version_repository import DocumentVersionRepository
 from src.repositories.pipeline_repository import PipelineRepository
 from src.services.service_factory import create_document_service
+from src.utils.markdown import markdown_to_text
 
 _MAX_MARKDOWN_LENGTH = 150_000
+_MARKDOWN_TRUNCATION_SUFFIX = "\n\n[Content truncated at 150,000 characters]"
 
 
 class DocumentStorer:
@@ -73,15 +75,17 @@ class DocumentStorer:
                         continue
 
                     # Cap markdown to avoid storing bloated omnibus legal documents.
-                    if len(document.markdown) > _MAX_MARKDOWN_LENGTH:
+                    # Idempotent: skip if already truncated from a previous run.
+                    if len(
+                        document.markdown
+                    ) > _MAX_MARKDOWN_LENGTH and not document.markdown.endswith(
+                        _MARKDOWN_TRUNCATION_SUFFIX
+                    ):
                         document.markdown = (
-                            document.markdown[:_MAX_MARKDOWN_LENGTH]
-                            + "\n\n[Content truncated at 150,000 characters]"
+                            document.markdown[:_MAX_MARKDOWN_LENGTH] + _MARKDOWN_TRUNCATION_SUFFIX
                         )
                         # Re-derive text from the capped markdown so hash comparisons
                         # are consistent with what will be stored.
-                        from src.utils.markdown import markdown_to_text
-
                         document.text = markdown_to_text(document.markdown)
 
                     source_product_id = document.product_id

--- a/packages/backend/src/pipeline/document_storer.py
+++ b/packages/backend/src/pipeline/document_storer.py
@@ -38,6 +38,8 @@ from src.repositories.document_version_repository import DocumentVersionReposito
 from src.repositories.pipeline_repository import PipelineRepository
 from src.services.service_factory import create_document_service
 
+_MAX_MARKDOWN_LENGTH = 150_000
+
 
 class DocumentStorer:
     def __init__(self, stats: ProcessingStats, job_id: str | None = None) -> None:
@@ -62,6 +64,26 @@ class DocumentStorer:
 
             for document in documents:
                 try:
+                    # Skip non-policy documents — they should never reach storage.
+                    if document.doc_type == "other":
+                        logger_storage.debug(
+                            "skipping other-type document (not a policy doc): %s",
+                            document.url,
+                        )
+                        continue
+
+                    # Cap markdown to avoid storing bloated omnibus legal documents.
+                    if len(document.markdown) > _MAX_MARKDOWN_LENGTH:
+                        document.markdown = (
+                            document.markdown[:_MAX_MARKDOWN_LENGTH]
+                            + "\n\n[Content truncated at 150,000 characters]"
+                        )
+                        # Re-derive text from the capped markdown so hash comparisons
+                        # are consistent with what will be stored.
+                        from src.utils.markdown import markdown_to_text
+
+                        document.text = markdown_to_text(document.markdown)
+
                     source_product_id = document.product_id
                     existing_doc = await document_service.get_document_by_url(db, document.url)
                     if not existing_doc:

--- a/packages/backend/src/pipeline/helpers.py
+++ b/packages/backend/src/pipeline/helpers.py
@@ -156,7 +156,7 @@ def canonicalize_url(url: str) -> str:
 
 
 def _diff_fields(existing: Document, incoming: Document) -> list[str]:
-    tracked = ["text", "title", "doc_type", "locale", "regions", "effective_date"]
+    tracked = ["markdown", "title", "doc_type", "locale", "regions", "effective_date"]
     changed = []
     for field in tracked:
         old_val = getattr(existing, field)

--- a/packages/backend/src/repositories/document_repository.py
+++ b/packages/backend/src/repositories/document_repository.py
@@ -234,7 +234,7 @@ class DocumentRepository(BaseRepository):
                 {"product_ids": product_id},
             ],
             "content_hash": content_hash,
-            "text": {"$ne": ""},
+            "markdown": {"$ne": ""},
         }
         cursor = db.documents.find(query).sort("url", 1)
         candidates = await cursor.to_list(length=10)
@@ -419,14 +419,15 @@ class DocumentRepository(BaseRepository):
             ValueError: If text and markdown are both empty / whitespace.
             Exception: If storage fails for other reasons.
         """
-        if not (document.text or "").strip() and not (document.markdown or "").strip():
+        if not (document.markdown or "").strip():
             raise ValueError(
                 f"Refusing to store empty document {document.id} for url={document.url} "
-                f"(text and markdown are both empty — fix upstream extraction instead "
+                f"(markdown is empty — fix upstream extraction instead "
                 f"of persisting a placeholder)."
             )
         try:
-            document_dict = document.model_dump()
+            # text is a transient derived field — exclude it from MongoDB storage.
+            document_dict = document.model_dump(exclude={"text"})
             document_dict["product_ids"] = _merge_product_ids(
                 canonical_product_id=document.product_id,
                 linked_product_ids=document_dict.get("product_ids"),
@@ -488,12 +489,11 @@ class DocumentRepository(BaseRepository):
             Exception: If update fails
         """
         try:
-            document_dict = document.model_dump()
-            incoming_text = document_dict.get("text") or ""
+            # text is a transient derived field — exclude it from MongoDB storage.
+            document_dict = document.model_dump(exclude={"text"})
             incoming_markdown = document_dict.get("markdown") or ""
             guarded_fields = ("analysis", "extraction", "consumer_explainer")
             projection = {
-                "text": 1,
                 "markdown": 1,
                 "product_id": 1,
                 "product_ids": 1,
@@ -524,19 +524,10 @@ class DocumentRepository(BaseRepository):
             # to None/"" before this Document was built, so writing the full model_dump
             # back would null out stored content. Drop any heavy field from the $set
             # when it is empty incoming but non-empty stored.
-            needs_guard = (
-                not incoming_text
-                or not incoming_markdown
-                or any(document_dict.get(field) is None for field in guarded_fields)
+            needs_guard = not incoming_markdown or any(
+                document_dict.get(field) is None for field in guarded_fields
             )
             if needs_guard:
-                if not incoming_text and (existing.get("text") or ""):
-                    document_dict.pop("text", None)
-                    logger.warning(
-                        "DocumentRepository.update refused to overwrite non-empty "
-                        f"text for document {document.id} with an empty value "
-                        "(caller likely loaded via a projecting reader)."
-                    )
                 if not incoming_markdown and (existing.get("markdown") or ""):
                     document_dict.pop("markdown", None)
                     logger.warning(

--- a/packages/backend/tests/unit/document_repository_test.py
+++ b/packages/backend/tests/unit/document_repository_test.py
@@ -78,7 +78,11 @@ async def test_update_drops_empty_text_when_stored_has_content() -> None:
 
 @pytest.mark.asyncio
 async def test_update_writes_text_when_incoming_has_content() -> None:
-    """Normal path: a full Document with real text writes through unchanged."""
+    """Normal path: a full Document with real content writes markdown through unchanged.
+
+    text is a transient derived field — it is always excluded from MongoDB writes.
+    Only markdown (the canonical representation) is expected in the $set payload.
+    """
     repo = DocumentRepository()
     db, update_one = _fake_db_with_existing(text="old text", markdown="# old")
     full_doc = _make_doc(text="new policy text", markdown="# new")
@@ -88,7 +92,8 @@ async def test_update_writes_text_when_incoming_has_content() -> None:
 
     args, _kwargs = update_one.call_args
     set_payload = args[1]["$set"]
-    assert set_payload["text"] == "new policy text"
+    # text is transient and excluded from MongoDB writes; only markdown is persisted.
+    assert "text" not in set_payload
     assert set_payload["markdown"] == "# new"
 
 

--- a/packages/backend/tests/unit/policy_change_tracking_test.py
+++ b/packages/backend/tests/unit/policy_change_tracking_test.py
@@ -34,9 +34,16 @@ class TestDiffFields:
         assert _diff_fields(doc, doc) == []
 
     def test_text_changed(self) -> None:
+        # text is a transient field — it is not persisted or diff-tracked.
+        # Changing text alone (without markdown) is not a meaningful change.
         old = _doc(text="old text " * 50)
         new = _doc(text="new text " * 50)
-        assert "text" in _diff_fields(old, new)
+        assert "text" not in _diff_fields(old, new)
+
+    def test_markdown_changed(self) -> None:
+        old = _doc(markdown="# Old policy content " * 20)
+        new = _doc(markdown="# New policy content " * 20)
+        assert "markdown" in _diff_fields(old, new)
 
     def test_title_changed(self) -> None:
         old = _doc(title="Old Title")
@@ -64,11 +71,11 @@ class TestDiffFields:
         assert "effective_date" in _diff_fields(old, new)
 
     def test_multiple_fields_changed(self) -> None:
-        old = _doc(title="Old", text="old " * 50)
-        new = _doc(title="New", text="new " * 50)
+        old = _doc(title="Old", markdown="# old policy " * 20)
+        new = _doc(title="New", markdown="# new policy " * 20)
         changed = _diff_fields(old, new)
         assert "title" in changed
-        assert "text" in changed
+        assert "markdown" in changed
 
 
 class TestDocumentVersionRepository:


### PR DESCRIPTION
## Summary

- **Stop persisting `other`-type documents**: `DocumentStorer` now skips any document with `doc_type='other'` before storage (debug-logged). These were non-policy pages that slipped through the `is_policy_document` guard when the classifier returned an unrecognised label.
- **Remove `text` field duplication**: `markdown` is the canonical representation. The `text` field was 47 MB of pure duplication across 2,830 docs (same content, twice). The repository's `save()`/`update()` now excludes `text` from `model_dump()`. The `Document` model auto-populates `text` from `markdown` on load via a `model_validator`, so all downstream analysis/extraction services continue to work transparently.
- **Cap document content at 150 KB**: `DocumentStorer` truncates `markdown` to 150,000 characters before storage (appending a note), re-derives `text` from the capped markdown for consistent hash comparisons. Prevents 1.1 MB Stripe SSAs and 585 KB Amazon terms from bloating the cluster.
- **One-time cleanup script** (`scripts/cleanup_documents.py`): idempotent script that deletes `other`-type docs, `$unset`s `text` from remaining docs, and truncates oversized markdown — with Atlas quota error handling.

## Related changes

- `helpers._diff_fields`: tracks `markdown` instead of `text` for change detection (text is no longer stored)
- `DocumentRepository.find_by_product_and_content_hash`: uses `markdown` sentinel instead of `text`
- `DocumentRepository.update`: removes the text-empty round-trip guard (text is excluded from all writes)

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format` — no reformatting needed
- [x] `uv run ty check` (changed source files only) — all checks passed
- [x] `uv run pytest tests/unit/pipeline/ tests/unit/models/` — 117 tests passed
- [x] Pre-commit hooks passed (ruff, backend tests)

## Notes for running cleanup

MongoDB writes are currently blocked (513/512 MB). Run `scripts/cleanup_documents.py` **after** the cluster is resized. The script handles `OperationFailure` code 8000 and prints a clear message if the quota is still exceeded.