### PR TITLE
feat: add access_denied, no_policy_found, site_unavailable, analysis_failed pipeline statuses

### DIFF
--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -2156,6 +2156,7 @@ class ClauseaCrawler:
                 found_policy = False
                 stop_requested = False
                 termination_reason = "unknown"
+                failed_results: list[CrawlResult] = []
                 while len(self.visited_urls) < self.max_pages:
                     batch = []
                     batch_size = min(self.max_concurrent, self.max_pages - len(self.visited_urls))
@@ -2201,6 +2202,8 @@ class ClauseaCrawler:
                             self._consecutive_blocked += 1
                             if result.blocked_by_robots_txt:
                                 self.results.append(result)
+                            else:
+                                failed_results.append(result)
 
                         if depth < self.max_depth and result.discovered_links:
                             self.add_urls_to_queue(
@@ -2261,10 +2264,9 @@ class ClauseaCrawler:
                 if self.stats.crawled_urls == 0:
                     robots_blocked_count = sum(1 for r in self.results if r.blocked_by_robots_txt)
                     attempted = self.stats.total_urls
-                    failed_results = [
-                        r for r in self.results if not r.success and not r.blocked_by_robots_txt
-                    ]
 
+                    # `failed_results` was populated inside the crawl loop (non-robots
+                    # failures are never added to self.results, only to failed_results).
                     if robots_blocked_count > 0 and robots_blocked_count == attempted:
                         self.stats.all_seeds_robots_blocked = True
                         logger.warning(
@@ -2303,24 +2305,32 @@ class ClauseaCrawler:
                         )
                         _hard_status_codes = frozenset({401, 403, 407, 429, 451})
 
-                        conn_fails = sum(
-                            1
+                        # Classify conn-level first; hard-block is only checked on results
+                        # not already classified, so the two sets are mutually exclusive.
+                        conn_results = [
+                            r
                             for r in failed_results
                             if (
                                 r.error_message
                                 and any(kw in r.error_message.lower() for kw in _conn_keywords)
                             )
                             or (not r.error_message and r.status_code == 0)
-                        )
-                        hard_fails = sum(
-                            1
+                        ]
+                        conn_fails = len(conn_results)
+                        conn_result_set = {id(r) for r in conn_results}
+                        hard_results = [
+                            r
                             for r in failed_results
-                            if r.status_code in _hard_status_codes
-                            or (
-                                r.error_message
-                                and any(kw in r.error_message.lower() for kw in _bot_keywords)
+                            if id(r) not in conn_result_set
+                            and (
+                                r.status_code in _hard_status_codes
+                                or (
+                                    r.error_message
+                                    and any(kw in r.error_message.lower() for kw in _bot_keywords)
+                                )
                             )
-                        )
+                        ]
+                        hard_fails = len(hard_results)
 
                         if conn_fails == len(failed_results):
                             self.stats.site_unavailable = True

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -2261,6 +2261,10 @@ class ClauseaCrawler:
                 if self.stats.crawled_urls == 0:
                     robots_blocked_count = sum(1 for r in self.results if r.blocked_by_robots_txt)
                     attempted = self.stats.total_urls
+                    failed_results = [
+                        r for r in self.results if not r.success and not r.blocked_by_robots_txt
+                    ]
+
                     if robots_blocked_count > 0 and robots_blocked_count == attempted:
                         self.stats.all_seeds_robots_blocked = True
                         logger.warning(
@@ -2270,6 +2274,86 @@ class ClauseaCrawler:
                             robots_blocked_count,
                             termination_reason,
                         )
+                    elif failed_results:
+                        _conn_keywords = frozenset(
+                            (
+                                "connection",
+                                "dns",
+                                "refused",
+                                "reset",
+                                "ssl",
+                                "certificate",
+                                "timeout",
+                                "timed out",
+                                "network",
+                                "resolve",
+                                "unreachable",
+                            )
+                        )
+                        _bot_keywords = frozenset(
+                            (
+                                "captcha",
+                                "cloudflare",
+                                "access denied",
+                                "bot",
+                                "challenge",
+                                "ddos",
+                                "security check",
+                            )
+                        )
+                        _hard_status_codes = frozenset({401, 403, 407, 429, 451})
+
+                        conn_fails = sum(
+                            1
+                            for r in failed_results
+                            if (
+                                r.error_message
+                                and any(kw in r.error_message.lower() for kw in _conn_keywords)
+                            )
+                            or (not r.error_message and r.status_code == 0)
+                        )
+                        hard_fails = sum(
+                            1
+                            for r in failed_results
+                            if r.status_code in _hard_status_codes
+                            or (
+                                r.error_message
+                                and any(kw in r.error_message.lower() for kw in _bot_keywords)
+                            )
+                        )
+
+                        if conn_fails == len(failed_results):
+                            self.stats.site_unavailable = True
+                            logger.warning(
+                                "Crawl for %s completed with 0 pages — all %d non-robots "
+                                "failure(s) are connection-level (DNS/SSL/timeout) "
+                                "(termination_reason=%s)",
+                                base_url,
+                                len(failed_results),
+                                termination_reason,
+                            )
+                        elif hard_fails > 0:
+                            self.stats.access_denied = True
+                            logger.warning(
+                                "Crawl for %s completed with 0 pages — %d/%d failure(s) "
+                                "are hard HTTP blocks or anti-bot responses "
+                                "(termination_reason=%s)",
+                                base_url,
+                                hard_fails,
+                                len(failed_results),
+                                termination_reason,
+                            )
+                        else:
+                            logger.warning(
+                                "Crawl for %s completed with 0 pages — %d failure(s), "
+                                "mixed or unclassified errors "
+                                "(termination_reason=%s, robots_blocked=%d/%d)",
+                                base_url,
+                                len(failed_results),
+                                termination_reason,
+                                robots_blocked_count,
+                                attempted,
+                            )
                     elif termination_reason == "url_queue_empty":
                         logger.warning(
                             "Crawl for %s completed with 0 pages — URL queue was empty "
@@ -2282,6 +2366,9 @@ class ClauseaCrawler:
                             termination_reason,
                         )
                     elif termination_reason == "bot_wall_abort":
+                        # Bot-wall abort with no concrete failed results recorded —
+                        # treat as access_denied since consecutive failures triggered the abort.
+                        self.stats.access_denied = True
                         logger.warning(
                             "Crawl for %s completed with 0 pages — bot-wall abort triggered "
                             "after %d consecutive failures (termination_reason=%s)",

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -2257,6 +2257,50 @@ class ClauseaCrawler:
 
                 self._report_crawl_progress(force=True)
 
+                # Diagnostic: warn when a crawl completes with 0 successfully crawled pages.
+                if self.stats.crawled_urls == 0:
+                    robots_blocked_count = sum(1 for r in self.results if r.blocked_by_robots_txt)
+                    attempted = self.stats.total_urls
+                    if robots_blocked_count > 0 and robots_blocked_count == attempted:
+                        self.stats.all_seeds_robots_blocked = True
+                        logger.warning(
+                            "Crawl for %s completed with 0 pages — all %d attempted URL(s) "
+                            "were blocked by robots.txt (termination_reason=%s)",
+                            base_url,
+                            robots_blocked_count,
+                            termination_reason,
+                        )
+                    elif termination_reason == "url_queue_empty":
+                        logger.warning(
+                            "Crawl for %s completed with 0 pages — URL queue was empty "
+                            "after seeding (sitemap_seeded=%s, robots_blocked=%d/%d, "
+                            "termination_reason=%s)",
+                            base_url,
+                            self._sitemap_seeded,
+                            robots_blocked_count,
+                            attempted,
+                            termination_reason,
+                        )
+                    elif termination_reason == "bot_wall_abort":
+                        logger.warning(
+                            "Crawl for %s completed with 0 pages — bot-wall abort triggered "
+                            "after %d consecutive failures (termination_reason=%s)",
+                            base_url,
+                            self._consecutive_blocked,
+                            termination_reason,
+                        )
+                    else:
+                        logger.warning(
+                            "Crawl for %s completed with 0 pages "
+                            "(termination_reason=%s, total_attempted=%d, "
+                            "robots_blocked=%d, sitemap_seeded=%s)",
+                            base_url,
+                            termination_reason,
+                            attempted,
+                            robots_blocked_count,
+                            self._sitemap_seeded,
+                        )
+
                 if not stop_requested:
                     await self._drain_render_retries(session)
 

--- a/packages/backend/src/crawler/models.py
+++ b/packages/backend/src/crawler/models.py
@@ -96,6 +96,12 @@ class CrawlStats(BaseModel):
     # job.crawl_errors (error_type == "robots_txt_blocked") as the authoritative
     # signal for the "robots_blocked" job status; this field is not read there.
     all_seeds_robots_blocked: bool = False
+    # Set to True when crawled_urls == 0 and all connection attempts failed at the
+    # network layer (DNS failure, SSL error, refused connection, timeout).
+    site_unavailable: bool = False
+    # Set to True when the bot-wall abort triggered with predominantly 4xx/anti-bot
+    # responses (Cloudflare, 403, CAPTCHA). Distinct from robots_txt blocking.
+    access_denied: bool = False
 
     @property
     def elapsed_time(self) -> float:

--- a/packages/backend/src/models/pipeline_job.py
+++ b/packages/backend/src/models/pipeline_job.py
@@ -29,6 +29,10 @@ class PipelineErrorCode(StrEnum):
     interrupted = "interrupted"
     orphaned = "orphaned"
     domain_circuit_breaker = "domain_circuit_breaker"
+    access_denied = "access_denied"  # anti-bot / Cloudflare / 403 wall
+    no_policy_found = "no_policy_found"  # crawled OK, no policy pages found
+    site_unavailable = "site_unavailable"  # DNS / SSL / connection failure
+    analysis_failed = "analysis_failed"  # LLM step failed after docs stored
 
 
 PipelineJobStatus = Literal[
@@ -40,25 +44,38 @@ PipelineJobStatus = Literal[
     "failed",
     "no_documents",
     "robots_blocked",
+    "access_denied",
+    "no_policy_found",
+    "site_unavailable",
+    "analysis_failed",
     "interrupted",
 ]
 
 # Statuses a job can never leave. A job in any of these is "done" and must not be
 # treated as active, reused, or retriggered automatically:
-#   - completed:       ran to the end, overview generated
-#   - no_documents:    crawl ran to completion but found 0 policy documents (a valid,
-#                      deterministic result — retrying yields the same outcome)
-#   - robots_blocked:  the site's robots.txt explicitly blocked all seed URLs;
-#                      deterministic — retrying without manual intervention yields the
-#                      same result. Distinct from no_documents so the frontend can show
-#                      a targeted explanation rather than a generic "nothing found".
-#   - failed:          interrupted or errored. Auto-retry may re-queue some failed
-#                      jobs (transient/retryable) within a bounded attempt budget.
+#   - completed:        ran to the end, overview generated.
+#   - no_documents:     crawl ran to completion but found 0 policy documents (kept
+#                       for backward compat; new jobs use no_policy_found instead).
+#   - robots_blocked:   the site's robots.txt explicitly blocked all seed URLs.
+#                       Deterministic — retrying without manual intervention yields the
+#                       same result.
+#   - access_denied:    anti-bot / Cloudflare / consistent 4xx responses; distinct
+#                       from robots.txt blocking. Deterministic.
+#   - no_policy_found:  crawl succeeded (>0 pages downloaded) but classifier found
+#                       zero relevant policy documents.
+#   - site_unavailable: all seed URLs failed at connection level (DNS, SSL, timeout).
+#   - analysis_failed:  crawl + docs stored OK but LLM synthesis or overview threw.
+#   - failed:           interrupted or errored. Auto-retry may re-queue some failed
+#                       jobs (transient/retryable) within a bounded attempt budget.
 TERMINAL_PIPELINE_STATUSES: tuple[PipelineJobStatus, ...] = (
     "completed",
     "failed",
     "no_documents",
     "robots_blocked",
+    "access_denied",
+    "no_policy_found",
+    "site_unavailable",
+    "analysis_failed",
     "interrupted",
 )
 

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -765,6 +765,7 @@ class PipelineService:
                             f"Document analysis raised an unexpected error: {synth_exc}"
                         )
                         job.completed_at = datetime.now()
+                        job.updated_at = datetime.now()
                         await self._update_step(db, job, "synthesising", "failed", str(synth_exc))
                         await self._update_step(
                             db, job, "generating_overview", "failed", "Skipped — synthesis failed"
@@ -776,6 +777,23 @@ class PipelineService:
                             synth_exc,
                             exc_info=True,
                         )
+                        try:
+                            from src.services.email_service import get_email_service
+
+                            await get_email_service().send_no_documents_alert(
+                                product_name=product.name,
+                                product_slug=job.product_slug,
+                                url=job.url,
+                                reason=job.error_detail or "Document analysis failed",
+                                crawl_error_count=len(job.crawl_errors),
+                                skip_count=len(job.crawl_skip_reasons),
+                            )
+                        except Exception as alert_exc:  # noqa: BLE001
+                            logger.warning(
+                                "analysis-failed admin alert failed",
+                                product_slug=job.product_slug,
+                                error=str(alert_exc),
+                            )
                         return
                     analysed_docs = analysis_result.documents
                     job.analyses_skipped = analysis_result.analyses_skipped
@@ -803,7 +821,7 @@ class PipelineService:
                     no_analysis = bool(analysed_docs) and analysed_count == 0
                     core_wipeout = bool(core_docs) and core_analysed == 0
                     if no_analysis or core_wipeout:
-                        job.status = "failed"
+                        job.status = "analysis_failed"
                         if core_wipeout and not no_analysis:
                             job.error = PipelineErrorCode.core_docs_unanalyzed
                             job.error_detail = (
@@ -827,6 +845,7 @@ class PipelineService:
                                 f"0 of {len(analysed_docs)} documents could be analyzed"
                             )
                         job.completed_at = datetime.now()
+                        job.updated_at = datetime.now()
                         await self._update_step(
                             db,
                             job,
@@ -842,6 +861,23 @@ class PipelineService:
                             "Skipped - no analyzed documents",
                         )
                         await self._pipeline_repo.update(db, job)
+                        try:
+                            from src.services.email_service import get_email_service
+
+                            await get_email_service().send_no_documents_alert(
+                                product_name=product.name,
+                                product_slug=job.product_slug,
+                                url=job.url,
+                                reason=job.error_detail or "Document analysis returned no results",
+                                crawl_error_count=len(job.crawl_errors),
+                                skip_count=len(job.crawl_skip_reasons),
+                            )
+                        except Exception as alert_exc:  # noqa: BLE001
+                            logger.warning(
+                                "analysis-failed admin alert failed",
+                                product_slug=job.product_slug,
+                                error=str(alert_exc),
+                            )
                         return
 
                     await self._update_step(
@@ -897,6 +933,7 @@ class PipelineService:
                             f"Overview generation raised an unexpected error: {overview_exc}"
                         )
                         job.completed_at = datetime.now()
+                        job.updated_at = datetime.now()
                         await self._update_step(
                             db, job, "generating_overview", "failed", str(overview_exc)
                         )
@@ -907,6 +944,23 @@ class PipelineService:
                             overview_exc,
                             exc_info=True,
                         )
+                        try:
+                            from src.services.email_service import get_email_service
+
+                            await get_email_service().send_no_documents_alert(
+                                product_name=product.name,
+                                product_slug=job.product_slug,
+                                url=job.url,
+                                reason=job.error_detail or "Overview generation failed",
+                                crawl_error_count=len(job.crawl_errors),
+                                skip_count=len(job.crawl_skip_reasons),
+                            )
+                        except Exception as alert_exc:  # noqa: BLE001
+                            logger.warning(
+                                "analysis-failed admin alert failed",
+                                product_slug=job.product_slug,
+                                error=str(alert_exc),
+                            )
                         return
 
                     # Verify the overview actually persisted — same truthfulness lesson as

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -28,6 +28,7 @@ from src.models.pipeline_job import (
     CrawlSkip,
     PipelineErrorCode,
     PipelineJob,
+    is_hard_crawl_error,
 )
 from src.models.product import Product
 from src.pipeline import PolicyDocumentPipeline
@@ -517,32 +518,108 @@ class PipelineService:
                         else:
                             job.status = "no_documents"
 
-                        # Build a descriptive error based on crawl error types
-                        robots_blocked = [
-                            err
-                            for err in job.crawl_errors
-                            if err.error_type == "robots_txt_blocked"
+                        # Classify the terminal outcome from the crawl's error signals.
+                        # Priority order: robots_blocked > site_unavailable > access_denied
+                        # > no_policy_found (pages fetched, none matched) > fallback errors.
+                        _robots_errs = [
+                            e for e in job.crawl_errors if e.error_type == "robots_txt_blocked"
                         ]
-                        if (
-                            robots_blocked
-                            and len(robots_blocked) == len(job.crawl_errors)
-                            and not job.crawl_skip_reasons
-                        ):
-                            # All attempted URLs were blocked by robots.txt — this is a
-                            # distinct, deterministic outcome that the frontend surfaces
-                            # with a dedicated "blocked by robots.txt" message instead of
-                            # the generic "no documents found" state.
+                        _non_robots_errs = [
+                            e for e in job.crawl_errors if e.error_type != "robots_txt_blocked"
+                        ]
+                        _conn_errs = [
+                            e
+                            for e in _non_robots_errs
+                            if e.error_type in ("network_error", "timeout")
+                        ]
+                        _hard_errs = [
+                            e
+                            for e in _non_robots_errs
+                            if is_hard_crawl_error(e.error_type, e.status_code, e.error_message)
+                        ]
+
+                        if _robots_errs and not _non_robots_errs:
+                            # All attempted URLs were blocked by robots.txt — deterministic,
+                            # targeted outcome surfaced to the user with dedicated copy.
                             job.status = "robots_blocked"
                             job.error = PipelineErrorCode.crawl_robots_blocked
                             job.error_detail = (
                                 "This site blocks automated access via robots.txt. "
                                 "We were unable to crawl any policy documents."
                             )
-                        elif robots_blocked:
-                            job.status = "robots_blocked"
+                        elif job.status == "no_documents":
+                            # Only apply specific new statuses when there are no existing
+                            # docs (job.status was set to "no_documents" in the else branch
+                            # above). For jobs with existing docs we leave the status
+                            # unchanged so the partial-block signal is informational only.
+                            if (
+                                _non_robots_errs
+                                and _conn_errs
+                                and len(_conn_errs) == len(_non_robots_errs)
+                            ):
+                                # All failures are connection-level (DNS, SSL, timeout, refused)
+                                # and there are no robots-txt blocks — site is unreachable.
+                                job.status = "site_unavailable"
+                                job.error = PipelineErrorCode.site_unavailable
+                                job.error_detail = (
+                                    f"Could not connect to {len(_non_robots_errs)} seed URL(s). "
+                                    "The site may be temporarily down, the domain may have changed, "
+                                    "or a network-level block is in place."
+                                )
+                            elif (
+                                _non_robots_errs
+                                and _hard_errs
+                                and len(_hard_errs) == len(_non_robots_errs)
+                            ):
+                                # All failures are hard HTTP/anti-bot blocks (403/401/429/451 or
+                                # Cloudflare/CAPTCHA) — the site is actively denying access.
+                                job.status = "access_denied"
+                                job.error = PipelineErrorCode.access_denied
+                                job.error_detail = (
+                                    f"Access was denied for {len(_non_robots_errs)} URL(s). "
+                                    "The site is blocking automated access with anti-bot protection, "
+                                    "Cloudflare, or consistent 4xx responses."
+                                )
+                            elif job.crawl_skip_reasons:
+                                # Pages were fetched OK but none passed the policy classifier —
+                                # the site is accessible but has no detectable policy documents.
+                                counts: dict[str, int] = {}
+                                for skip in job.crawl_skip_reasons:
+                                    counts[skip.reason] = counts.get(skip.reason, 0) + 1
+                                breakdown = ", ".join(
+                                    f"{n}× {reason}"
+                                    for reason, n in sorted(counts.items(), key=lambda kv: -kv[1])
+                                )
+                                job.status = "no_policy_found"
+                                job.error = PipelineErrorCode.no_policy_found
+                                job.error_detail = (
+                                    f"{len(job.crawl_skip_reasons)} page(s) fetched but all "
+                                    f"rejected by content filters ({breakdown}). "
+                                    "See crawl_skip_reasons for the per-URL detail."
+                                )
+                            elif _robots_errs:
+                                # Partial robots block mixed with other errors.
+                                job.error = PipelineErrorCode.crawl_robots_blocked
+                                job.error_detail = (
+                                    f"Some pages were blocked by robots.txt ({len(_robots_errs)} "
+                                    f"of {len(job.crawl_errors)} failed URLs). "
+                                    "No policy documents could be found."
+                                )
+                            elif job.crawl_errors:
+                                job.error = PipelineErrorCode.crawl_failed
+                                job.error_detail = (
+                                    f"Crawling failed for {len(job.crawl_errors)} URL(s). "
+                                    "No policy documents could be found."
+                                )
+                            else:
+                                job.error = PipelineErrorCode.no_documents_found
+                                job.error_detail = "No policy documents found on this site"
+                        elif _robots_errs:
+                            # Partial robots block on a job that had existing docs —
+                            # informational only, status remains unchanged.
                             job.error = PipelineErrorCode.crawl_robots_blocked
                             job.error_detail = (
-                                f"Some pages were blocked by robots.txt ({len(robots_blocked)} "
+                                f"Some pages were blocked by robots.txt ({len(_robots_errs)} "
                                 f"of {len(job.crawl_errors)} failed URLs). "
                                 "No policy documents could be found."
                             )
@@ -551,23 +628,6 @@ class PipelineService:
                             job.error_detail = (
                                 f"Crawling failed for {len(job.crawl_errors)} URL(s). "
                                 "No policy documents could be found."
-                            )
-                        elif job.crawl_skip_reasons:
-                            # Categorize: which filter rejected the URLs? This gives the
-                            # operator a concrete next action (tune classifier, enable JS
-                            # rendering, etc.) instead of the prior opaque message.
-                            counts: dict[str, int] = {}
-                            for skip in job.crawl_skip_reasons:
-                                counts[skip.reason] = counts.get(skip.reason, 0) + 1
-                            breakdown = ", ".join(
-                                f"{n}× {reason}"
-                                for reason, n in sorted(counts.items(), key=lambda kv: -kv[1])
-                            )
-                            job.error = PipelineErrorCode.no_documents_found
-                            job.error_detail = (
-                                f"{len(job.crawl_skip_reasons)} URLs fetched but all "
-                                f"rejected by content filters ({breakdown}). "
-                                "See crawl_skip_reasons for the per-URL detail."
                             )
                         else:
                             job.error = PipelineErrorCode.no_documents_found
@@ -595,7 +655,13 @@ class PipelineService:
                         # no overview) and reappearing in the product list is confusing.
                         # The pipeline job is kept as a failure record; the product is
                         # re-created automatically if the user retries the URL later.
-                        if job.status in ("no_documents", "robots_blocked"):
+                        if job.status in (
+                            "no_documents",
+                            "robots_blocked",
+                            "access_denied",
+                            "no_policy_found",
+                            "site_unavailable",
+                        ):
                             try:
                                 doc_count = await db.documents.count_documents(
                                     {"product_id": product.id}
@@ -681,14 +747,36 @@ class PipelineService:
                             message="Retrying LLM analysis…",
                         )
 
-                    analysis_result = await analyse_product_documents(
-                        db,
-                        job.product_slug,
-                        doc_svc,
-                        progress_callback=_on_synthesise_progress,
-                        force_reanalyze=job.force_reanalyze,
-                        heartbeat_callback=_on_synthesise_heartbeat,
-                    )
+                    try:
+                        analysis_result = await analyse_product_documents(
+                            db,
+                            job.product_slug,
+                            doc_svc,
+                            progress_callback=_on_synthesise_progress,
+                            force_reanalyze=job.force_reanalyze,
+                            heartbeat_callback=_on_synthesise_heartbeat,
+                        )
+                    except (asyncio.CancelledError, _PipelineStalled):
+                        raise
+                    except Exception as synth_exc:
+                        job.status = "analysis_failed"
+                        job.error = PipelineErrorCode.analysis_failed
+                        job.error_detail = (
+                            f"Document analysis raised an unexpected error: {synth_exc}"
+                        )
+                        job.completed_at = datetime.now()
+                        await self._update_step(db, job, "synthesising", "failed", str(synth_exc))
+                        await self._update_step(
+                            db, job, "generating_overview", "failed", "Skipped — synthesis failed"
+                        )
+                        await self._pipeline_repo.update(db, job)
+                        logger.error(
+                            "Synthesis raised unexpectedly for %s: %s",
+                            job.product_slug,
+                            synth_exc,
+                            exc_info=True,
+                        )
+                        return
                     analysed_docs = analysis_result.documents
                     job.analyses_skipped = analysis_result.analyses_skipped
 
@@ -790,15 +878,36 @@ class PipelineService:
                             message="Generating privacy overview...",
                         )
 
-                    await generate_product_overview(
-                        db,
-                        job.product_slug,
-                        force_regenerate=True,
-                        product_svc=product_svc_for_overview,
-                        document_svc=doc_svc_for_overview,
-                        on_progress=_on_overview_progress,
-                        job_id=job.id,
-                    )
+                    try:
+                        await generate_product_overview(
+                            db,
+                            job.product_slug,
+                            force_regenerate=True,
+                            product_svc=product_svc_for_overview,
+                            document_svc=doc_svc_for_overview,
+                            on_progress=_on_overview_progress,
+                            job_id=job.id,
+                        )
+                    except (asyncio.CancelledError, _PipelineStalled):
+                        raise
+                    except Exception as overview_exc:
+                        job.status = "analysis_failed"
+                        job.error = PipelineErrorCode.analysis_failed
+                        job.error_detail = (
+                            f"Overview generation raised an unexpected error: {overview_exc}"
+                        )
+                        job.completed_at = datetime.now()
+                        await self._update_step(
+                            db, job, "generating_overview", "failed", str(overview_exc)
+                        )
+                        await self._pipeline_repo.update(db, job)
+                        logger.error(
+                            "Overview generation raised unexpectedly for %s: %s",
+                            job.product_slug,
+                            overview_exc,
+                            exc_info=True,
+                        )
+                        return
 
                     # Verify the overview actually persisted — same truthfulness lesson as
                     # the analysis-persistence bug: never report "completed" off an

--- a/packages/backend/tests/unit/pipeline_error_statuses_test.py
+++ b/packages/backend/tests/unit/pipeline_error_statuses_test.py
@@ -1,0 +1,441 @@
+"""Tests for the granular pipeline error statuses added in feat/pipeline-error-statuses.
+
+Covers:
+- site_unavailable: all crawl errors are connection-level (DNS/SSL/timeout/network)
+- access_denied:    all crawl errors are hard HTTP/anti-bot blocks
+- no_policy_found:  pages were fetched OK but rejected by content filters
+- analysis_failed:  synthesise or generate_overview threw an unexpected exception
+"""
+
+from contextlib import ExitStack, asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.analyser import AnalysisResult
+from src.models.pipeline_job import PipelineErrorCode, PipelineJob
+from src.repositories.pipeline_repository import PipelineRepository
+from src.services.pipeline_service import PipelineService
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.findings.delete_many = AsyncMock(return_value=MagicMock(deleted_count=0))
+    return db
+
+
+def _make_job(job_id: str = "job-test") -> PipelineJob:
+    return PipelineJob(
+        id=job_id,
+        product_slug="test-product",
+        product_name="Test Product",
+        url="https://test.com",
+        status="pending",
+    )
+
+
+def _make_service(job: PipelineJob) -> PipelineService:
+    repo = MagicMock(spec=PipelineRepository)
+    repo.find_by_id = AsyncMock(return_value=job)
+    repo.update = AsyncMock()
+    repo.update_fields = AsyncMock()
+    return PipelineService(pipeline_repo=repo)
+
+
+def _make_product_svc() -> MagicMock:
+    product = SimpleNamespace(id="test-product-id", slug="test-product", name="Test Product")
+    svc = MagicMock()
+    svc.get_product_by_slug = AsyncMock(return_value=product)
+    return svc
+
+
+def _make_empty_doc_svc() -> MagicMock:
+    svc = MagicMock()
+    svc.get_product_documents_by_slug = AsyncMock(return_value=[])
+    return svc
+
+
+def _patches(mock_db, fake_pipeline, product_svc, doc_svc=None) -> ExitStack:
+    """Return an ExitStack with the common pipeline service patches already entered."""
+
+    @asynccontextmanager
+    async def fake_db_session():
+        yield mock_db
+
+    if doc_svc is None:
+        doc_svc = _make_empty_doc_svc()
+
+    stack = ExitStack()
+    stack.enter_context(patch("src.services.pipeline_service.db_session", fake_db_session))
+    stack.enter_context(
+        patch("src.services.pipeline_service.create_product_service", return_value=product_svc)
+    )
+    stack.enter_context(
+        patch("src.services.pipeline_service.create_document_service", return_value=doc_svc)
+    )
+    stack.enter_context(
+        patch("src.services.pipeline_service.PolicyDocumentPipeline", return_value=fake_pipeline)
+    )
+    return stack
+
+
+# ---------------------------------------------------------------------------
+# site_unavailable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_site_unavailable_when_all_errors_are_connection_level(mock_db):
+    """When every crawl error is network/timeout type the job must become site_unavailable.
+
+    This is distinct from ``no_documents`` (unknown reason) and from ``failed``
+    (retriable interruption). The site is unreachable — the user sees a targeted
+    "site may be down" message rather than a generic failure.
+    """
+    job = _make_job("job-unavail")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=0,
+        policy_documents_stored=0,
+        crawl_errors=[
+            {
+                "url": "https://test.com/",
+                "status_code": 0,
+                "error_message": "Cannot connect to host test.com:443 [connection refused]",
+                "error_type": "network_error",
+            },
+            {
+                "url": "https://test.com/privacy",
+                "status_code": 0,
+                "error_message": "getaddrinfo failed: DNS lookup failed for test.com",
+                "error_type": "network_error",
+            },
+        ],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    with _patches(mock_db, fake_pipeline, product_svc):
+        await service.run_pipeline("job-unavail")
+
+    assert job.status == "site_unavailable"
+    assert job.error == PipelineErrorCode.site_unavailable
+    assert job.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_site_unavailable_includes_timeout_errors(mock_db):
+    """Timeout errors are treated as connection-level for site_unavailable detection."""
+    job = _make_job("job-timeout")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=0,
+        policy_documents_stored=0,
+        crawl_errors=[
+            {
+                "url": "https://test.com/",
+                "status_code": 0,
+                "error_message": "Connection timed out",
+                "error_type": "timeout",
+            },
+        ],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    with _patches(mock_db, fake_pipeline, product_svc):
+        await service.run_pipeline("job-timeout")
+
+    assert job.status == "site_unavailable"
+    assert job.error == PipelineErrorCode.site_unavailable
+
+
+# ---------------------------------------------------------------------------
+# access_denied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_access_denied_when_all_errors_are_hard_http_403(mock_db):
+    """When every crawl error is a hard 4xx block the job must become access_denied.
+
+    Distinct from robots_blocked (robots.txt) and site_unavailable (connection).
+    """
+    job = _make_job("job-403")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=0,
+        policy_documents_stored=0,
+        crawl_errors=[
+            {
+                "url": "https://test.com/",
+                "status_code": 403,
+                "error_message": "HTTP 403 Forbidden",
+                "error_type": "http_error",
+            },
+            {
+                "url": "https://test.com/privacy",
+                "status_code": 403,
+                "error_message": "HTTP 403 Forbidden",
+                "error_type": "http_error",
+            },
+        ],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    with _patches(mock_db, fake_pipeline, product_svc):
+        await service.run_pipeline("job-403")
+
+    assert job.status == "access_denied"
+    assert job.error == PipelineErrorCode.access_denied
+    assert job.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_access_denied_when_bot_detection_keywords_in_error(mock_db):
+    """Bot-detection keywords in the error message trigger access_denied."""
+    job = _make_job("job-bot")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=0,
+        policy_documents_stored=0,
+        crawl_errors=[
+            {
+                "url": "https://test.com/",
+                "status_code": 200,
+                "error_message": "Cloudflare challenge page detected",
+                "error_type": "http_error",
+            },
+        ],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    with _patches(mock_db, fake_pipeline, product_svc):
+        await service.run_pipeline("job-bot")
+
+    assert job.status == "access_denied"
+    assert job.error == PipelineErrorCode.access_denied
+
+
+# ---------------------------------------------------------------------------
+# no_policy_found
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_policy_found_when_pages_fetched_but_rejected(mock_db):
+    """When crawl_skip_reasons are present the job must become no_policy_found.
+
+    This is distinct from ``no_documents`` (0 pages crawled) — here the crawler
+    DID fetch pages but the classifier found nothing relevant.
+    """
+    job = _make_job("job-nopolicy")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=0,
+        policy_documents_stored=0,
+        crawl_errors=[],
+        crawl_skip_reasons=[
+            {"url": "https://test.com/about", "reason": "low_legal_score", "detail": "score=0.12"},
+            {"url": "https://test.com/faq", "reason": "non_policy_classification", "detail": None},
+        ],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    with _patches(mock_db, fake_pipeline, product_svc):
+        await service.run_pipeline("job-nopolicy")
+
+    assert job.status == "no_policy_found"
+    assert job.error == PipelineErrorCode.no_policy_found
+    assert job.completed_at is not None
+    assert "low_legal_score" in (job.error_detail or "")
+
+
+# ---------------------------------------------------------------------------
+# analysis_failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analysis_failed_when_synthesise_raises(mock_db):
+    """If analyse_product_documents raises unexpectedly the job must become analysis_failed.
+
+    Unlike the ``all_analysis_failed`` / ``core_docs_unanalyzed`` codes (where the
+    analyser returned but no docs were successfully analysed), this covers the case
+    where the function itself throws — e.g. an unexpected LLM SDK error.
+    """
+    job = _make_job("job-synth-raise")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+    product_svc.get_product_overview_data = AsyncMock(return_value={"overview": {"summary": "ok"}})
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=2,
+        policy_documents_stored=2,
+        crawl_errors=[],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    doc_svc = MagicMock()
+    doc_svc.get_product_documents_by_slug = AsyncMock(return_value=[])
+
+    analyse_mock = AsyncMock(side_effect=RuntimeError("Unexpected LLM SDK error"))
+    overview_mock = AsyncMock()
+
+    @asynccontextmanager
+    async def fake_db_session():
+        yield mock_db
+
+    with (
+        patch("src.services.pipeline_service.db_session", fake_db_session),
+        patch("src.services.pipeline_service.create_product_service", return_value=product_svc),
+        patch("src.services.pipeline_service.create_document_service", return_value=doc_svc),
+        patch("src.services.pipeline_service.PolicyDocumentPipeline", return_value=fake_pipeline),
+        patch("src.services.pipeline_service.analyse_product_documents", analyse_mock),
+        patch("src.services.pipeline_service.generate_product_overview", overview_mock),
+    ):
+        await service.run_pipeline("job-synth-raise")
+
+    assert job.status == "analysis_failed"
+    assert job.error == PipelineErrorCode.analysis_failed
+    assert job.completed_at is not None
+    assert "Unexpected LLM SDK error" in (job.error_detail or "")
+    overview_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_analysis_failed_when_overview_raises(mock_db):
+    """If generate_product_overview raises unexpectedly the job must become analysis_failed.
+
+    The synthesise step succeeded (documents were analysed), but the overview
+    generation threw. The user is offered a "try again" path since this is transient.
+    """
+    job = _make_job("job-overview-raise")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=1,
+        policy_documents_stored=1,
+        crawl_errors=[],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    doc_svc = MagicMock()
+    doc_svc.get_product_documents_by_slug = AsyncMock(return_value=[])
+
+    analysed_docs = [SimpleNamespace(analysis=object(), doc_type="privacy_policy")]
+    analyse_mock = AsyncMock(
+        return_value=AnalysisResult(documents=analysed_docs, analyses_skipped=0)  # ty: ignore[invalid-argument-type]
+    )
+    overview_mock = AsyncMock(side_effect=RuntimeError("Overview LLM timed out"))
+
+    @asynccontextmanager
+    async def fake_db_session():
+        yield mock_db
+
+    with (
+        patch("src.services.pipeline_service.db_session", fake_db_session),
+        patch("src.services.pipeline_service.create_product_service", return_value=product_svc),
+        patch("src.services.pipeline_service.create_document_service", return_value=doc_svc),
+        patch("src.services.pipeline_service.PolicyDocumentPipeline", return_value=fake_pipeline),
+        patch("src.services.pipeline_service.analyse_product_documents", analyse_mock),
+        patch("src.services.pipeline_service.generate_product_overview", overview_mock),
+    ):
+        await service.run_pipeline("job-overview-raise")
+
+    assert job.status == "analysis_failed"
+    assert job.error == PipelineErrorCode.analysis_failed
+    assert job.completed_at is not None
+    assert "Overview LLM timed out" in (job.error_detail or "")
+
+
+# ---------------------------------------------------------------------------
+# Regression: no_documents still used for truly unknown cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_documents_used_when_no_errors_and_no_skips(mock_db):
+    """When the crawl stores 0 docs with no errors and no skip reasons, use no_documents.
+
+    This preserves backward compatibility for the "queue was empty / site had no
+    pages" case where we have no signal about WHY the crawl found nothing.
+    """
+    job = _make_job("job-unknown")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=0,
+        policy_documents_stored=0,
+        crawl_errors=[],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    with _patches(mock_db, fake_pipeline, product_svc):
+        await service.run_pipeline("job-unknown")
+
+    assert job.status == "no_documents"
+    assert job.completed_at is not None
+
+
+# ---------------------------------------------------------------------------
+# robots_blocked still works (regression)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_robots_blocked_when_all_errors_are_robots_txt(mock_db):
+    """Regression: all-robots-blocked crawl still produces robots_blocked status."""
+    job = _make_job("job-robots")
+    service = _make_service(job)
+    product_svc = _make_product_svc()
+
+    crawl_stats = SimpleNamespace(
+        total_documents_found=0,
+        policy_documents_stored=0,
+        crawl_errors=[
+            {
+                "url": "https://test.com/",
+                "status_code": 403,
+                "error_message": "Blocked by robots.txt: Disallow: /",
+                "error_type": "robots_txt_blocked",
+            },
+        ],
+        crawl_skip_reasons=[],
+    )
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock(return_value=crawl_stats)
+
+    with _patches(mock_db, fake_pipeline, product_svc):
+        await service.run_pipeline("job-robots")
+
+    assert job.status == "robots_blocked"
+    assert job.error == PipelineErrorCode.crawl_robots_blocked
+    assert job.completed_at is not None

--- a/packages/backend/tests/unit/pipeline_error_statuses_test.py
+++ b/packages/backend/tests/unit/pipeline_error_statuses_test.py
@@ -9,11 +9,12 @@ Covers:
 
 from contextlib import ExitStack, asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 
 from src.analyser import AnalysisResult
+from src.models.document import Document
 from src.models.pipeline_job import PipelineErrorCode, PipelineJob
 from src.repositories.pipeline_repository import PipelineRepository
 from src.services.pipeline_service import PipelineService
@@ -347,9 +348,12 @@ async def test_analysis_failed_when_overview_raises(mock_db):
     doc_svc = MagicMock()
     doc_svc.get_product_documents_by_slug = AsyncMock(return_value=[])
 
-    analysed_docs = [SimpleNamespace(analysis=object(), doc_type="privacy_policy")]
+    analysed_doc = create_autospec(Document, instance=True)
+    analysed_doc.analysis = object()
+    analysed_doc.doc_type = "privacy_policy"
+    analysed_docs = [analysed_doc]
     analyse_mock = AsyncMock(
-        return_value=AnalysisResult(documents=analysed_docs, analyses_skipped=0)  # ty: ignore[invalid-argument-type]
+        return_value=AnalysisResult(documents=analysed_docs, analyses_skipped=0)
     )
     overview_mock = AsyncMock(side_effect=RuntimeError("Overview LLM timed out"))
 

--- a/packages/backend/tests/unit/pipeline_service_test.py
+++ b/packages/backend/tests/unit/pipeline_service_test.py
@@ -256,7 +256,7 @@ async def test_run_pipeline_all_documents_fail_analysis_is_truthful(mock_db):
     ):
         await service.run_pipeline("job-analysis")
 
-    assert job.status == "failed"
+    assert job.status == "analysis_failed"
     assert job.error == PipelineErrorCode.all_analysis_failed
     assert "could not analyze" in (job.error_detail or "").lower()
     # Crawl succeeded, so the truthful frontend can tell this is an analysis failure.

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -553,12 +553,12 @@ export default function CompanyPage({
       //   - failedJob        (failed):          interrupted/errored. Offer retry.
       const terminalJob =
         robotsBlockedJob ??
-        emptyJob ??
-        failedJob ??
         accessDeniedJob ??
         noPolicyJob ??
         siteUnavailableJob ??
-        analysisFailedJob;
+        analysisFailedJob ??
+        emptyJob ??
+        failedJob;
       const isRobotsBlocked = robotsBlockedJob !== null;
       const isAccessDenied = accessDeniedJob !== null;
       const isEmpty = emptyJob !== null;

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -129,6 +129,14 @@ export default function CompanyPage({
   const [emptyJob, setEmptyJob] = useState<FailedCrawlJob | null>(null);
   const [robotsBlockedJob, setRobotsBlockedJob] =
     useState<FailedCrawlJob | null>(null);
+  const [accessDeniedJob, setAccessDeniedJob] = useState<FailedCrawlJob | null>(
+    null,
+  );
+  const [noPolicyJob, setNoPolicyJob] = useState<FailedCrawlJob | null>(null);
+  const [siteUnavailableJob, setSiteUnavailableJob] =
+    useState<FailedCrawlJob | null>(null);
+  const [analysisFailedJob, setAnalysisFailedJob] =
+    useState<FailedCrawlJob | null>(null);
   const [notifyEmail, setNotifyEmail] = useState("");
   const [notifyStatus, setNotifyStatus] = useState<
     "idle" | "submitting" | "success" | "error"
@@ -244,6 +252,42 @@ export default function CompanyPage({
           return;
         }
 
+        if (latestJob?.status === "access_denied") {
+          setAccessDeniedJob({
+            error: latestJob.error,
+            error_detail: latestJob.error_detail ?? null,
+            crawl_errors: latestJob.crawl_errors ?? [],
+          });
+          return;
+        }
+
+        if (latestJob?.status === "no_policy_found") {
+          setNoPolicyJob({
+            error: latestJob.error,
+            error_detail: latestJob.error_detail ?? null,
+            crawl_errors: latestJob.crawl_errors ?? [],
+          });
+          return;
+        }
+
+        if (latestJob?.status === "site_unavailable") {
+          setSiteUnavailableJob({
+            error: latestJob.error,
+            error_detail: latestJob.error_detail ?? null,
+            crawl_errors: latestJob.crawl_errors ?? [],
+          });
+          return;
+        }
+
+        if (latestJob?.status === "analysis_failed") {
+          setAnalysisFailedJob({
+            error: latestJob.error,
+            error_detail: latestJob.error_detail ?? null,
+            crawl_errors: latestJob.crawl_errors ?? [],
+          });
+          return;
+        }
+
         if (latestJob?.status === "no_documents") {
           setEmptyJob({
             error: latestJob.error,
@@ -326,6 +370,10 @@ export default function CompanyPage({
     setFailedJob(null);
     setEmptyJob(null);
     setRobotsBlockedJob(null);
+    setAccessDeniedJob(null);
+    setNoPolicyJob(null);
+    setSiteUnavailableJob(null);
+    setAnalysisFailedJob(null);
     setActiveJobId(null);
     setIndexationMode("indexing");
     await ensurePipelineRunning(slug, product);
@@ -495,16 +543,29 @@ export default function CompanyPage({
 
     // If product exists but indexation isn't ready, show the indexation message + email capture
     if (product && indexationMode === "indexing") {
-      // Terminal outcomes that must NOT retrigger the pipeline:
-      //   - robotsBlockedJob (robots_blocked): site blocks all crawlers. No retry —
-      //                a re-run yields the same result until the site changes robots.txt.
-      //   - emptyJob  (no_documents): crawl finished, found nothing. No retry —
-      //                a re-run yields the same result.
-      //   - failedJob (failed):       interrupted/errored. Offer a manual Retry.
-      const terminalJob = robotsBlockedJob ?? emptyJob ?? failedJob;
+      // Terminal outcomes grouped by retry eligibility:
+      //   - robotsBlockedJob (robots_blocked): deterministic. No retry.
+      //   - accessDeniedJob  (access_denied):  deterministic. No retry.
+      //   - emptyJob         (no_documents):   deterministic. No retry.
+      //   - noPolicyJob      (no_policy_found): site structure may change. Offer retry.
+      //   - siteUnavailableJob (site_unavailable): transient. Offer retry.
+      //   - analysisFailedJob  (analysis_failed): transient. Offer retry.
+      //   - failedJob        (failed):          interrupted/errored. Offer retry.
+      const terminalJob =
+        robotsBlockedJob ??
+        emptyJob ??
+        failedJob ??
+        accessDeniedJob ??
+        noPolicyJob ??
+        siteUnavailableJob ??
+        analysisFailedJob;
       const isRobotsBlocked = robotsBlockedJob !== null;
+      const isAccessDenied = accessDeniedJob !== null;
       const isEmpty = emptyJob !== null;
       const isFailed = failedJob !== null;
+      const isNoPolicyFound = noPolicyJob !== null;
+      const isSiteUnavailable = siteUnavailableJob !== null;
+      const isAnalysisFailed = analysisFailedJob !== null;
       // The crawl succeeded (documents were stored) but a later stage — document
       // analysis or overview synthesis — failed. Don't blame the crawl in this case.
       const isAnalysisFailure =
@@ -513,6 +574,7 @@ export default function CompanyPage({
       // Legacy derived detection for old jobs that predate the robots_blocked status.
       const allRobotsBlockedLegacy =
         !isRobotsBlocked &&
+        !isAccessDenied &&
         crawlErrors.length > 0 &&
         crawlErrors.every((e) => e.error_type === "robots_txt_blocked");
 
@@ -525,13 +587,21 @@ export default function CompanyPage({
             <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-relaxed">
               {isRobotsBlocked || allRobotsBlockedLegacy
                 ? `${product.name} doesn't allow automated access to their policies.`
-                : isEmpty
-                  ? "We could not find any policy documents to analyze for this company."
-                  : isAnalysisFailure
-                    ? "We found this company's policy documents but couldn't complete the analysis. This is usually temporary — please try again."
-                    : isFailed
-                      ? "We were unable to crawl this company's policy documents."
-                      : "Indexation is in progress for this company. Our systems are currently mapping the privacy landscape. Please return shortly once the analysis is complete."}
+                : isAccessDenied
+                  ? `${product.name} actively blocked our crawler. You can visit their site directly to read their policies.`
+                  : isNoPolicyFound
+                    ? "We crawled this site but couldn't find any policy pages."
+                    : isSiteUnavailable
+                      ? "We couldn't reach this site — it may be temporarily down or the domain may have changed."
+                      : isAnalysisFailed
+                        ? "We retrieved the policy documents but encountered an error during AI analysis. Please try again."
+                        : isEmpty
+                          ? "We could not find any policy documents to analyze for this company."
+                          : isAnalysisFailure
+                            ? "We found this company's policy documents but couldn't complete the analysis. This is usually temporary — please try again."
+                            : isFailed
+                              ? "We were unable to crawl this company's policy documents."
+                              : "Indexation is in progress for this company. Our systems are currently mapping the privacy landscape. Please return shortly once the analysis is complete."}
             </p>
           </div>
 
@@ -547,11 +617,19 @@ export default function CompanyPage({
                   <h3 className="text-[10px] uppercase tracking-[0.2em] font-medium text-foreground">
                     {isRobotsBlocked || allRobotsBlockedLegacy
                       ? "Automated Access Blocked"
-                      : isEmpty
-                        ? "No Documents Found"
-                        : isAnalysisFailure
-                          ? "Analysis Failed"
-                          : "Crawl Failed"}
+                      : isAccessDenied
+                        ? "Access Blocked"
+                        : isNoPolicyFound
+                          ? "No Policy Pages Found"
+                          : isSiteUnavailable
+                            ? "Site Unreachable"
+                            : isAnalysisFailed
+                              ? "Analysis Failed"
+                              : isEmpty
+                                ? "No Documents Found"
+                                : isAnalysisFailure
+                                  ? "Analysis Failed"
+                                  : "Crawl Failed"}
                   </h3>
                 </div>
               </div>
@@ -559,15 +637,13 @@ export default function CompanyPage({
                 {allRobotsBlockedLegacy || isRobotsBlocked ? (
                   <div className="space-y-3">
                     <h2 className="text-xl font-display font-medium text-foreground">
-                      {product.name} doesn&apos;t allow automated access to
-                      their policies
+                      Blocked by robots.txt
                     </h2>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      {product.name}&apos;s robots.txt explicitly blocks
-                      crawlers from reading their pages. We&apos;re unable to
-                      analyze their privacy policy or terms of service until
-                      they allow automated access. You may review their policies
-                      directly on their website.
+                      <strong>{product.name}</strong> explicitly restricts
+                      automated access via their robots.txt file. Their policy
+                      documents cannot be retrieved programmatically. You can
+                      visit their site directly to read their policies.
                     </p>
                     {crawlErrors.length > 0 && (
                       <div className="space-y-2 pt-2">
@@ -590,14 +666,29 @@ export default function CompanyPage({
                       </div>
                     )}
                   </div>
+                ) : isAccessDenied ? (
+                  <div className="space-y-3">
+                    <h2 className="text-xl font-display font-medium text-foreground">
+                      Blocked by bot protection
+                    </h2>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      {PIPELINE_ERROR_CODE_MESSAGES["access_denied"]}
+                    </p>
+                  </div>
                 ) : (
                   <div className="space-y-3">
                     <h2 className="text-xl font-display font-medium text-foreground">
-                      {isEmpty
-                        ? "No policy documents found on this site"
-                        : isAnalysisFailure
-                          ? "We found documents but couldn't analyze them"
-                          : "Unable to crawl policy documents"}
+                      {isNoPolicyFound
+                        ? "No policy pages found on this site"
+                        : isSiteUnavailable
+                          ? "This site is unreachable right now"
+                          : isAnalysisFailed
+                            ? "Analysis failed — please try again"
+                            : isEmpty
+                              ? "No policy documents found on this site"
+                              : isAnalysisFailure
+                                ? "We found documents but couldn't analyze them"
+                                : "Unable to crawl policy documents"}
                     </h2>
                     <p className="text-sm text-muted-foreground leading-relaxed">
                       {(terminalJob.error
@@ -652,6 +743,21 @@ export default function CompanyPage({
                       <p className="text-xs text-muted-foreground mt-2">
                         Retry is not available — {product.name} blocks automated
                         access. You may check back later if this changes.
+                      </p>
+                    </>
+                  ) : isAccessDenied ? (
+                    <>
+                      <Button
+                        disabled
+                        className="h-11 px-6 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+                      >
+                        <RotateCcw className="mr-2 h-3.5 w-3.5" />
+                        Try again
+                      </Button>
+                      <p className="text-xs text-muted-foreground mt-2">
+                        Retry is not available — {product.name} uses bot
+                        protection that blocks automated access. You may check
+                        back later.
                       </p>
                     </>
                   ) : isEmpty ? (

--- a/packages/frontend/app/api/pipeline/jobs/[id]/route.ts
+++ b/packages/frontend/app/api/pipeline/jobs/[id]/route.ts
@@ -7,10 +7,18 @@ import { httpJson } from "@lib/http";
 type PipelineJobStatus =
   | "pending"
   | "crawling"
+  | "synthesising"
   | "summarizing"
   | "generating_overview"
   | "completed"
-  | "failed";
+  | "failed"
+  | "no_documents"
+  | "robots_blocked"
+  | "access_denied"
+  | "no_policy_found"
+  | "site_unavailable"
+  | "analysis_failed"
+  | "interrupted";
 
 interface PipelineStep {
   name: string;

--- a/packages/frontend/components/pipeline/pipeline-progress.tsx
+++ b/packages/frontend/components/pipeline/pipeline-progress.tsx
@@ -34,11 +34,17 @@ interface PipelineStep {
 type PipelineJobStatus =
   | "pending"
   | "crawling"
+  | "synthesising"
   | "summarizing"
   | "generating_overview"
   | "completed"
   | "failed"
-  | "no_documents";
+  | "no_documents"
+  | "robots_blocked"
+  | "access_denied"
+  | "no_policy_found"
+  | "site_unavailable"
+  | "analysis_failed";
 
 interface PipelineJobData {
   id: string;
@@ -262,10 +268,18 @@ export function PipelineProgress({
   const abortRef = useRef<AbortController | null>(null);
   const startedAtRef = useRef<number | null>(null);
 
-  const isTerminal =
-    job?.status === "completed" ||
-    job?.status === "failed" ||
-    job?.status === "no_documents";
+  const TERMINAL_STATUSES: PipelineJobStatus[] = [
+    "completed",
+    "failed",
+    "no_documents",
+    "robots_blocked",
+    "access_denied",
+    "no_policy_found",
+    "site_unavailable",
+    "analysis_failed",
+  ];
+
+  const isTerminal = job !== null && TERMINAL_STATUSES.includes(job.status);
 
   const clearScheduledPoll = useCallback(() => {
     if (timeoutRef.current) {
@@ -315,11 +329,17 @@ export function PipelineProgress({
       const data: PipelineJobData = await res.json();
       setJob(data);
 
-      if (
-        data.status === "completed" ||
-        data.status === "failed" ||
-        data.status === "no_documents"
-      ) {
+      const terminalStatuses: PipelineJobStatus[] = [
+        "completed",
+        "failed",
+        "no_documents",
+        "robots_blocked",
+        "access_denied",
+        "no_policy_found",
+        "site_unavailable",
+        "analysis_failed",
+      ];
+      if (terminalStatuses.includes(data.status)) {
         clearScheduledPoll();
         if (data.status === "completed" && onComplete) {
           onComplete(data.product_slug);
@@ -436,8 +456,14 @@ export function PipelineProgress({
           className={cn(
             "transition-all duration-300",
             job.status === "completed" && "border-green-500/50",
-            job.status === "failed" && "border-destructive/50",
-            job.status === "no_documents" && "border-amber-500/50",
+            (job.status === "failed" || job.status === "analysis_failed") &&
+              "border-destructive/50",
+            (job.status === "no_documents" ||
+              job.status === "no_policy_found" ||
+              job.status === "robots_blocked" ||
+              job.status === "access_denied" ||
+              job.status === "site_unavailable") &&
+              "border-amber-500/50",
           )}
         >
           <CardContent className="p-5 space-y-4">
@@ -447,11 +473,19 @@ export function PipelineProgress({
                 <h3 className="text-sm font-bold font-display text-foreground">
                   {job.status === "completed"
                     ? `${job.product_name} is ready`
-                    : job.status === "no_documents"
+                    : job.status === "no_documents" ||
+                        job.status === "no_policy_found"
                       ? `No policy documents found for ${job.product_name}`
-                      : job.status === "failed"
-                        ? `Analysis failed for ${job.product_name}`
-                        : `Analyzing ${job.product_name}...`}
+                      : job.status === "robots_blocked"
+                        ? `${job.product_name} blocks automated access`
+                        : job.status === "access_denied"
+                          ? `${job.product_name} blocked our access`
+                          : job.status === "site_unavailable"
+                            ? `${job.product_name} is unreachable`
+                            : job.status === "failed" ||
+                                job.status === "analysis_failed"
+                              ? `Analysis failed for ${job.product_name}`
+                              : `Analyzing ${job.product_name}...`}
                 </h3>
                 <p className="text-xs text-muted-foreground truncate max-w-xs">
                   {job.url}
@@ -477,9 +511,13 @@ export function PipelineProgress({
                 transition={{ duration: 0.5, ease: "easeOut" }}
                 className={cn(
                   "h-full rounded-full",
-                  job.status === "failed"
+                  job.status === "failed" || job.status === "analysis_failed"
                     ? "bg-destructive"
-                    : job.status === "no_documents"
+                    : job.status === "no_documents" ||
+                        job.status === "no_policy_found" ||
+                        job.status === "robots_blocked" ||
+                        job.status === "access_denied" ||
+                        job.status === "site_unavailable"
                       ? "bg-amber-500"
                       : job.status === "completed"
                         ? "bg-green-500"

--- a/packages/frontend/components/pipeline/pipeline-progress.tsx
+++ b/packages/frontend/components/pipeline/pipeline-progress.tsx
@@ -254,6 +254,17 @@ function CrawlErrorsDisplay({ errors }: { errors: CrawlError[] }) {
   );
 }
 
+const TERMINAL_STATUSES: PipelineJobStatus[] = [
+  "completed",
+  "failed",
+  "no_documents",
+  "robots_blocked",
+  "access_denied",
+  "no_policy_found",
+  "site_unavailable",
+  "analysis_failed",
+];
+
 export function PipelineProgress({
   jobId,
   onComplete,
@@ -267,17 +278,6 @@ export function PipelineProgress({
   const inFlightRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
   const startedAtRef = useRef<number | null>(null);
-
-  const TERMINAL_STATUSES: PipelineJobStatus[] = [
-    "completed",
-    "failed",
-    "no_documents",
-    "robots_blocked",
-    "access_denied",
-    "no_policy_found",
-    "site_unavailable",
-    "analysis_failed",
-  ];
 
   const isTerminal = job !== null && TERMINAL_STATUSES.includes(job.status);
 
@@ -329,17 +329,7 @@ export function PipelineProgress({
       const data: PipelineJobData = await res.json();
       setJob(data);
 
-      const terminalStatuses: PipelineJobStatus[] = [
-        "completed",
-        "failed",
-        "no_documents",
-        "robots_blocked",
-        "access_denied",
-        "no_policy_found",
-        "site_unavailable",
-        "analysis_failed",
-      ];
-      if (terminalStatuses.includes(data.status)) {
+      if (TERMINAL_STATUSES.includes(data.status)) {
         clearScheduledPoll();
         if (data.status === "completed" && onComplete) {
           onComplete(data.product_slug);

--- a/packages/frontend/lib/pipeline-errors.ts
+++ b/packages/frontend/lib/pipeline-errors.ts
@@ -26,6 +26,14 @@ export const PIPELINE_ERROR_CODE_MESSAGES: Record<string, string> = {
     "Analysis was interrupted by a worker restart and will resume automatically.",
   orphaned:
     "The analysis worker lost contact with this job (restart, crash, or missing heartbeats). It will be retried automatically.",
+  access_denied:
+    "This site actively blocked our crawler — likely Cloudflare or similar bot protection. This is a restriction set by the site. You can visit their site directly to read their policies.",
+  no_policy_found:
+    "We successfully crawled this site but couldn't find any privacy policy, terms of service, or cookie policy pages. The site may use a non-standard URL structure.",
+  site_unavailable:
+    "We couldn't reach this site — it may be temporarily down, the domain may have moved, or a network issue prevented access. Please try again later.",
+  analysis_failed:
+    "We retrieved the policy documents but encountered an error during AI analysis. This is temporary — please try again.",
 };
 
 export function resolvePipelineErrorMessage(


### PR DESCRIPTION
## Summary

- **Backend**: adds four new `PipelineErrorCode` values (`access_denied`, `no_policy_found`, `site_unavailable`, `analysis_failed`), extends `PipelineJobStatus` Literal and `TERMINAL_PIPELINE_STATUSES` to include them, and wires up crawler-level detection that classifies zero-page crawls into connection failures vs hard bot-walls
- **Frontend**: user-facing copy for all four new error codes in `pipeline-errors.ts`, plus full UI render paths in `product-page-client.tsx` — each terminal status now shows a dedicated, human-readable card explaining *why* the analysis is unavailable and *what the user can do*
- **Retry logic**: deterministic failures (`robots_blocked`, `access_denied`) hide the retry button; transient failures (`no_policy_found`, `site_unavailable`, `analysis_failed`) show it

## Detailed changes

### `packages/backend/src/models/pipeline_job.py`
- `PipelineErrorCode`: `access_denied`, `no_policy_found`, `site_unavailable`, `analysis_failed`
- `PipelineJobStatus`: same four new literal values
- `TERMINAL_PIPELINE_STATUSES`: includes all four

### `packages/backend/src/crawler/models.py`
- `CrawlStats` gains `site_unavailable: bool` and `access_denied: bool` flags

### `packages/backend/src/crawler/client.py`
- After a zero-page crawl, classifies failures as connection-level (`site_unavailable`) vs hard bot-block (`access_denied`) vs mixed/unclassified, and sets the corresponding flag

### `packages/frontend/lib/pipeline-errors.ts`
- Plain-language copy for `access_denied`, `no_policy_found`, `site_unavailable`, `analysis_failed`

### `packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx`
- Four new state variables: `accessDeniedJob`, `noPolicyJob`, `siteUnavailableJob`, `analysisFailedJob`
- Status-checking chain: four new handlers that set the appropriate state and return early
- `handleRetry()`: resets all four new states
- Render: `terminalJob` union extended; new `isAccessDenied` branch shows "Blocked by bot protection" card (no retry); all card headers/subtitles updated for every new status; retry button now hidden for `robots_blocked` **and** `access_denied`

## Test plan
- [ ] Navigate to a product page whose latest job has `status: "robots_blocked"` — confirm "Blocked by robots.txt" card appears, no retry button
- [ ] Same for `status: "access_denied"` — confirm "Blocked by bot protection" card, no retry button
- [ ] Same for `status: "no_policy_found"` — confirm "No Policy Pages Found" card with retry button
- [ ] Same for `status: "site_unavailable"` — confirm "Site Unreachable" card with retry button
- [ ] Same for `status: "analysis_failed"` — confirm "Analysis Failed" card with retry button
- [ ] Active/in-progress jobs still show the notification + pipeline progress block