### PR TITLE
fix(pipeline): access_denied for SPA blocks + PDF policy crawl support

### DIFF
--- a/packages/backend/scripts/post_refactor_maintenance.py
+++ b/packages/backend/scripts/post_refactor_maintenance.py
@@ -1,0 +1,376 @@
+"""One-shot production maintenance after product_intelligence refactor.
+
+1. Drop legacy MongoDB collections (data already in product_intelligence).
+2. Unstick the pipeline queue (defer poison jobs, reset quarantined failures).
+3. Backfill product_intelligence for products that missed the migration.
+
+Usage:
+    uv run python scripts/post_refactor_maintenance.py --use-production
+    uv run python scripts/post_refactor_maintenance.py --use-production --skip-backfill
+    uv run python scripts/post_refactor_maintenance.py --use-production --only-backfill
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import time
+from datetime import UTC, datetime
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+LEGACY_COLLECTIONS = (
+    "findings",
+    "aggregations",
+    "product_overviews",
+    "document_versions",
+    "product_overview_history",
+    "product_compliance",
+    "product_explainers",
+    "deep_analyses",
+)
+
+FRESH_STEPS = [
+    {
+        "name": name,
+        "status": "pending",
+        "message": None,
+        "progress_current": None,
+        "progress_total": None,
+        "progress_percent": None,
+        "started_at": None,
+        "completed_at": None,
+    }
+    for name in ("crawling", "synthesising", "generating_overview")
+]
+
+HIGH_ATTEMPT_DEFER_THRESHOLD = 10
+NON_RETRYABLE_ERRORS = frozenset(
+    {
+        "product_not_found",
+        "crawl_robots_blocked",
+        "no_documents_found",
+        "domain_circuit_breaker",
+    }
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Post-refactor production maintenance")
+    parser.add_argument(
+        "--use-production",
+        action="store_true",
+        help="Use PRODUCTION_MONGO_URI instead of MONGO_URI",
+    )
+    parser.add_argument(
+        "--skip-backfill",
+        action="store_true",
+        help="Only drop legacy collections and reset pipeline",
+    )
+    parser.add_argument(
+        "--only-backfill",
+        action="store_true",
+        help="Only run intelligence backfill (skip drop + pipeline reset)",
+    )
+    parser.add_argument(
+        "--skip-overview",
+        action="store_true",
+        help="Backfill rollups only; skip LLM overview generation",
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="SLUG",
+        help="Skip these product slugs during backfill (repeatable)",
+    )
+    parser.add_argument(
+        "slugs",
+        nargs="*",
+        help="Optional explicit slugs to backfill (default: auto-detect missing intelligence)",
+    )
+    return parser.parse_args()
+
+
+async def _drop_legacy_collections(db) -> list[str]:
+    dropped: list[str] = []
+    existing = set(await db.list_collection_names())
+    for name in LEGACY_COLLECTIONS:
+        if name not in existing:
+            print(f"[drop] skip {name} (not present)")
+            continue
+        count = await db[name].count_documents({})
+        await db[name].drop()
+        dropped.append(f"{name} ({count} docs)")
+        print(f"[drop] {name}: removed {count} documents")
+    return dropped
+
+
+async def _unstick_pipeline(db) -> dict[str, int]:
+    now = datetime.now()
+    stats: dict[str, int] = {}
+
+    in_progress = ["crawling", "synthesising", "generating_overview"]
+    high_attempt = await db.pipeline_jobs.find(
+        {"status": {"$in": in_progress}, "attempts": {"$gte": HIGH_ATTEMPT_DEFER_THRESHOLD}},
+        {"product_slug": 1, "attempts": 1},
+    ).to_list(length=100)
+    if high_attempt:
+        slugs = [j["product_slug"] for j in high_attempt]
+        result = await db.pipeline_jobs.update_many(
+            {"product_slug": {"$in": slugs}, "status": {"$in": in_progress}},
+            {
+                "$set": {
+                    "status": "failed",
+                    "active": False,
+                    "error": "deferred",
+                    "error_detail": (
+                        f"Deferred during maintenance: {HIGH_ATTEMPT_DEFER_THRESHOLD}+ attempts "
+                        "without completion. Re-trigger manually when ready."
+                    ),
+                    "auto_retry_disabled": True,
+                    "auto_retry_disabled_reason": "maintenance: high-attempt defer",
+                    "completed_at": now,
+                    "updated_at": now,
+                }
+            },
+        )
+        stats["deferred_high_attempt"] = result.modified_count
+        print(
+            f"[pipeline] deferred {result.modified_count} high-attempt in-progress job(s): {slugs}"
+        )
+
+    reset_in_progress = await db.pipeline_jobs.update_many(
+        {"status": {"$in": in_progress}, "active": True},
+        {
+            "$set": {
+                "status": "failed",
+                "active": False,
+                "error": "interrupted",
+                "error_detail": "Reset during post-refactor maintenance for a clean retry.",
+                "auto_retry_disabled": False,
+                "auto_retry_disabled_reason": None,
+                "completed_at": now,
+                "updated_at": now,
+            }
+        },
+    )
+    stats["failed_in_progress"] = reset_in_progress.modified_count
+    if reset_in_progress.modified_count:
+        print(
+            f"[pipeline] marked {reset_in_progress.modified_count} remaining in-progress job(s) failed"
+        )
+
+    reset_failed = await db.pipeline_jobs.update_many(
+        {
+            "status": "failed",
+            "auto_retry_disabled": True,
+            "error": {"$nin": list(NON_RETRYABLE_ERRORS) + ["deferred"]},
+            "auto_retry_disabled_reason": {"$ne": "maintenance: high-attempt defer"},
+        },
+        {
+            "$set": {
+                "status": "pending",
+                "active": True,
+                "steps": FRESH_STEPS,
+                "error": None,
+                "error_detail": None,
+                "attempts": 0,
+                "auto_retry_disabled": False,
+                "auto_retry_disabled_reason": None,
+                "force_reanalyze": False,
+                "started_at": None,
+                "completed_at": None,
+                "last_heartbeat": None,
+                "documents_found": 0,
+                "documents_stored": 0,
+                "crawl_errors": [],
+                "crawl_skip_reasons": [],
+                "updated_at": now,
+            }
+        },
+    )
+    stats["reset_quarantined"] = reset_failed.modified_count
+    if reset_failed.modified_count:
+        print(
+            f"[pipeline] reset {reset_failed.modified_count} quarantined failed job(s) to pending"
+        )
+
+    retryable_failed = await db.pipeline_jobs.update_many(
+        {
+            "status": "failed",
+            "active": False,
+            "auto_retry_disabled": {"$ne": True},
+            "error": {"$nin": list(NON_RETRYABLE_ERRORS)},
+        },
+        {
+            "$set": {
+                "status": "pending",
+                "active": True,
+                "steps": FRESH_STEPS,
+                "error": None,
+                "error_detail": None,
+                "attempts": 0,
+                "started_at": None,
+                "completed_at": None,
+                "last_heartbeat": None,
+                "documents_found": 0,
+                "documents_stored": 0,
+                "crawl_errors": [],
+                "crawl_skip_reasons": [],
+                "updated_at": now,
+            }
+        },
+    )
+    stats["requeued_failed"] = retryable_failed.modified_count
+    if retryable_failed.modified_count:
+        print(f"[pipeline] requeued {retryable_failed.modified_count} retryable failed job(s)")
+
+    from src.repositories.pipeline_repository import PipelineRepository
+
+    requeued = await PipelineRepository().requeue_failed_jobs(db)
+    stats["requeue_via_repo"] = requeued
+    if requeued:
+        print(f"[pipeline] repository requeue_failed_jobs: {requeued}")
+
+    return stats
+
+
+async def _products_needing_backfill(db) -> list[str]:
+    with_docs = set(await db.documents.distinct("product_id"))
+    intel_ids = set(await db.product_intelligence.distinct("product_id"))
+    missing_shell: list[str] = []
+    for pid in sorted(with_docs - intel_ids):
+        row = await db.products.find_one({"id": pid}, {"slug": 1})
+        if row and row.get("slug"):
+            missing_shell.append(row["slug"])
+
+    no_overview: list[str] = []
+    async for row in db.product_intelligence.find(
+        {"$or": [{"overview": {"$exists": False}}, {"overview": None}]},
+        {"product_id": 1, "product_slug": 1},
+    ):
+        if row["product_id"] in with_docs:
+            no_overview.append(row["product_slug"])
+
+    return sorted(set(missing_shell + no_overview))
+
+
+async def _backfill_slugs(db, slugs: list[str], *, skip_overview: bool) -> None:
+    from src.analyser import analyse_product_documents, generate_product_overview
+    from src.repositories.document_repository import DocumentRepository
+    from src.services.product_rollup_service import ProductRollupService
+    from src.services.service_factory import create_document_service, create_product_service
+
+    product_svc = create_product_service()
+    doc_svc = create_document_service()
+    rollup_svc = ProductRollupService(document_repo=DocumentRepository())
+
+    succeeded: list[str] = []
+    failed: list[str] = []
+
+    for slug in slugs:
+        product = await product_svc.get_product_by_slug(db, slug)
+        if not product:
+            print(f"[backfill] skip {slug}: product not found")
+            failed.append(slug)
+            continue
+        print(f"[backfill] start {slug}")
+        t0 = time.perf_counter()
+        try:
+            rollup = await rollup_svc.build_product_rollup(
+                db, product_id=product.id, product_slug=slug
+            )
+            print(
+                f"  rollup: findings={len(rollup.findings)} conflicts={len(rollup.conflicts)} "
+                f"coverage={len(rollup.coverage or [])}"
+            )
+            if not skip_overview:
+                await analyse_product_documents(db, slug, doc_svc)
+                overview = await generate_product_overview(
+                    db,
+                    slug,
+                    force_regenerate=True,
+                    product_svc=product_svc,
+                    document_svc=doc_svc,
+                )
+                print(
+                    f"  overview: risk={overview.risk_score} verdict={overview.verdict} "
+                    f"stances={len(overview.topic_stances or [])}"
+                )
+            print(f"[backfill] done {slug} in {time.perf_counter() - t0:.1f}s")
+            succeeded.append(slug)
+        except Exception as exc:  # noqa: BLE001 - continue batch on single-product failure
+            print(f"[backfill] FAILED {slug}: {exc}")
+            failed.append(slug)
+
+    print(f"[backfill] complete: {len(succeeded)} ok, {len(failed)} failed")
+    if failed:
+        print("  failed: " + ", ".join(failed))
+
+
+async def _print_queue_summary(db) -> None:
+    by_status: dict[str, int] = {}
+    async for row in db.pipeline_jobs.aggregate([{"$group": {"_id": "$status", "n": {"$sum": 1}}}]):
+        by_status[row["_id"]] = row["n"]
+    overviews = await db.product_intelligence.count_documents(
+        {"overview": {"$exists": True, "$ne": None}}
+    )
+    intel_total = await db.product_intelligence.count_documents({})
+    print(
+        f"[summary] pipeline={sum(by_status.values())} {by_status} "
+        f"intelligence={intel_total} with_overview={overviews}"
+    )
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if args.use_production:
+        uri = os.getenv("PRODUCTION_MONGO_URI")
+        if not uri:
+            print("PRODUCTION_MONGO_URI is not set")
+            return 1
+        os.environ["MONGO_URI"] = uri
+
+    from src.core.database import db_session
+    from src.core.logging import setup_logging
+
+    setup_logging()
+    print(f"=== post-refactor maintenance {datetime.now(UTC).isoformat()} ===")
+
+    async with db_session() as db:
+        if not args.only_backfill:
+            print("\n--- drop legacy collections ---")
+            await _drop_legacy_collections(db)
+
+            print("\n--- unstick pipeline ---")
+            await _unstick_pipeline(db)
+
+        if not args.skip_backfill:
+            exclude = set(args.exclude or [])
+            slugs = list(args.slugs) if args.slugs else await _products_needing_backfill(db)
+            slugs = [s for s in slugs if s not in exclude]
+            print(f"\n--- backfill {len(slugs)} product(s) ---")
+            if exclude:
+                print(f"  excluded: {', '.join(sorted(exclude))}")
+            if slugs:
+                print("  " + ", ".join(slugs))
+                await _backfill_slugs(db, slugs, skip_overview=args.skip_overview)
+            else:
+                print("[backfill] nothing to do")
+
+        print("\n--- final state ---")
+        await _print_queue_summary(db)
+
+    return 0
+
+
+def main() -> None:
+    args = _parse_args()
+    raise SystemExit(asyncio.run(_run(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/backend/scripts/post_refactor_maintenance.py
+++ b/packages/backend/scripts/post_refactor_maintenance.py
@@ -114,14 +114,14 @@ async def _unstick_pipeline(db) -> dict[str, int]:
     stats: dict[str, int] = {}
 
     in_progress = ["crawling", "synthesising", "generating_overview"]
-    high_attempt = await db.pipeline_jobs.find(
-        {"status": {"$in": in_progress}, "attempts": {"$gte": HIGH_ATTEMPT_DEFER_THRESHOLD}},
-        {"product_slug": 1, "attempts": 1},
-    ).to_list(length=100)
-    if high_attempt:
-        slugs = [j["product_slug"] for j in high_attempt]
+    high_attempt_filter = {
+        "status": {"$in": in_progress},
+        "attempts": {"$gte": HIGH_ATTEMPT_DEFER_THRESHOLD},
+    }
+    deferred_slugs = await db.pipeline_jobs.distinct("product_slug", high_attempt_filter)
+    if deferred_slugs:
         result = await db.pipeline_jobs.update_many(
-            {"product_slug": {"$in": slugs}, "status": {"$in": in_progress}},
+            high_attempt_filter,
             {
                 "$set": {
                     "status": "failed",
@@ -140,7 +140,8 @@ async def _unstick_pipeline(db) -> dict[str, int]:
         )
         stats["deferred_high_attempt"] = result.modified_count
         print(
-            f"[pipeline] deferred {result.modified_count} high-attempt in-progress job(s): {slugs}"
+            f"[pipeline] deferred {result.modified_count} high-attempt in-progress job(s): "
+            f"{sorted(deferred_slugs)}"
         )
 
     reset_in_progress = await db.pipeline_jobs.update_many(
@@ -242,11 +243,12 @@ async def _unstick_pipeline(db) -> dict[str, int]:
 async def _products_needing_backfill(db) -> list[str]:
     with_docs = set(await db.documents.distinct("product_id"))
     intel_ids = set(await db.product_intelligence.distinct("product_id"))
+    missing_ids = sorted(with_docs - intel_ids)
     missing_shell: list[str] = []
-    for pid in sorted(with_docs - intel_ids):
-        row = await db.products.find_one({"id": pid}, {"slug": 1})
-        if row and row.get("slug"):
-            missing_shell.append(row["slug"])
+    if missing_ids:
+        async for row in db.products.find({"id": {"$in": missing_ids}}, {"slug": 1}):
+            if row.get("slug"):
+                missing_shell.append(row["slug"])
 
     no_overview: list[str] = []
     async for row in db.product_intelligence.find(

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -149,6 +149,15 @@ def needs_browser_fallback(raw: StaticFetchResult) -> bool:
     return len(soup.get_text(" ", strip=True)) < MIN_CONTENT_LENGTH_FOR_SPA_CHECK
 
 
+def _is_pdf_response(content_type: str, url: str) -> bool:
+    """True when a response should be parsed as PDF (not other application/* blobs)."""
+    ct = (content_type or "").split(";")[0].strip().lower()
+    if ct in ("application/pdf", "application/x-pdf"):
+        return True
+    path = urlparse(url).path.lower()
+    return path.endswith(".pdf") and ct in ("application/octet-stream", "binary/octet-stream")
+
+
 # ---- ClauseaCrawler ----------------------------------------------------------------
 
 
@@ -182,7 +191,7 @@ class ClauseaCrawler:
         allowed_paths: list[str] | None = None,
         denied_paths: list[str] | None = None,
         delay_jitter: float = 0.0,
-        enable_binary_crawling: bool = False,
+        enable_pdf_crawling: bool = False,
         use_tika_for_binaries: bool = False,
         use_pdfminer_for_pdf: bool = False,
         progress_callback: Callable[[int, int], None] | None = None,
@@ -214,7 +223,7 @@ class ClauseaCrawler:
         self.allowed_paths = allowed_paths
         self.denied_paths = denied_paths
 
-        self.enable_binary_crawling = enable_binary_crawling
+        self.enable_pdf_crawling = enable_pdf_crawling
         self.use_tika_for_binaries = use_tika_for_binaries
         self.use_pdfminer_for_pdf = use_pdfminer_for_pdf
 
@@ -279,7 +288,7 @@ class ClauseaCrawler:
         binary_exclusions = "jpg|jpeg|png|gif|css|js|ico"
         first_pattern = (
             rf"\.(?:{binary_exclusions})$"
-            if self.enable_binary_crawling
+            if self.enable_pdf_crawling
             else r"\.(?:pdf|jpg|jpeg|png|gif|css|js|ico)$"
         )
         self.compiled_skip_patterns = [
@@ -576,7 +585,7 @@ class ClauseaCrawler:
             )
         )
         if not is_text_type:
-            return await self._extract_binary_content(raw, url)
+            return await self._extract_pdf_content(raw, url)
 
         if "markdown" in ct:
             return await asyncio.to_thread(self._extract_markdown_content, raw, url)
@@ -740,12 +749,10 @@ class ClauseaCrawler:
             status_code=raw.status_code,
         )
 
-    async def _extract_binary_content(self, raw: StaticFetchResult, url: str) -> PageContent | None:
-        if not self.enable_binary_crawling:
+    async def _extract_pdf_content(self, raw: StaticFetchResult, url: str) -> PageContent | None:
+        if not self.enable_pdf_crawling:
             return None
-        if "application/pdf" not in raw.content_type and not raw.content_type.startswith(
-            "application/"
-        ):
+        if not _is_pdf_response(raw.content_type, url):
             return None
         if not raw.raw_bytes:
             return None
@@ -758,8 +765,9 @@ class ClauseaCrawler:
             prefer_tika=self.use_tika_for_binaries,
             prefer_pdfminer=self.use_pdfminer_for_pdf,
         )
-        filename = urlparse(url).path.split("/")[-1] or "document"
-        text_content = await processor._extract_text(raw.raw_bytes, filename, raw.content_type)
+        filename = urlparse(url).path.split("/")[-1] or "document.pdf"
+        content_type = "application/pdf"
+        text_content = await processor._extract_text(raw.raw_bytes, filename, content_type)
 
         if not text_content:
             return None

--- a/packages/backend/src/models/pipeline_job.py
+++ b/packages/backend/src/models/pipeline_job.py
@@ -105,6 +105,8 @@ _BOT_DETECTION_KEYWORDS: frozenset[str] = frozenset(
         "security check",
         "ddos protection",
         "anti-bot",
+        "browser rendering failed",
+        "static content unusable",
     }
 )
 

--- a/packages/backend/src/pipeline/pipeline.py
+++ b/packages/backend/src/pipeline/pipeline.py
@@ -300,6 +300,7 @@ class PolicyDocumentPipeline:
             result_callback=result_callback,
             stop_callback=stop_callback,
             recently_stored_urls=recently_stored_urls,
+            enable_pdf_crawling=True,
         )
 
     async def _store_documents(self, documents: list[Document]) -> int:

--- a/packages/backend/tests/unit/crawler/binary_parsing_test.py
+++ b/packages/backend/tests/unit/crawler/binary_parsing_test.py
@@ -44,9 +44,9 @@ async def test_document_processor_pdf_fallbacks_are_invoked():
 
 
 @pytest.mark.asyncio
-async def test_crawler_respects_enable_binary_crawling_flag(monkeypatch):
-    # Create a crawler that enables binary crawling and disables robots.txt checking
-    crawler = ClauseaCrawler(enable_binary_crawling=True, respect_robots_txt=False)
+async def test_crawler_respects_enable_pdf_crawling_flag(monkeypatch):
+    # PDF crawling enabled: fetch and extract policy PDFs (e.g. CDN-hosted legal docs).
+    crawler = ClauseaCrawler(enable_pdf_crawling=True, respect_robots_txt=False)
 
     # Mock an aiohttp response via a lightweight fake
     class FakeResponse:
@@ -90,3 +90,43 @@ async def test_crawler_respects_enable_binary_crawling_flag(monkeypatch):
     assert res.success is True
     assert "legal pdf content" in res.content
     assert res.metadata.get("content-type") == "application/pdf"
+
+
+@pytest.mark.asyncio
+async def test_crawler_skips_non_pdf_application_types_when_pdf_crawling_enabled(monkeypatch):
+    crawler = ClauseaCrawler(enable_pdf_crawling=True, respect_robots_txt=False)
+
+    class FakeResponse:
+        def __init__(self, status, headers, content_bytes, url: str = ""):
+            self.status = status
+            self.headers = headers
+            self._content = content_bytes
+            self.url = url
+            self.charset = None
+            self.content = _FakeContent(content_bytes)
+
+        async def read(self):
+            return self._content
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    class FakeSession:
+        def get(self, url, **kwargs):
+            return FakeResponse(
+                200,
+                {"content-type": "application/json"},
+                b'{"not": "a policy"}',
+                url=url,
+            )
+
+    session = FakeSession()
+    res = await crawler._fetch_page_internal(
+        cast(aiohttp.ClientSession, session), "https://cdn.example.com/blob/data"
+    )
+
+    assert res.success is False
+    assert "Unsupported content type" in (res.error_message or "")

--- a/packages/backend/tests/unit/pipeline_domain_circuit_breaker_test.py
+++ b/packages/backend/tests/unit/pipeline_domain_circuit_breaker_test.py
@@ -35,6 +35,13 @@ from src.repositories.pipeline_repository import PipelineRepository
         ("unknown", 0, "Blocked by Cloudflare DDoS protection", True),
         # Hard: "Access Denied" in message
         ("http_error", 403, "Access Denied — automated access not allowed", True),
+        # Hard: SPA returned 200 but browser render could not extract policy text
+        (
+            "unknown",
+            200,
+            "Static content unusable and browser rendering failed",
+            True,
+        ),
         # Transient: network timeout
         ("timeout", 0, "Request timed out after 30s", False),
         # Transient: network/DNS error


### PR DESCRIPTION
## What this PR delivers

Two pipeline/crawler improvements:

1. **SPA / bot-wall classification** — Crawl failures with “browser rendering failed” or “static content unusable” now terminate as `access_denied` instead of misleading `no_documents`.
2. **PDF-only crawl parsing** — When a policy crawl hits a PDF (seed URL or link from HTML), extract text via pdfplumber. Supports CDN PDFs (`application/pdf` and `application/octet-stream` with `.pdf` path). Does **not** parse other `application/*` blobs.

Also adds `scripts/post_refactor_maintenance.py` for one-shot ops (legacy collection drop, queue unstick, intelligence backfill).

## Why this matters

**Operators:** Bot-blocked sites (Duolingo, OpenAI HTML, etc.) get the correct terminal status and UI copy. PDFs hosted on CDNs (e.g. legal docs behind HTML walls) can be ingested when linked or seeded — without crawling random CDN JSON/assets.

**Maintainers:** Hard-failure classification aligns with #180’s `access_denied` path. PDF support is narrowly scoped (`enable_pdf_crawling`), not full binary crawl.

## How pipeline / crawler behaviour changes

| Path | Change |
|------|--------|
| 0 docs stored, all errors are render/static-content failures | **`access_denied`** (was `no_documents` + `crawl_failed`) |
| Crawl hits `application/pdf` or `.pdf` octet-stream | **Extracted and stored** when `enable_pdf_crawling=True` (on in pipeline) |
| Crawl hits `application/json`, docx, zip, etc. | **Unchanged** — still skipped |
| PDF document | **No link discovery** — one URL = one doc unless explicitly seeded again |
| OpenAI | **No product-specific seeds** in this PR |

## UX changes operators will notice

- Fewer false `no_documents` on bot-blocked products; more accurate `access_denied`.
- Products that link to PDF policies may gain documents without HTML access.

## Tests

- `pipeline_domain_circuit_breaker_test.py` — SPA render failure counts as hard error
- `binary_parsing_test.py` — PDF extract works; JSON blobs rejected
- Pre-commit: ruff, ty, backend tests pass

### Edge cases to verify in staging

1. Duolingo-style SPA (200 + render fail) → `access_denied`
2. Seed a known CDN PDF URL on any product → one policy doc stored, no CDN walk
3. `post_refactor_maintenance.py --only-backfill --exclude coinbase` on a missing-intelligence slug

## Notes for reviewers

- PDF crawling is **global in pipeline** but **PDF-only** — not a CDN blob harvester.
- Deploy crawler to pick up both classification fix and PDF parsing.