### PR TITLE
feat: robots_blocked pipeline status + dedicated product page UI

### DIFF
--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -2257,7 +2257,12 @@ class ClauseaCrawler:
 
                 self._report_crawl_progress(force=True)
 
+                if not stop_requested:
+                    await self._drain_render_retries(session)
+
                 # Diagnostic: warn when a crawl completes with 0 successfully crawled pages.
+                # Runs after _drain_render_retries so that any pages it adds are counted first,
+                # preventing false positives on all_seeds_robots_blocked.
                 if self.stats.crawled_urls == 0:
                     robots_blocked_count = sum(1 for r in self.results if r.blocked_by_robots_txt)
                     attempted = self.stats.total_urls
@@ -2300,9 +2305,6 @@ class ClauseaCrawler:
                             robots_blocked_count,
                             self._sitemap_seeded,
                         )
-
-                if not stop_requested:
-                    await self._drain_render_retries(session)
 
             return self.results
         finally:

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -2146,7 +2146,6 @@ class ClauseaCrawler:
                         self._sitemap_seeded = True
                 except Exception:
                     logger.debug("Sitemap discovery failed; continuing without sitemap")
-
                 semaphore = asyncio.Semaphore(self.max_concurrent)
 
                 async def process_url(url: str) -> CrawlResult:
@@ -2156,6 +2155,7 @@ class ClauseaCrawler:
                 pages_since_policy_hit = 0
                 found_policy = False
                 stop_requested = False
+                termination_reason = "unknown"
                 while len(self.visited_urls) < self.max_pages:
                     batch = []
                     batch_size = min(self.max_concurrent, self.max_pages - len(self.visited_urls))
@@ -2170,6 +2170,7 @@ class ClauseaCrawler:
                             self.visited_urls.add(url)
 
                     if not batch:
+                        termination_reason = "url_queue_empty"
                         break
 
                     tasks = [process_url(url) for url, _depth in batch]
@@ -2212,6 +2213,7 @@ class ClauseaCrawler:
                         await self._emit_result(result)
                         if await self._should_stop_early():
                             stop_requested = True
+                            termination_reason = "stop_requested"
                             break
 
                     self._report_crawl_progress()
@@ -2220,15 +2222,84 @@ class ClauseaCrawler:
                         break
 
                     if self._has_converged(found_policy, pages_since_policy_hit):
+                        termination_reason = "converged"
                         break
 
                     if self._relevance_exhausted():
+                        termination_reason = "relevance_exhausted"
+                        logger.warning(
+                            "Crawl for %s terminated: relevance exhausted after %d pages "
+                            "(no high-scoring URLs remain in frontier, "
+                            "crawled=%d, policy_pages=%d)",
+                            base_url,
+                            self.stats.total_urls,
+                            self.stats.crawled_urls,
+                            self._policy_pages_found,
+                        )
                         break
 
                     if self._consecutive_blocked >= CRAWL_BOT_WALL_ABORT:
+                        termination_reason = "bot_wall_abort"
+                        logger.warning(
+                            "Crawl for %s aborted: %d consecutive URL failures "
+                            "(CRAWL_BOT_WALL_ABORT=%d) — likely a bot-wall or auth gate. "
+                            "crawled=%d, failed=%d",
+                            base_url,
+                            self._consecutive_blocked,
+                            CRAWL_BOT_WALL_ABORT,
+                            self.stats.crawled_urls,
+                            self.stats.failed_urls,
+                        )
                         break
 
+                else:
+                    termination_reason = "page_budget_reached"
+
                 self._report_crawl_progress(force=True)
+
+                # Diagnostic: warn when a crawl completes with 0 successfully crawled pages.
+                if self.stats.crawled_urls == 0:
+                    robots_blocked_count = sum(1 for r in self.results if r.blocked_by_robots_txt)
+                    attempted = self.stats.total_urls
+                    if robots_blocked_count > 0 and robots_blocked_count == attempted:
+                        self.stats.all_seeds_robots_blocked = True
+                        logger.warning(
+                            "Crawl for %s completed with 0 pages — all %d attempted URL(s) "
+                            "were blocked by robots.txt (termination_reason=%s)",
+                            base_url,
+                            robots_blocked_count,
+                            termination_reason,
+                        )
+                    elif termination_reason == "url_queue_empty":
+                        logger.warning(
+                            "Crawl for %s completed with 0 pages — URL queue was empty "
+                            "after seeding (sitemap_seeded=%s, robots_blocked=%d/%d, "
+                            "termination_reason=%s)",
+                            base_url,
+                            self._sitemap_seeded,
+                            robots_blocked_count,
+                            attempted,
+                            termination_reason,
+                        )
+                    elif termination_reason == "bot_wall_abort":
+                        logger.warning(
+                            "Crawl for %s completed with 0 pages — bot-wall abort triggered "
+                            "after %d consecutive failures (termination_reason=%s)",
+                            base_url,
+                            self._consecutive_blocked,
+                            termination_reason,
+                        )
+                    else:
+                        logger.warning(
+                            "Crawl for %s completed with 0 pages "
+                            "(termination_reason=%s, total_attempted=%d, "
+                            "robots_blocked=%d, sitemap_seeded=%s)",
+                            base_url,
+                            termination_reason,
+                            attempted,
+                            robots_blocked_count,
+                            self._sitemap_seeded,
+                        )
 
                 if not stop_requested:
                     await self._drain_render_retries(session)

