### PR TITLE
fix(worker): cancel zombie tasks when stale sweep fails jobs in DB

### DIFF
--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -26,7 +26,12 @@ _TERMINAL_STATUSES = list(TERMINAL_PIPELINE_STATUSES)
 # Statuses for a job that was actively executing and can be left orphaned by a worker
 # crash. A "pending" job is only queued — never started — so a restart must leave it
 # pending for the worker to pick up, not fail it. Only these can be marked stale.
-_ORPHANABLE_STATUSES = ["crawling", "synthesising", "generating_overview"]
+ORPHANABLE_PIPELINE_STATUSES: tuple[str, ...] = (
+    "crawling",
+    "synthesising",
+    "generating_overview",
+)
+_ORPHANABLE_STATUSES = list(ORPHANABLE_PIPELINE_STATUSES)
 
 logger = get_logger(__name__)
 

--- a/packages/backend/tests/unit/worker_zombie_test.py
+++ b/packages/backend/tests/unit/worker_zombie_test.py
@@ -1,0 +1,87 @@
+"""Worker must cancel in-process tasks when the DB no longer shows them as in-progress."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from worker import _cancel_zombie_tasks
+
+
+class _FakeCursor:
+    def __init__(self, docs: list[dict[str, str]]) -> None:
+        self._docs = docs
+
+    def __aiter__(self):
+        self._iter = iter(self._docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+@pytest.mark.asyncio
+async def test_cancel_zombie_tasks_cancels_failed_jobs() -> None:
+    async def _hang_forever() -> None:
+        await asyncio.Event().wait()
+
+    task_alive = asyncio.create_task(_hang_forever())
+    task_done = asyncio.create_task(asyncio.sleep(0))
+    await task_done
+
+    running = {
+        task_alive: "job-still-running",
+        task_done: "job-already-done",
+    }
+
+    collection = MagicMock()
+    collection.find.return_value = _FakeCursor(
+        [
+            {"id": "job-still-running", "status": "failed"},
+            {"id": "job-already-done", "status": "failed"},
+        ]
+    )
+    db = MagicMock()
+    db.__getitem__.return_value = collection
+
+    with patch("worker.db_session") as mock_session:
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=None)
+        cancelled = await _cancel_zombie_tasks(running)
+
+    assert cancelled == 1
+    await asyncio.sleep(0)
+    assert task_alive.cancelled() or task_alive.cancelling()
+    task_alive.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task_alive
+
+
+@pytest.mark.asyncio
+async def test_cancel_zombie_tasks_leaves_in_progress_jobs() -> None:
+    async def _hang_forever() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_hang_forever())
+    running = {task: "job-active"}
+
+    collection = MagicMock()
+    collection.find.return_value = _FakeCursor([{"id": "job-active", "status": "synthesising"}])
+    db = MagicMock()
+    db.__getitem__.return_value = collection
+
+    with patch("worker.db_session") as mock_session:
+        mock_session.return_value.__aenter__ = AsyncMock(return_value=db)
+        mock_session.return_value.__aexit__ = AsyncMock(return_value=None)
+        cancelled = await _cancel_zombie_tasks(running)
+
+    assert cancelled == 0
+    assert not task.cancelled()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/packages/backend/tests/unit/worker_zombie_test.py
+++ b/packages/backend/tests/unit/worker_zombie_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,41 +26,71 @@ class _FakeCursor:
             raise StopAsyncIteration from exc
 
 
+class _SlowCursor:
+    """Yields after an await so callers can mutate `running` mid-query."""
+
+    def __init__(self, docs: list[dict[str, str]], on_first_row: asyncio.Event) -> None:
+        self._docs = docs
+        self._on_first_row = on_first_row
+
+    def __aiter__(self):
+        self._iter = iter(self._docs)
+        self._first = True
+        return self
+
+    async def __anext__(self):
+        if self._first:
+            self._first = False
+            self._on_first_row.set()
+            await asyncio.sleep(0)
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+async def _cancel_hanging_task(task: asyncio.Task[None]) -> None:
+    if not task.done():
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
 @pytest.mark.asyncio
 async def test_cancel_zombie_tasks_cancels_failed_jobs() -> None:
     async def _hang_forever() -> None:
         await asyncio.Event().wait()
 
-    task_alive = asyncio.create_task(_hang_forever())
-    task_done = asyncio.create_task(asyncio.sleep(0))
-    await task_done
+    zombie_task = asyncio.create_task(_hang_forever())
+    finished_task = asyncio.create_task(asyncio.sleep(0))
+    await finished_task
 
     running = {
-        task_alive: "job-still-running",
-        task_done: "job-already-done",
+        zombie_task: "job-zombie",
+        finished_task: "job-finished",
     }
 
     collection = MagicMock()
     collection.find.return_value = _FakeCursor(
         [
-            {"id": "job-still-running", "status": "failed"},
-            {"id": "job-already-done", "status": "failed"},
+            {"id": "job-zombie", "status": "failed"},
+            {"id": "job-finished", "status": "failed"},
         ]
     )
     db = MagicMock()
     db.__getitem__.return_value = collection
 
-    with patch("worker.db_session") as mock_session:
-        mock_session.return_value.__aenter__ = AsyncMock(return_value=db)
-        mock_session.return_value.__aexit__ = AsyncMock(return_value=None)
-        cancelled = await _cancel_zombie_tasks(running)
+    try:
+        with patch("worker.db_session") as mock_session:
+            mock_session.return_value.__aenter__ = AsyncMock(return_value=db)
+            mock_session.return_value.__aexit__ = AsyncMock(return_value=None)
+            cancelled = await _cancel_zombie_tasks(running)
 
-    assert cancelled == 1
-    await asyncio.sleep(0)
-    assert task_alive.cancelled() or task_alive.cancelling()
-    task_alive.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task_alive
+        assert cancelled == 1
+        await asyncio.sleep(0)
+        assert zombie_task.cancelled() or zombie_task.cancelling()
+    finally:
+        await _cancel_hanging_task(zombie_task)
 
 
 @pytest.mark.asyncio
@@ -67,21 +98,69 @@ async def test_cancel_zombie_tasks_leaves_in_progress_jobs() -> None:
     async def _hang_forever() -> None:
         await asyncio.Event().wait()
 
-    task = asyncio.create_task(_hang_forever())
-    running = {task: "job-active"}
+    active_task = asyncio.create_task(_hang_forever())
+    running = {active_task: "job-active"}
 
     collection = MagicMock()
     collection.find.return_value = _FakeCursor([{"id": "job-active", "status": "synthesising"}])
     db = MagicMock()
     db.__getitem__.return_value = collection
 
-    with patch("worker.db_session") as mock_session:
-        mock_session.return_value.__aenter__ = AsyncMock(return_value=db)
-        mock_session.return_value.__aexit__ = AsyncMock(return_value=None)
-        cancelled = await _cancel_zombie_tasks(running)
+    try:
+        with patch("worker.db_session") as mock_session:
+            mock_session.return_value.__aenter__ = AsyncMock(return_value=db)
+            mock_session.return_value.__aexit__ = AsyncMock(return_value=None)
+            cancelled = await _cancel_zombie_tasks(running)
 
-    assert cancelled == 0
-    assert not task.cancelled()
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+        assert cancelled == 0
+        assert not active_task.cancelled()
+        assert not active_task.cancelling()
+    finally:
+        await _cancel_hanging_task(active_task)
+
+
+@pytest.mark.asyncio
+async def test_cancel_zombie_tasks_does_not_cancel_tasks_added_during_db_query() -> None:
+    async def _hang_forever() -> None:
+        await asyncio.Event().wait()
+
+    zombie_task = asyncio.create_task(_hang_forever())
+    running = {zombie_task: "job-zombie"}
+    gate = asyncio.Event()
+    new_task: asyncio.Task[None] | None = None
+
+    collection = MagicMock()
+    collection.find.return_value = _SlowCursor(
+        [{"id": "job-zombie", "status": "failed"}],
+        gate,
+    )
+    db = MagicMock()
+    db.__getitem__.return_value = collection
+
+    async def _add_task_mid_query() -> None:
+        nonlocal new_task
+        await gate.wait()
+        new_task = asyncio.create_task(_hang_forever())
+        running[new_task] = "job-new"
+
+    add_task = asyncio.create_task(_add_task_mid_query())
+
+    try:
+        with patch("worker.db_session") as mock_session:
+            mock_session.return_value.__aenter__ = AsyncMock(return_value=db)
+            mock_session.return_value.__aexit__ = AsyncMock(return_value=None)
+            cancelled = await _cancel_zombie_tasks(running)
+
+        await add_task
+        assert new_task is not None
+        assert cancelled == 1
+        assert zombie_task.cancelled() or zombie_task.cancelling()
+        assert not new_task.cancelled()
+        assert not new_task.cancelling()
+    finally:
+        add_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await add_task
+        await _cancel_hanging_task(zombie_task)
+        if new_task is not None:
+            await _cancel_hanging_task(new_task)

--- a/packages/backend/tests/unit/worker_zombie_test.py
+++ b/packages/backend/tests/unit/worker_zombie_test.py
@@ -88,7 +88,7 @@ async def test_cancel_zombie_tasks_cancels_failed_jobs() -> None:
 
         assert cancelled == 1
         await asyncio.sleep(0)
-        assert zombie_task.cancelled() or zombie_task.cancelling()
+        assert zombie_task.cancelled()
     finally:
         await _cancel_hanging_task(zombie_task)
 
@@ -154,9 +154,9 @@ async def test_cancel_zombie_tasks_does_not_cancel_tasks_added_during_db_query()
         await add_task
         assert new_task is not None
         assert cancelled == 1
-        assert zombie_task.cancelled() or zombie_task.cancelling()
+        await asyncio.sleep(0)
+        assert zombie_task.cancelled()
         assert not new_task.cancelled()
-        assert not new_task.cancelling()
     finally:
         add_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -164,3 +164,28 @@ async def test_cancel_zombie_tasks_does_not_cancel_tasks_added_during_db_query()
         await _cancel_hanging_task(zombie_task)
         if new_task is not None:
             await _cancel_hanging_task(new_task)
+
+
+@pytest.mark.asyncio
+async def test_cancel_zombie_tasks_skips_jobs_missing_from_db() -> None:
+    async def _hang_forever() -> None:
+        await asyncio.Event().wait()
+
+    active_task = asyncio.create_task(_hang_forever())
+    running = {active_task: "job-missing-from-db"}
+
+    collection = MagicMock()
+    collection.find.return_value = _FakeCursor([])
+    db = MagicMock()
+    db.__getitem__.return_value = collection
+
+    try:
+        with patch("worker.db_session") as mock_session:
+            mock_session.return_value.__aenter__ = AsyncMock(return_value=db)
+            mock_session.return_value.__aexit__ = AsyncMock(return_value=None)
+            cancelled = await _cancel_zombie_tasks(running)
+
+        assert cancelled == 0
+        assert not active_task.cancelled()
+    finally:
+        await _cancel_hanging_task(active_task)

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -72,7 +72,10 @@ async def _cancel_zombie_tasks(running: dict[asyncio.Task[None], str]) -> int:
     if not running:
         return 0
 
-    job_ids = list(running.values())
+    # Snapshot before the async DB round-trip so tasks claimed while we await
+    # are not accidentally cancelled.
+    snapshot = list(running.items())
+    job_ids = [job_id for _, job_id in snapshot]
     try:
         async with db_session() as db:
             cursor = db[PipelineRepository.COLLECTION].find(
@@ -86,7 +89,7 @@ async def _cancel_zombie_tasks(running: dict[asyncio.Task[None], str]) -> int:
 
     orphanable = set(ORPHANABLE_PIPELINE_STATUSES)
     cancelled = 0
-    for task, job_id in list(running.items()):
+    for task, job_id in snapshot:
         status = statuses.get(job_id)
         if status in orphanable:
             continue

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -21,7 +21,11 @@ from aiohttp import web
 from src.core.database import close_motor_client, db_session
 from src.core.logging import get_logger, setup_logging
 from src.repositories.monitoring_schedule_repository import MonitoringScheduleRepository
-from src.repositories.pipeline_repository import PipelineRepository, StaleReapContext
+from src.repositories.pipeline_repository import (
+    ORPHANABLE_PIPELINE_STATUSES,
+    PipelineRepository,
+    StaleReapContext,
+)
 from src.services.service_factory import create_pipeline_service
 
 logger = get_logger(__name__)
@@ -59,7 +63,49 @@ async def _start_health_server() -> web.AppRunner:
     return runner
 
 
-async def _sweep_stale(repo: PipelineRepository) -> None:
+async def _cancel_zombie_tasks(running: dict[asyncio.Task[None], str]) -> int:
+    """Cancel in-process tasks whose job is no longer in-progress in MongoDB.
+
+    The stale sweep marks wedged jobs as failed in the DB but previously left the
+    matching asyncio tasks running, which blocked concurrency slots until redeploy.
+    """
+    if not running:
+        return 0
+
+    job_ids = list(running.values())
+    try:
+        async with db_session() as db:
+            cursor = db[PipelineRepository.COLLECTION].find(
+                {"id": {"$in": job_ids}},
+                {"id": 1, "status": 1},
+            )
+            statuses = {doc["id"]: doc["status"] async for doc in cursor}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Zombie task check failed (continuing): %s", exc)
+        return 0
+
+    orphanable = set(ORPHANABLE_PIPELINE_STATUSES)
+    cancelled = 0
+    for task, job_id in list(running.items()):
+        status = statuses.get(job_id)
+        if status in orphanable:
+            continue
+        if task.done():
+            continue
+        task.cancel()
+        cancelled += 1
+        logger.warning(
+            "Cancelled zombie task for job %s (db status=%s)",
+            job_id,
+            status or "missing",
+        )
+    return cancelled
+
+
+async def _sweep_stale(
+    repo: PipelineRepository,
+    running: dict[asyncio.Task[None], str] | None = None,
+) -> None:
     """Self-heal the queue (boot + periodic): re-queue interrupted/failed jobs, then
     reap crash-orphaned in-progress jobs — retries are unlimited.
 
