### PR TITLE
fix(aggregations): cap stored evidence to reduce MongoDB bloat

### DIFF
--- a/packages/backend/scripts/cleanup_aggregations.py
+++ b/packages/backend/scripts/cleanup_aggregations.py
@@ -1,0 +1,92 @@
+"""One-time cleanup: remove orphan aggregations and slim stored evidence.
+
+Aggregations duplicate evidence already stored on findings. The topics API only
+needs up to TOPIC_CITATION_LIMIT spans per finding, but legacy rows kept every
+merged span (~800 KB each).
+
+Operations (idempotent):
+1. Delete aggregations for products whose pipeline job is not ``completed``.
+2. Cap ``findings[].evidence`` and ``conflicts[].evidence`` to TOPIC_CITATION_LIMIT.
+
+Usage:
+    uv run python scripts/cleanup_aggregations.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+async def run_cleanup() -> None:
+    import certifi
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    from src.core.config import config
+    from src.models.finding import Aggregation
+    from src.repositories.aggregation_repository import AggregationRepository
+    from src.repositories.document_repository import DocumentRepository
+    from src.repositories.finding_repository import FindingRepository
+    from src.services.aggregation_service import AggregationService
+
+    uri = config.database.mongodb_uri
+    if not uri:
+        print("MONGO_URI is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    if "+srv" in uri:
+        client = AsyncIOMotorClient(uri, tls=True, tlsCAFile=certifi.where())
+    else:
+        client = AsyncIOMotorClient(uri)
+
+    db = client[config.database.mongodb_database]
+
+    stats_before = await db.command("collStats", "aggregations")
+    count_before = stats_before.get("count", 0)
+    size_before_mb = stats_before.get("size", 0) / 1024 / 1024
+
+    completed_ids: set[str] = set()
+    async for job in db.pipeline_jobs.find({"status": "completed"}, {"product_id": 1}):
+        pid = job.get("product_id")
+        if pid:
+            completed_ids.add(pid)
+
+    orphan_result = await db.aggregations.delete_many({"product_id": {"$nin": list(completed_ids)}})
+    print(f"Deleted {orphan_result.deleted_count} orphan aggregation(s)")
+
+    service = AggregationService(
+        DocumentRepository(),
+        FindingRepository(),
+        AggregationRepository(),
+    )
+
+    slimmed = 0
+    async for raw in db.aggregations.find({}):
+        aggregation = Aggregation(**raw)
+        slim = service._slim_aggregation_for_storage(aggregation)
+        if slim.model_dump() != aggregation.model_dump():
+            await db.aggregations.replace_one(
+                {"product_id": aggregation.product_id}, slim.model_dump()
+            )
+            slimmed += 1
+
+    stats_after = await db.command("collStats", "aggregations")
+    count_after = stats_after.get("count", 0)
+    size_after_mb = stats_after.get("size", 0) / 1024 / 1024
+    storage_after_mb = stats_after.get("storageSize", 0) / 1024 / 1024
+
+    print(
+        f"Aggregations: {count_before} -> {count_after} docs, "
+        f"data {size_before_mb:.1f} MB -> {size_after_mb:.1f} MB, "
+        f"storage {storage_after_mb:.1f} MB"
+    )
+    print(f"Slimmed evidence on {slimmed} aggregation(s)")
+    client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_cleanup())

--- a/packages/backend/src/services/aggregation_service.py
+++ b/packages/backend/src/services/aggregation_service.py
@@ -18,7 +18,7 @@ from src.models.finding import AggregatedFinding, Aggregation, Finding, FindingC
 from src.repositories.aggregation_repository import AggregationRepository
 from src.repositories.document_repository import DocumentRepository
 from src.repositories.finding_repository import FindingRepository
-from src.services.evidence_relevance import filter_evidence_spans
+from src.services.evidence_relevance import filter_evidence_spans, select_topic_citations
 from src.services.extraction_service import extract_document_facts
 from src.utils.standard_terms import should_exclude_from_dangers
 
@@ -745,6 +745,36 @@ class AggregationService:
             items.append(CoverageItem(category=category, status=status))
         return items
 
+    def _slim_aggregation_for_storage(self, aggregation: Aggregation) -> Aggregation:
+        """Cap stored evidence to topic citation limits — findings already hold full evidence."""
+        slim_findings = [
+            finding.model_copy(
+                update={
+                    "evidence": select_topic_citations(
+                        finding.evidence,
+                        category=finding.category,
+                        finding_value=finding.value,
+                    )
+                }
+            )
+            for finding in aggregation.findings
+        ]
+        slim_conflicts = [
+            conflict.model_copy(
+                update={
+                    "evidence": select_topic_citations(
+                        conflict.evidence,
+                        category=conflict.category,
+                        finding_value=conflict.description,
+                    )
+                }
+            )
+            for conflict in aggregation.conflicts
+        ]
+        return aggregation.model_copy(
+            update={"findings": slim_findings, "conflicts": slim_conflicts}
+        )
+
     async def build_product_aggregation(
         self, db: AgnosticDatabase, product_id: str, product_slug: str
     ) -> Aggregation:
@@ -766,6 +796,7 @@ class AggregationService:
             conflicts=conflicts,
             coverage=coverage,
         )
+        aggregation = self._slim_aggregation_for_storage(aggregation)
         await self._aggregation_repo.save(db, aggregation)
         if coverage:
             status_counts: dict[str, int] = {}

--- a/packages/backend/tests/unit/aggregation_service_test.py
+++ b/packages/backend/tests/unit/aggregation_service_test.py
@@ -81,6 +81,43 @@ def test_aggregation_fixture_shape() -> None:
     assert isinstance(payload["findings"], list)
 
 
+def test_slim_aggregation_for_storage_caps_evidence() -> None:
+    from src.models.document import EvidenceSpan
+    from src.models.finding import AggregatedFinding, Aggregation, FindingConflict
+    from src.services.evidence_relevance import TOPIC_CITATION_LIMIT
+
+    service = _service()
+    spans = [
+        EvidenceSpan(
+            document_id="d1", url="https://example.com/privacy", quote=f"quote {idx}", verified=True
+        )
+        for idx in range(TOPIC_CITATION_LIMIT + 3)
+    ]
+    aggregation = Aggregation(
+        product_id="p1",
+        product_slug="example",
+        findings=[
+            AggregatedFinding(
+                category="data_collection",
+                value="Email",
+                documents=["d1"],
+                evidence=spans,
+            )
+        ],
+        conflicts=[
+            FindingConflict(
+                category="data_sale",
+                description="Conflict",
+                evidence=spans,
+            )
+        ],
+    )
+
+    slim = service._slim_aggregation_for_storage(aggregation)
+    assert len(slim.findings[0].evidence) == TOPIC_CITATION_LIMIT
+    assert len(slim.conflicts[0].evidence) == TOPIC_CITATION_LIMIT
+
+
 # ── _findings_from_retention_rules ──────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Cap `findings[].evidence` and `conflicts[].evidence` to `TOPIC_CITATION_LIMIT` (5) before persisting aggregations — full evidence remains in `findings`
- Add `scripts/cleanup_aggregations.py` to delete orphan aggregations and slim existing rows
- Ran cleanup on production: **45 orphans deleted**, aggregations collection **82 MB → 44 MB**, total DB data **451 MB → 413 MB**

## Why
Aggregations are still required for `/products/{slug}/topics`, but storing every merged evidence span was redundant and consumed ~28 MB of wasted storage.

## Test plan
- [x] `uv run pytest tests/unit/aggregation_service_test.py::test_slim_aggregation_for_storage_caps_evidence`
- [x] Production cleanup executed successfully
- [ ] Verify topics API still returns citations for a completed product after deploy