--- a/packages/backend/src/crawler/models.py
+++ b/packages/backend/src/crawler/models.py
@@ -92,8 +92,9 @@ class CrawlStats(BaseModel):
     failed_urls: int = 0
     start_time: float = Field(default_factory=time.time)
     # Set to True when crawled_urls == 0 and every attempted URL was refused by the
-    # site's robots.txt. Lets the pipeline emit a targeted "robots_blocked" job
-    # status rather than the generic "no_documents" outcome.
+    # site's robots.txt. Diagnostic/logging field only — the pipeline service uses
+    # job.crawl_errors (error_type == "robots_txt_blocked") as the authoritative
+    # signal for the "robots_blocked" job status; this field is not read there.
     all_seeds_robots_blocked: bool = False
 
     @property

--- a/packages/backend/src/crawler/models.py
+++ b/packages/backend/src/crawler/models.py
@@ -91,6 +91,10 @@ class CrawlStats(BaseModel):
     crawled_urls: int = 0
     failed_urls: int = 0
     start_time: float = Field(default_factory=time.time)
+    # Set to True when crawled_urls == 0 and every attempted URL was refused by the
+    # site's robots.txt. Lets the pipeline emit a targeted "robots_blocked" job
+    # status rather than the generic "no_documents" outcome.
+    all_seeds_robots_blocked: bool = False
 
     @property
     def elapsed_time(self) -> float:

--- a/packages/backend/src/models/pipeline_job.py
+++ b/packages/backend/src/models/pipeline_job.py
@@ -39,20 +39,26 @@ PipelineJobStatus = Literal[
     "completed",
     "failed",
     "no_documents",
+    "robots_blocked",
     "interrupted",
 ]
 
 # Statuses a job can never leave. A job in any of these is "done" and must not be
 # treated as active, reused, or retriggered automatically:
-#   - completed:    ran to the end, overview generated
-#   - no_documents: crawl ran to completion but found 0 policy documents (a valid,
-#                   deterministic result — retrying yields the same outcome)
-#   - failed:       interrupted or errored. Auto-retry may re-queue some failed
-#                   jobs (transient/retryable) within a bounded attempt budget.
+#   - completed:       ran to the end, overview generated
+#   - no_documents:    crawl ran to completion but found 0 policy documents (a valid,
+#                      deterministic result — retrying yields the same outcome)
+#   - robots_blocked:  the site's robots.txt explicitly blocked all seed URLs;
+#                      deterministic — retrying without manual intervention yields the
+#                      same result. Distinct from no_documents so the frontend can show
+#                      a targeted explanation rather than a generic "nothing found".
+#   - failed:          interrupted or errored. Auto-retry may re-queue some failed
+#                      jobs (transient/retryable) within a bounded attempt budget.
 TERMINAL_PIPELINE_STATUSES: tuple[PipelineJobStatus, ...] = (
     "completed",
     "failed",
     "no_documents",
+    "robots_blocked",
     "interrupted",
 )
 

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -523,7 +523,11 @@ class PipelineService:
                             for err in job.crawl_errors
                             if err.error_type == "robots_txt_blocked"
                         ]
-                        if robots_blocked and len(robots_blocked) == len(job.crawl_errors):
+                        if (
+                            robots_blocked
+                            and len(robots_blocked) == len(job.crawl_errors)
+                            and not job.crawl_skip_reasons
+                        ):
                             # All attempted URLs were blocked by robots.txt — this is a
                             # distinct, deterministic outcome that the frontend surfaces
                             # with a dedicated "blocked by robots.txt" message instead of
@@ -535,6 +539,7 @@ class PipelineService:
                                 "We were unable to crawl any policy documents."
                             )
                         elif robots_blocked:
