### PR TITLE
chore(frontend): align hero and OG copy with page title

### DIFF
--- a/packages/frontend/app/og/route.tsx
+++ b/packages/frontend/app/og/route.tsx
@@ -366,7 +366,7 @@ export async function GET(request: NextRequest) {
       >
         <div
           style={{
-            fontSize: 114,
+            fontSize: 96,
             fontWeight: 700,
             color: "#faf9f6",
             lineHeight: 0.88,
@@ -374,11 +374,11 @@ export async function GET(request: NextRequest) {
             fontFamily,
           }}
         >
-          Automated
+          Privacy Policies
         </div>
         <div
           style={{
-            fontSize: 114,
+            fontSize: 96,
             fontWeight: 700,
             color: "#faf9f6",
             lineHeight: 0.88,
@@ -387,7 +387,7 @@ export async function GET(request: NextRequest) {
             fontFamily,
           }}
         >
-          Legal Analysis.
+          & Terms, Made Easy.
         </div>
         <div
           style={{

--- a/packages/frontend/components/clausea/Hero.tsx
+++ b/packages/frontend/components/clausea/Hero.tsx
@@ -36,9 +36,8 @@ export default function Hero({
         transition={{ duration: 0.8, delay: 0.1, ease: "easeOut" }}
         className="font-display text-5xl sm:text-6xl md:text-[140px] leading-[0.85] font-medium tracking-tight md:-ml-1.5 text-foreground"
       >
-        Automated
-        <br />
-        Legal Analysis.
+        Privacy Policies
+        <br />& Terms, Made Easy.
       </motion.h1>
       <motion.div
         initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
## What this PR does

Updates the homepage hero and dynamically generated OG image headline from "Automated Legal Analysis" to "Privacy Policies & Terms, Made Easy" so on-site messaging matches the page title and social preview metadata.

## Why

"Automated Legal Analysis" overstates Clausea's scope — the product focuses on privacy policies, terms of service, and related policy documents, not general legal work. The metadata title already used the more accurate tagline; this change closes the gap between what users see on the site, what link previews show, and what the product actually does.

## How to test

- [ ] Open the homepage and confirm the hero reads "Privacy Policies / & Terms, Made Easy."
- [ ] Visit `/og` locally (or on preview) and confirm the OG image uses the same headline at a readable size.
- [ ] Share a preview URL in Slack/Twitter debugger and confirm the card title still shows "Clausea AI - Privacy Policies & Terms, Made Easy" with the updated image.
- [ ] Check mobile viewport — longer headline should still wrap cleanly without overflow.