@@ -81,6 +127,10 @@ async def _sweep_stale(repo: PipelineRepository) -> None:
             logger.info("Reaped %d stale job(s) as failed", reaped)
         if requeued:
             logger.info("Re-queued %d failed job(s) for retry", requeued)
+        if running is not None:
+            zombies = await _cancel_zombie_tasks(running)
+            if zombies:
+                logger.info("Cancelled %d zombie in-process task(s)", zombies)
     except Exception as exc:  # noqa: BLE001 - the queue self-heal must not kill the worker
         logger.error("Stale sweep failed (continuing): %s", exc, exc_info=True)
 
@@ -202,7 +252,7 @@ async def _run_worker_loop(
 
     while not stop.is_set():
         if loop.time() - last_sweep >= _STALE_SWEEP_SECONDS:
-            await _sweep_stale(repo)
+            await _sweep_stale(repo, running)
             last_sweep = loop.time()
 
         if loop.time() - last_monitoring_sweep >= _MONITORING_SWEEP_SECONDS:
@@ -210,6 +260,8 @@ async def _run_worker_loop(
             last_monitoring_sweep = loop.time()
 
         if len(running) >= _CONCURRENCY:
+            # Stale sweep may have failed jobs in DB while asyncio tasks still hold slots.
+            await _cancel_zombie_tasks(running)
             await _sleep_or_stop(stop, _POLL_SECONDS)
             continue
 

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -91,6 +91,9 @@ async def _cancel_zombie_tasks(running: dict[asyncio.Task[None], str]) -> int:
     cancelled = 0
     for task, job_id in snapshot:
         status = statuses.get(job_id)
+        if status is None:
+            # Job absent from query (replication lag, etc.) — don't kill on missing data.
+            continue
         if status in orphanable:
             continue
         if task.done():


### PR DESCRIPTION
## Summary
- Add `_cancel_zombie_tasks()` to cancel in-process asyncio tasks when MongoDB no longer shows the job as in-progress (`crawling` / `synthesising` / `generating_overview`)
- Run zombie cleanup after each stale sweep and when concurrency slots are full, so wedged workers self-heal without manual redeploy
- Export `ORPHANABLE_PIPELINE_STATUSES` from the pipeline repository for shared use
- Add unit tests for zombie cancellation behavior

## Problem
The stale sweep marks jobs `failed` in the DB, but the worker kept the matching asyncio tasks alive. All concurrency slots stayed occupied and the worker stopped claiming new jobs until redeploy.

## Test plan
- [x] `uv run pytest tests/unit/worker_zombie_test.py tests/unit/worker_health_test.py`
- [x] `uv run ruff check worker.py src/repositories/pipeline_repository.py tests/unit/worker_zombie_test.py`
- [ ] Merge and verify crawler worker resumes claiming jobs after a stale reap without redeploy