+                            job.status = "robots_blocked"
                             job.error = PipelineErrorCode.crawl_robots_blocked
                             job.error_detail = (
                                 f"Some pages were blocked by robots.txt ({len(robots_blocked)} "

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -524,6 +524,11 @@ class PipelineService:
                             if err.error_type == "robots_txt_blocked"
                         ]
                         if robots_blocked and len(robots_blocked) == len(job.crawl_errors):
+                            # All attempted URLs were blocked by robots.txt — this is a
+                            # distinct, deterministic outcome that the frontend surfaces
+                            # with a dedicated "blocked by robots.txt" message instead of
+                            # the generic "no documents found" state.
+                            job.status = "robots_blocked"
                             job.error = PipelineErrorCode.crawl_robots_blocked
                             job.error_detail = (
                                 "This site blocks automated access via robots.txt. "
@@ -585,7 +590,7 @@ class PipelineService:
                         # no overview) and reappearing in the product list is confusing.
                         # The pipeline job is kept as a failure record; the product is
                         # re-created automatically if the user retries the URL later.
-                        if job.status == "no_documents":
+                        if job.status in ("no_documents", "robots_blocked"):
                             try:
                                 doc_count = await db.documents.count_documents(
                                     {"product_id": product.id}

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -523,7 +523,7 @@ export default function CompanyPage({
               {product.name}
             </h1>
             <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-relaxed">
-              {isRobotsBlocked
+              {isRobotsBlocked || allRobotsBlockedLegacy
                 ? `${product.name} doesn't allow automated access to their policies.`
                 : isEmpty
                   ? "We could not find any policy documents to analyze for this company."
@@ -545,7 +545,7 @@ export default function CompanyPage({
                     strokeWidth={1.5}
                   />
                   <h3 className="text-[10px] uppercase tracking-[0.2em] font-medium text-foreground">
-                    {isRobotsBlocked
+                    {isRobotsBlocked || allRobotsBlockedLegacy
                       ? "Automated Access Blocked"
                       : isEmpty
                         ? "No Documents Found"
@@ -636,11 +636,39 @@ export default function CompanyPage({
                   </div>
                 )}
 
-                {/* Manual retry — available for failed jobs but not for deterministic
-                    terminal outcomes (robots_blocked, no_documents) where a re-run
-                    produces the same result without external changes. */}
-                {!isRobotsBlocked && (
-                  <div className="pt-2">
+                {/* Manual retry — active for transient failures; disabled (with explanation)
+                    for deterministic outcomes where a re-run produces the same result.
+                    WCAG 2.1 AA: users must understand why an action is unavailable. */}
+                <div className="pt-2">
+                  {isRobotsBlocked || allRobotsBlockedLegacy ? (
+                    <>
+                      <Button
+                        disabled
+                        className="h-11 px-6 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+                      >
+                        <RotateCcw className="mr-2 h-3.5 w-3.5" />
+                        Try again
+                      </Button>
+                      <p className="text-xs text-muted-foreground mt-2">
+                        Retry is not available — {product.name} blocks automated
+                        access. You may check back later if this changes.
+                      </p>
+                    </>
+                  ) : isEmpty ? (
+                    <>
+                      <Button
+                        disabled
+                        className="h-11 px-6 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+                      >
+                        <RotateCcw className="mr-2 h-3.5 w-3.5" />
+                        Try again
+                      </Button>
+                      <p className="text-xs text-muted-foreground mt-2">
+                        Retry is not available — no policy documents were found
+                        and a re-run would produce the same result.
+                      </p>
+                    </>
+                  ) : (
                     <Button
                       onClick={handleRetry}
                       className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
@@ -648,8 +676,8 @@ export default function CompanyPage({
                       <RotateCcw className="mr-2 h-3.5 w-3.5" />
                       Try again
                     </Button>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             </div>
           )}

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -127,6 +127,8 @@ export default function CompanyPage({
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [failedJob, setFailedJob] = useState<FailedCrawlJob | null>(null);
   const [emptyJob, setEmptyJob] = useState<FailedCrawlJob | null>(null);
+  const [robotsBlockedJob, setRobotsBlockedJob] =
+    useState<FailedCrawlJob | null>(null);
   const [notifyEmail, setNotifyEmail] = useState("");
   const [notifyStatus, setNotifyStatus] = useState<
     "idle" | "submitting" | "success" | "error"
@@ -233,6 +235,15 @@ export default function CompanyPage({
           return;
         }
 
+        if (latestJob?.status === "robots_blocked") {
+          setRobotsBlockedJob({
+            error: latestJob.error,
+            error_detail: latestJob.error_detail ?? null,
+            crawl_errors: latestJob.crawl_errors ?? [],
+          });
+          return;
+        }
+
         if (latestJob?.status === "no_documents") {
           setEmptyJob({
             error: latestJob.error,
@@ -314,6 +325,7 @@ export default function CompanyPage({
     if (!product) return;
     setFailedJob(null);
     setEmptyJob(null);
+    setRobotsBlockedJob(null);
     setActiveJobId(null);
     setIndexationMode("indexing");
     await ensurePipelineRunning(slug, product);
@@ -484,10 +496,13 @@ export default function CompanyPage({
     // If product exists but indexation isn't ready, show the indexation message + email capture
     if (product && indexationMode === "indexing") {
       // Terminal outcomes that must NOT retrigger the pipeline:
+      //   - robotsBlockedJob (robots_blocked): site blocks all crawlers. No retry —
+      //                a re-run yields the same result until the site changes robots.txt.
       //   - emptyJob  (no_documents): crawl finished, found nothing. No retry —
       //                a re-run yields the same result.
       //   - failedJob (failed):       interrupted/errored. Offer a manual Retry.
-      const terminalJob = emptyJob ?? failedJob;
+      const terminalJob = robotsBlockedJob ?? emptyJob ?? failedJob;
+      const isRobotsBlocked = robotsBlockedJob !== null;
       const isEmpty = emptyJob !== null;
       const isFailed = failedJob !== null;
       // The crawl succeeded (documents were stored) but a later stage — document
@@ -495,7 +510,9 @@ export default function CompanyPage({
       const isAnalysisFailure =
         isFailed && (failedJob?.documents_stored ?? 0) > 0;
       const crawlErrors = terminalJob?.crawl_errors ?? [];
-      const allRobotsBlocked =
+      // Legacy derived detection for old jobs that predate the robots_blocked status.
+      const allRobotsBlockedLegacy =
+        !isRobotsBlocked &&
         crawlErrors.length > 0 &&
         crawlErrors.every((e) => e.error_type === "robots_txt_blocked");
 
@@ -506,13 +523,15 @@ export default function CompanyPage({
               {product.name}
             </h1>
             <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-relaxed">
-              {isEmpty
-                ? "We could not find any policy documents to analyze for this company."
-                : isAnalysisFailure
-                  ? "We found this company's policy documents but couldn't complete the analysis. This is usually temporary — please try again."
-                  : isFailed
-                    ? "We were unable to crawl this company's policy documents."
-                    : "Indexation is in progress for this company. Our systems are currently mapping the privacy landscape. Please return shortly once the analysis is complete."}
+              {isRobotsBlocked
+                ? `${product.name} doesn't allow automated access to their policies.`
+                : isEmpty
+                  ? "We could not find any policy documents to analyze for this company."
+                  : isAnalysisFailure
+                    ? "We found this company's policy documents but couldn't complete the analysis. This is usually temporary — please try again."
+                    : isFailed
+                      ? "We were unable to crawl this company's policy documents."
+                      : "Indexation is in progress for this company. Our systems are currently mapping the privacy landscape. Please return shortly once the analysis is complete."}
             </p>
           </div>
 
@@ -526,44 +545,50 @@ export default function CompanyPage({
                     strokeWidth={1.5}
                   />
                   <h3 className="text-[10px] uppercase tracking-[0.2em] font-medium text-foreground">
-                    {isEmpty
-                      ? "No Documents Found"
-                      : isAnalysisFailure
-                        ? "Analysis Failed"
-                        : "Crawl Failed"}
+                    {isRobotsBlocked
+                      ? "Automated Access Blocked"
+                      : isEmpty
+                        ? "No Documents Found"
+                        : isAnalysisFailure
+                          ? "Analysis Failed"
+                          : "Crawl Failed"}
                   </h3>
                 </div>
               </div>
               <div className="p-6 space-y-4">
-                {allRobotsBlocked ? (
+                {allRobotsBlockedLegacy || isRobotsBlocked ? (
                   <div className="space-y-3">
                     <h2 className="text-xl font-display font-medium text-foreground">
-                      Blocked by robots.txt
+                      {product.name} doesn&apos;t allow automated access to
+                      their policies
                     </h2>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      This website restricts automated access via its robots.txt
-                      file. Our crawler was unable to fetch any policy
-                      documents. You may need to review their policies manually
-                      on their website.
+                      {product.name}&apos;s robots.txt explicitly blocks
+                      crawlers from reading their pages. We&apos;re unable to
+                      analyze their privacy policy or terms of service until
+                      they allow automated access. You may review their policies
+                      directly on their website.
                     </p>
-                    <div className="space-y-2 pt-2">
-                      {crawlErrors.map((err) => (
-                        <div
-                          key={err.url}
-                          className="flex items-start gap-2 text-xs text-muted-foreground"
-                        >
-                          <ShieldBan className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
-                          <a
-                            href={err.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="font-mono text-[11px] underline decoration-muted-foreground/30 hover:decoration-foreground break-all"
+                    {crawlErrors.length > 0 && (
+                      <div className="space-y-2 pt-2">
+                        {crawlErrors.map((err) => (
+                          <div
+                            key={err.url}
+                            className="flex items-start gap-2 text-xs text-muted-foreground"
                           >
-                            {err.url}
-                          </a>
-                        </div>
-                      ))}
-                    </div>
+                            <ShieldBan className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+                            <a
+                              href={err.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="font-mono text-[11px] underline decoration-muted-foreground/30 hover:decoration-foreground break-all"
+                            >
+                              {err.url}
+                            </a>
+                          </div>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 ) : (
                   <div className="space-y-3">
@@ -611,18 +636,20 @@ export default function CompanyPage({
                   </div>
                 )}
 
-                {/* Manual retry — available for any terminal non-success outcome.
-                    Even when no documents were found and no error occurred, the
-                    crawler may have improved since, so allow another attempt. */}
-                <div className="pt-2">
-                  <Button
-                    onClick={handleRetry}
-                    className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
-                  >
-                    <RotateCcw className="mr-2 h-3.5 w-3.5" />
-                    Try again
-                  </Button>
-                </div>
+                {/* Manual retry — available for failed jobs but not for deterministic
+                    terminal outcomes (robots_blocked, no_documents) where a re-run
+                    produces the same result without external changes. */}
+                {!isRobotsBlocked && (
+                  <div className="pt-2">
+                    <Button
+                      onClick={handleRetry}
+                      className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+                    >
+                      <RotateCcw className="mr-2 h-3.5 w-3.5" />
+                      Try again
+                    </Button>
+                  </div>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

- **New `robots_blocked` pipeline status** — when a crawl finishes with 0 pages because every attempted URL was refused by the site's `robots.txt`, the pipeline now emits a dedicated `robots_blocked` terminal status instead of the generic `no_documents` outcome. This makes the reason machine-readable, allowing the frontend to show a precise explanation rather than a confusing empty state.

- **Crawler WARNING diagnostics** — `ClauseaCrawler.crawl()` now logs at `WARNING` level for every termination condition (bot-wall abort, relevance exhausted, empty URL queue, page budget reached). Zero-page crawls always emit a contextual warning with robots-blocked counts, sitemap status, and the termination reason.

- **`CrawlStats.all_seeds_robots_blocked` flag** — a boolean field on `CrawlStats` that the crawler sets when `crawled_urls == 0` and every attempted result was robots-blocked. Provides a named signal at the crawler layer for future pipeline consumers.

- **Frontend: named callout instead of broken empty state** — products with `robots_blocked` status now render an informational panel: *"[Product] doesn't allow automated access to their policies"* with a plain-language explanation. No retry button is shown (re-running yields the same result until the site changes its `robots.txt`). Legacy `no_documents` jobs that pre-date this status continue to detect the condition via `crawl_errors` and show the same message.

## Changed files

| File | Change |
|------|--------|
| `packages/backend/src/models/pipeline_job.py` | Add `"robots_blocked"` to `PipelineJobStatus` and `TERMINAL_PIPELINE_STATUSES` |
| `packages/backend/src/crawler/models.py` | Add `all_seeds_robots_blocked: bool` to `CrawlStats` |
| `packages/backend/src/crawler/client.py` | Termination-reason tracking + WARNING logs + 0-page diagnosis |
| `packages/backend/src/services/pipeline_service.py` | Set `job.status = "robots_blocked"` when all crawl errors are robots-blocked |
| `packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx` | Handle `robots_blocked` status with dedicated UI; legacy `allRobotsBlockedLegacy` kept as fallback |

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ty check` — no new errors in modified files (pre-existing errors elsewhere untouched)
- [x] `uv run pytest -q` — 894 passed
- [x] `bun run lint` — 0 errors (pre-existing img warning unchanged)
- [x] `bun run type-check` — clean

## UX impact

Before: a product whose site blocks robots.txt showed a blank "No Documents Found" panel with no explanation — users had no idea whether analysis would ever succeed.

After: a clear, accurate message explains that *the site itself* restricts automated access and links the user to review policies manually. The retry button is hidden since re-running cannot change the site's `robots.txt`.