### PR TITLE
Fix Pro users receiving 429 on product report pages

### DIFF
--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -202,7 +202,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return None
 
         try:
-            token = auth_header.split(" ")[1]
+            token = auth_header.removeprefix("Bearer ").strip()
+            if not token:
+                return None
+
             payload: dict[str, Any] = await clerk_auth_service.verify_token(token)
             user_id = payload.get("sub") or payload.get("id")
             if not user_id:

--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -216,9 +216,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 "email": payload.get("email"),
                 "name": payload.get("name"),
             }
-            self.logger.info(
+            self.logger.debug(
                 "Optional JWT authentication on public product route",
-                email=user_info.get("email"),
                 user_id=user_info.get("user_id"),
                 path=request.url.path,
             )

--- a/packages/backend/src/core/middleware.py
+++ b/packages/backend/src/core/middleware.py
@@ -67,6 +67,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         # Skip authentication for whitelisted routes
         if self._is_whitelisted(request):
+            if self._is_public_product_get(request):
+                auth_result = await self._authenticate_optional_jwt(request)
+                if auth_result:
+                    request.state.user = auth_result
             return await call_next(request)
 
         # Try different authentication methods
@@ -77,6 +81,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         # No valid authentication found
         return JSONResponse(status_code=401, content={"detail": "Authorization required"})
+
+    def _is_public_product_get(self, request: Request) -> bool:
+        return request.method == "GET" and bool(_PUBLIC_PRODUCT_GET_RE.match(request.url.path))
 
     def _is_whitelisted(self, request: Request) -> bool:
         """Check if the request path is whitelisted"""
@@ -182,6 +189,38 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 path=request.url.path,
                 method=request.method,
             )
+            return None
+
+    async def _authenticate_optional_jwt(self, request: Request) -> dict[str, Any] | None:
+        """Best-effort JWT auth for public product routes.
+
+        Signed-in users send Bearer tokens on product pages, but those routes are
+        public so missing/invalid tokens must not block access.
+        """
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return None
+
+        try:
+            token = auth_header.split(" ")[1]
+            payload: dict[str, Any] = await clerk_auth_service.verify_token(token)
+            user_id = payload.get("sub") or payload.get("id")
+            if not user_id:
+                return None
+
+            user_info = {
+                "user_id": user_id,
+                "email": payload.get("email"),
+                "name": payload.get("name"),
+            }
+            self.logger.info(
+                "Optional JWT authentication on public product route",
+                email=user_info.get("email"),
+                user_id=user_info.get("user_id"),
+                path=request.url.path,
+            )
+            return user_info
+        except Exception:
             return None
 
     def _log_request(self, request: Request) -> None:

--- a/packages/backend/src/core/tier_deps.py
+++ b/packages/backend/src/core/tier_deps.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from fastapi import Depends, HTTPException, Request
 from motor.core import AgnosticDatabase
 
 from src.core.database import get_db
+from src.core.jwt import clerk_auth_service
 from src.models.user import UserTier
 from src.services.product_preview_usage import ProductPreviewUsageService
 from src.services.service_factory import create_user_service
@@ -28,10 +30,44 @@ _METERED_PRODUCT_GET_RE = re.compile(
 _preview_usage_svc = ProductPreviewUsageService()
 
 
-def _get_user_id(request: Request) -> str | None:
+def _user_id_from_state(request: Request) -> str | None:
     user = getattr(request.state, "user", None)
     if user and isinstance(user, dict):
-        return user.get("user_id")
+        user_id = user.get("user_id")
+        if isinstance(user_id, str) and user_id:
+            return user_id
+    return None
+
+
+async def _resolve_request_user_id(request: Request) -> str | None:
+    """Resolve the authenticated user ID from middleware state or Bearer JWT."""
+    user_id = _user_id_from_state(request)
+    if user_id:
+        return user_id
+
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+
+    token = auth_header.removeprefix("Bearer ").strip()
+    if not token:
+        return None
+
+    try:
+        payload: dict[str, Any] = await clerk_auth_service.verify_token(token)
+    except HTTPException:
+        return None
+    except Exception:
+        return None
+
+    resolved = payload.get("sub") or payload.get("id")
+    if isinstance(resolved, str) and resolved:
+        request.state.user = {
+            "user_id": resolved,
+            "email": payload.get("email"),
+            "name": payload.get("name"),
+        }
+        return resolved
     return None
 
 
@@ -55,12 +91,17 @@ def _should_increment_preview(request: Request) -> bool:
     return request.url.path.endswith("/overview")
 
 
+def _has_bearer_token(request: Request) -> bool:
+    auth_header = request.headers.get("Authorization", "")
+    return auth_header.startswith("Bearer ") and bool(auth_header.removeprefix("Bearer ").strip())
+
+
 async def require_pro(
     request: Request,
     db: AgnosticDatabase = Depends(get_db),
 ) -> None:
     """Dependency that blocks unauthenticated requests (HTTP 401) and non-PRO users (HTTP 402)."""
-    user_id = _get_user_id(request)
+    user_id = await _resolve_request_user_id(request)
     if user_id in _BYPASS_USER_IDS:
         return
     if user_id is None:
@@ -79,11 +120,17 @@ async def check_usage_limit(
     db: AgnosticDatabase = Depends(get_db),
 ) -> None:
     """Dependency that enforces usage limits for signed-in and anonymous users."""
-    user_id = _get_user_id(request)
+    user_id = await _resolve_request_user_id(request)
     if user_id in _BYPASS_USER_IDS:
         return
 
     if user_id is None:
+        if _has_bearer_token(request):
+            raise HTTPException(
+                status_code=401,
+                detail="Session expired. Please sign in again.",
+            )
+
         if not _is_metered_product_get(request) or _is_crawler_request(request):
             return
 
@@ -102,6 +149,11 @@ async def check_usage_limit(
             )
         return
 
+    user_service = create_user_service()
+    user = await user_service.get_user_by_id(db, user_id)
+    if user and user.tier == UserTier.PRO:
+        return
+
     allowed, _ = await UsageService.check_usage_limit(db, user_id)
     if not allowed:
         raise HTTPException(
@@ -115,9 +167,14 @@ async def increment_usage(
     db: AgnosticDatabase = Depends(get_db),
 ) -> None:
     """Dependency that increments usage counter. Call AFTER successful response."""
-    user_id = _get_user_id(request)
+    user_id = await _resolve_request_user_id(request)
     if user_id in _BYPASS_USER_IDS or user_id is None:
         return
+    user_service = create_user_service()
+    user = await user_service.get_user_by_id(db, user_id)
+    if user and user.tier == UserTier.PRO:
+        return
+
     await UsageService.increment_usage(db, user_id, endpoint=request.url.path)
 
 
@@ -126,7 +183,7 @@ async def get_user_tier(
     db: AgnosticDatabase = Depends(get_db),
 ) -> UserTier:
     """Return the authenticated user's tier, defaulting to FREE."""
-    user_id = _get_user_id(request)
+    user_id = await _resolve_request_user_id(request)
     if user_id in _BYPASS_USER_IDS or user_id is None:
         return UserTier.FREE
 

--- a/packages/backend/src/routes/paddle.py
+++ b/packages/backend/src/routes/paddle.py
@@ -14,6 +14,10 @@ from src.core.logging import get_logger
 from src.models.user import UserTier
 from src.services.paddle_service import paddle_service
 from src.services.service_factory import create_user_service
+from src.services.subscription_sync import (
+    apply_subscription_data_to_user,
+    resolve_tier_from_price_id,
+)
 from src.services.user_service import UserService
 
 logger = get_logger(__name__)
@@ -46,18 +50,8 @@ async def handle_subscription_created(
             return
 
         price_id = items[0].get("price", {}).get("id")
-        tier = UserTier.FREE
+        tier = resolve_tier_from_price_id(price_id)
 
-        # Map price_id to tier
-        from src.core.config import config
-
-        if price_id in [
-            config.paddle.price_pro_monthly,
-            config.paddle.price_pro_annual,
-        ]:
-            tier = UserTier.PRO
-
-        # Update user
         user.tier = tier
         user.paddle_customer_id = subscription.get("customer_id")
         user.paddle_subscription_id = subscription.get("id")
@@ -92,17 +86,11 @@ async def handle_subscription_updated(
             return
 
         # Use the found user object directly
-        user_obj = user
-
-        # Update subscription status
-        user_obj.subscription_status = subscription.get("status")
-        user_obj.subscription_current_period_end = datetime.fromisoformat(
-            subscription.get("current_billing_period", {}).get("ends_at").replace("Z", "+00:00")
-        )
+        user_obj = apply_subscription_data_to_user(user, subscription)
 
         await user_service.upsert_user(db, user_obj)
         logger.info(
-            f"Updated subscription status for user {user_obj.id}: {user_obj.subscription_status}"
+            f"Updated subscription status for user {user_obj.id}: {user_obj.subscription_status} (tier={user_obj.tier.value})"
         )
 
     except Exception as e:

--- a/packages/backend/src/routes/subscription.py
+++ b/packages/backend/src/routes/subscription.py
@@ -15,6 +15,10 @@ from src.core.logging import get_logger
 from src.models.clerkUser import ClerkUser
 from src.services.paddle_service import paddle_service
 from src.services.service_factory import create_user_service
+from src.services.subscription_sync import (
+    sync_user_subscription_from_paddle,
+    user_needs_subscription_sync,
+)
 
 logger = get_logger(__name__)
 
@@ -128,6 +132,9 @@ async def get_my_subscription(
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
 
+        if user_needs_subscription_sync(user):
+            user = await sync_user_subscription_from_paddle(db, user)
+
         subscription_data: dict[str, Any] = {
             "tier": user.tier.value,
             "status": user.subscription_status or "inactive",
@@ -153,6 +160,41 @@ async def get_my_subscription(
     except Exception as e:
         logger.error(f"Error getting subscription: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve subscription") from e
+
+
+@router.post("/sync")
+async def sync_my_subscription(
+    current: ClerkUser = Depends(get_current_user),
+    db: AgnosticDatabase = Depends(get_db),
+) -> dict[str, Any]:
+    """Reconcile local subscription state with Paddle."""
+    if not current.user_id:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    try:
+        user_service = create_user_service()
+        user = await user_service.get_user_by_id(db, current.user_id)
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        if not user.paddle_subscription_id:
+            user = await sync_user_subscription_from_paddle(db, user, recover_by_email=True)
+            if not user.paddle_subscription_id:
+                raise HTTPException(status_code=400, detail="No Paddle subscription linked")
+
+        user = await sync_user_subscription_from_paddle(db, user, recover_by_email=True)
+
+        return {
+            "tier": user.tier.value,
+            "status": user.subscription_status or "inactive",
+            "synced": True,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error syncing subscription: {e}")
+        raise HTTPException(status_code=500, detail="Subscription sync failed") from e
 
 
 @router.post("/cancel")

--- a/packages/backend/src/routes/subscription.py
+++ b/packages/backend/src/routes/subscription.py
@@ -177,12 +177,9 @@ async def sync_my_subscription(
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
 
-        if not user.paddle_subscription_id:
-            user = await sync_user_subscription_from_paddle(db, user, recover_by_email=True)
-            if not user.paddle_subscription_id:
-                raise HTTPException(status_code=400, detail="No Paddle subscription linked")
-
         user = await sync_user_subscription_from_paddle(db, user, recover_by_email=True)
+        if not user.paddle_subscription_id:
+            raise HTTPException(status_code=400, detail="No Paddle subscription linked")
 
         return {
             "tier": user.tier.value,

--- a/packages/backend/src/routes/users.py
+++ b/packages/backend/src/routes/users.py
@@ -30,14 +30,25 @@ async def upsert_user(
     if not current.user_id:
         raise HTTPException(status_code=401, detail="Invalid user")
 
+    user_service = create_user_service()
+    existing = await user_service.get_user_by_id(db, current.user_id)
+
+    profile_data = {
+        "email": req.email or current.email,
+        "first_name": req.first_name,
+        "last_name": req.last_name,
+    }
+
+    if existing:
+        await user_service.update_user_profile(db, current.user_id, profile_data)
+        return {"status": "ok", "user_id": current.user_id}
+
     user = User(
         id=current.user_id,
-        email=req.email or current.email,
+        email=profile_data["email"],
         first_name=req.first_name,
         last_name=req.last_name,
     )
-
-    user_service = create_user_service()
     await user_service.upsert_user(db, user)
 
     return {"status": "ok", "user_id": user.id}

--- a/packages/backend/src/services/paddle_service.py
+++ b/packages/backend/src/services/paddle_service.py
@@ -132,6 +132,40 @@ class PaddleService:
             logger.error(f"Error getting subscription {subscription_id}: {e}")
             raise
 
+    async def list_customers_by_email(self, email: str) -> dict[str, Any]:
+        """List Paddle customers matching an email address."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.base_url}/customers",
+                    headers=self._get_headers(),
+                    params={"email": email},
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+                return response.json()
+
+        except Exception as e:
+            logger.error(f"Error listing customers for {email}: {e}")
+            raise
+
+    async def list_subscriptions_for_customer(self, customer_id: str) -> dict[str, Any]:
+        """List subscriptions for a Paddle customer."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.base_url}/subscriptions",
+                    headers=self._get_headers(),
+                    params={"customer_id": customer_id, "status": "active"},
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+                return response.json()
+
+        except Exception as e:
+            logger.error(f"Error listing subscriptions for customer {customer_id}: {e}")
+            raise
+
     async def cancel_subscription(
         self, subscription_id: str, effective_from: str = "next_billing_period"
     ) -> dict[str, Any]:

--- a/packages/backend/src/services/subscription_sync.py
+++ b/packages/backend/src/services/subscription_sync.py
@@ -48,7 +48,7 @@ def apply_subscription_data_to_user(user: User, subscription: dict[str, Any]) ->
 
     if status in _ACTIVE_SUBSCRIPTION_STATUSES:
         user.tier = tier
-    elif status == "canceled":
+    else:
         user.tier = UserTier.FREE
 
     user.paddle_customer_id = subscription.get("customer_id") or user.paddle_customer_id
@@ -82,10 +82,7 @@ async def sync_user_subscription_from_paddle(
     subscription_id = user.paddle_subscription_id
 
     if not subscription_id and recover_by_email:
-        user = await _recover_subscription_by_email(db, user)
-        subscription_id = user.paddle_subscription_id
-        if not subscription_id:
-            return user
+        return await _recover_subscription_by_email(db, user)
 
     if not subscription_id:
         return user

--- a/packages/backend/src/services/subscription_sync.py
+++ b/packages/backend/src/services/subscription_sync.py
@@ -41,6 +41,7 @@ def _parse_paddle_datetime(value: str | None) -> datetime | None:
 
 def apply_subscription_data_to_user(user: User, subscription: dict[str, Any]) -> User:
     """Apply Paddle subscription payload fields onto a user record."""
+    user = user.model_copy()
     items = subscription.get("items", [])
     price_id = items[0].get("price", {}).get("id") if items else None
     status = subscription.get("status")
@@ -72,7 +73,11 @@ def apply_subscription_data_to_user(user: User, subscription: dict[str, Any]) ->
 
 def user_needs_subscription_sync(user: User) -> bool:
     """Return True when local subscription state may be stale."""
-    return user.tier != UserTier.PRO and bool(user.paddle_subscription_id)
+    if not user.paddle_subscription_id:
+        return False
+    if user.tier == UserTier.PRO and user.subscription_status in _ACTIVE_SUBSCRIPTION_STATUSES:
+        return False
+    return True
 
 
 async def sync_user_subscription_from_paddle(

--- a/packages/backend/src/services/subscription_sync.py
+++ b/packages/backend/src/services/subscription_sync.py
@@ -1,0 +1,158 @@
+"""Sync Clausea user subscription state from Paddle."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from motor.core import AgnosticDatabase
+
+from src.core.config import config
+from src.core.logging import get_logger
+from src.models.user import User, UserTier
+from src.services.paddle_service import paddle_service
+from src.services.service_factory import create_user_service
+
+logger = get_logger(__name__)
+
+_ACTIVE_SUBSCRIPTION_STATUSES = {"active", "trialing", "past_due"}
+
+
+def resolve_tier_from_price_id(price_id: str | None) -> UserTier:
+    """Map a Paddle price ID to a Clausea user tier."""
+    if not price_id:
+        return UserTier.FREE
+
+    pro_price_ids = {
+        config.paddle.price_pro_monthly,
+        config.paddle.price_pro_annual,
+    }
+    if price_id in pro_price_ids:
+        return UserTier.PRO
+
+    return UserTier.FREE
+
+
+def _parse_paddle_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def apply_subscription_data_to_user(user: User, subscription: dict[str, Any]) -> User:
+    """Apply Paddle subscription payload fields onto a user record."""
+    items = subscription.get("items", [])
+    price_id = items[0].get("price", {}).get("id") if items else None
+    status = subscription.get("status")
+    tier = resolve_tier_from_price_id(price_id)
+
+    if status in _ACTIVE_SUBSCRIPTION_STATUSES:
+        user.tier = tier
+    elif status == "canceled":
+        user.tier = UserTier.FREE
+
+    user.paddle_customer_id = subscription.get("customer_id") or user.paddle_customer_id
+    user.paddle_subscription_id = subscription.get("id") or user.paddle_subscription_id
+    user.subscription_status = status
+    user.subscription_started_at = (
+        _parse_paddle_datetime(subscription.get("started_at")) or user.subscription_started_at
+    )
+
+    billing_period = subscription.get("current_billing_period") or {}
+    user.subscription_current_period_end = (
+        _parse_paddle_datetime(billing_period.get("ends_at"))
+        or user.subscription_current_period_end
+    )
+
+    if status == "canceled":
+        user.subscription_canceled_at = user.subscription_canceled_at or datetime.now()
+
+    return user
+
+
+def user_needs_subscription_sync(user: User) -> bool:
+    """Return True when local subscription state may be stale."""
+    return user.tier != UserTier.PRO and bool(user.paddle_subscription_id)
+
+
+async def sync_user_subscription_from_paddle(
+    db: AgnosticDatabase, user: User, *, recover_by_email: bool = False
+) -> User:
+    """Refresh a user's subscription fields from Paddle."""
+    subscription_id = user.paddle_subscription_id
+
+    if not subscription_id and recover_by_email:
+        user = await _recover_subscription_by_email(db, user)
+        subscription_id = user.paddle_subscription_id
+        if not subscription_id:
+            return user
+
+    if not subscription_id:
+        return user
+
+    try:
+        response = await paddle_service.get_subscription(subscription_id)
+        subscription = response.get("data", {})
+        if not subscription:
+            logger.warning("No subscription data returned from Paddle for user %s", user.id)
+            return user
+
+        updated_user = apply_subscription_data_to_user(user, subscription)
+        user_service = create_user_service()
+        await user_service.upsert_user(db, updated_user)
+        logger.info(
+            "Synced subscription for user %s: tier=%s status=%s",
+            user.id,
+            updated_user.tier.value,
+            updated_user.subscription_status,
+        )
+        return updated_user
+    except Exception as e:
+        logger.error("Failed to sync subscription for user %s: %s", user.id, e)
+        return user
+
+
+async def _recover_subscription_by_email(db: AgnosticDatabase, user: User) -> User:
+    """Link a user to an active Paddle subscription using their account email."""
+    if not user.email:
+        return user
+
+    try:
+        customers_response = await paddle_service.list_customers_by_email(user.email)
+        customers = customers_response.get("data", [])
+        if not customers:
+            return user
+
+        for customer in customers:
+            customer_id = customer.get("id")
+            if not customer_id:
+                continue
+
+            subscriptions_response = await paddle_service.list_subscriptions_for_customer(
+                customer_id
+            )
+            subscriptions = subscriptions_response.get("data", [])
+            active_subscription = next(
+                (
+                    sub
+                    for sub in subscriptions
+                    if sub.get("status") in _ACTIVE_SUBSCRIPTION_STATUSES
+                ),
+                None,
+            )
+            if not active_subscription:
+                continue
+
+            updated_user = apply_subscription_data_to_user(user, active_subscription)
+            updated_user.paddle_customer_id = customer_id
+            user_service = create_user_service()
+            await user_service.upsert_user(db, updated_user)
+            logger.info(
+                "Recovered Paddle subscription for user %s via email lookup",
+                user.id,
+            )
+            return updated_user
+    except Exception as e:
+        logger.error("Failed to recover subscription for user %s: %s", user.id, e)
+
+    return user

--- a/packages/backend/tests/unit/core/middleware_test.py
+++ b/packages/backend/tests/unit/core/middleware_test.py
@@ -233,6 +233,31 @@ class TestDispatchFlow:
         call_next.assert_called_once_with(request)
 
     @pytest.mark.asyncio
+    @patch("src.core.middleware.clerk_auth_service")
+    async def test_public_product_route_honors_jwt(
+        self, mock_clerk: MagicMock, middleware: AuthMiddleware
+    ) -> None:
+        mock_clerk.verify_token = AsyncMock(
+            return_value={"sub": "user_123", "email": "user@example.com"}
+        )
+        request = _make_request(
+            path="/products/acme/overview",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+        await middleware.dispatch(request, call_next)
+        call_next.assert_called_once_with(request)
+        assert request.state.user["user_id"] == "user_123"
+
+    @pytest.mark.asyncio
+    async def test_public_product_route_allows_anonymous(self, middleware: AuthMiddleware) -> None:
+        request = _make_request(path="/products/acme/overview", headers={})
+        call_next = AsyncMock(return_value=MagicMock(status_code=200))
+        response = await middleware.dispatch(request, call_next)
+        assert response.status_code == 200
+        call_next.assert_called_once_with(request)
+
+    @pytest.mark.asyncio
     @patch("src.core.middleware.config")
     async def test_authenticated_request_proceeds(
         self, mock_config: MagicMock, middleware: AuthMiddleware

--- a/packages/backend/tests/unit/subscription_sync_test.py
+++ b/packages/backend/tests/unit/subscription_sync_test.py
@@ -41,6 +41,7 @@ def test_apply_subscription_data_to_user_sets_pro_tier() -> None:
     assert updated.tier == UserTier.PRO
     assert updated.paddle_subscription_id == "sub_123"
     assert updated.subscription_status == "active"
+    assert user.tier == UserTier.FREE
 
 
 def test_user_needs_subscription_sync_when_pro() -> None:
@@ -49,8 +50,20 @@ def test_user_needs_subscription_sync_when_pro() -> None:
         email="test@example.com",
         tier=UserTier.PRO,
         paddle_subscription_id="sub_123",
+        subscription_status="active",
     )
     assert user_needs_subscription_sync(user) is False
+
+
+def test_user_needs_subscription_sync_when_pro_with_canceled_status() -> None:
+    user = User(
+        id="user-1",
+        email="test@example.com",
+        tier=UserTier.PRO,
+        paddle_subscription_id="sub_123",
+        subscription_status="canceled",
+    )
+    assert user_needs_subscription_sync(user) is True
 
 
 def test_apply_subscription_data_to_user_downgrades_paused_tier() -> None:

--- a/packages/backend/tests/unit/subscription_sync_test.py
+++ b/packages/backend/tests/unit/subscription_sync_test.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+
+from src.models.user import User, UserTier
+from src.services.subscription_sync import (
+    apply_subscription_data_to_user,
+    resolve_tier_from_price_id,
+    user_needs_subscription_sync,
+)
+
+
+def test_resolve_tier_from_price_id_pro_monthly() -> None:
+    with patch("src.services.subscription_sync.config") as mock_config:
+        mock_config.paddle.price_pro_monthly = "pri_monthly"
+        mock_config.paddle.price_pro_annual = "pri_annual"
+        assert resolve_tier_from_price_id("pri_monthly") == UserTier.PRO
+
+
+def test_resolve_tier_from_price_id_unknown() -> None:
+    with patch("src.services.subscription_sync.config") as mock_config:
+        mock_config.paddle.price_pro_monthly = "pri_monthly"
+        mock_config.paddle.price_pro_annual = "pri_annual"
+        assert resolve_tier_from_price_id("pri_other") == UserTier.FREE
+
+
+def test_apply_subscription_data_to_user_sets_pro_tier() -> None:
+    user = User(id="user-1", email="test@example.com")
+    subscription = {
+        "id": "sub_123",
+        "customer_id": "ctm_123",
+        "status": "active",
+        "started_at": "2026-01-01T00:00:00Z",
+        "current_billing_period": {"ends_at": "2026-02-01T00:00:00Z"},
+        "items": [{"price": {"id": "pri_monthly"}}],
+    }
+
+    with patch("src.services.subscription_sync.config") as mock_config:
+        mock_config.paddle.price_pro_monthly = "pri_monthly"
+        mock_config.paddle.price_pro_annual = "pri_annual"
+        updated = apply_subscription_data_to_user(user, subscription)
+
+    assert updated.tier == UserTier.PRO
+    assert updated.paddle_subscription_id == "sub_123"
+    assert updated.subscription_status == "active"
+
+
+def test_user_needs_subscription_sync_when_pro() -> None:
+    user = User(
+        id="user-1",
+        email="test@example.com",
+        tier=UserTier.PRO,
+        paddle_subscription_id="sub_123",
+    )
+    assert user_needs_subscription_sync(user) is False
+
+
+def test_user_needs_subscription_sync_when_free_with_subscription() -> None:
+    user = User(
+        id="user-1",
+        email="test@example.com",
+        tier=UserTier.FREE,
+        paddle_subscription_id="sub_123",
+        subscription_status="active",
+    )
+    assert user_needs_subscription_sync(user) is True

--- a/packages/backend/tests/unit/subscription_sync_test.py
+++ b/packages/backend/tests/unit/subscription_sync_test.py
@@ -53,6 +53,26 @@ def test_user_needs_subscription_sync_when_pro() -> None:
     assert user_needs_subscription_sync(user) is False
 
 
+def test_apply_subscription_data_to_user_downgrades_paused_tier() -> None:
+    user = User(id="user-1", email="test@example.com", tier=UserTier.PRO)
+    subscription = {
+        "id": "sub_123",
+        "customer_id": "ctm_123",
+        "status": "paused",
+        "started_at": "2026-01-01T00:00:00Z",
+        "current_billing_period": {"ends_at": "2026-02-01T00:00:00Z"},
+        "items": [{"price": {"id": "pri_monthly"}}],
+    }
+
+    with patch("src.services.subscription_sync.config") as mock_config:
+        mock_config.paddle.price_pro_monthly = "pri_monthly"
+        mock_config.paddle.price_pro_annual = "pri_annual"
+        updated = apply_subscription_data_to_user(user, subscription)
+
+    assert updated.tier == UserTier.FREE
+    assert updated.subscription_status == "paused"
+
+
 def test_user_needs_subscription_sync_when_free_with_subscription() -> None:
     user = User(
         id="user-1",

--- a/packages/backend/tests/unit/tier_access_test.py
+++ b/packages/backend/tests/unit/tier_access_test.py
@@ -111,6 +111,7 @@ def _mock_request(user_id: str | None) -> MagicMock:
         request.state.user = None
     else:
         request.state.user = {"user_id": user_id}
+    request.headers = {}
     return request
 
 
@@ -225,3 +226,52 @@ async def test_check_usage_limit_enforces_signed_in_monthly_limit() -> None:
 
     assert exc_info.value.status_code == 429
     assert "Monthly usage limit" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_check_usage_limit_skips_pro_users() -> None:
+    request = _mock_request("pro-user-456")
+    request.method = "GET"
+    request.url.path = "/products/acme/overview"
+    db = AsyncMock()
+
+    mock_user = MagicMock()
+    mock_user.tier = UserTier.PRO
+
+    with patch("src.core.tier_deps.create_user_service") as mock_factory:
+        mock_svc = AsyncMock()
+        mock_svc.get_user_by_id.return_value = mock_user
+        mock_factory.return_value = mock_svc
+
+        with patch(
+            "src.core.tier_deps.UsageService.check_usage_limit",
+            new=AsyncMock(),
+        ) as mock_check:
+            result = await check_usage_limit(request=request, db=db)
+
+    assert result is None
+    mock_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_usage_limit_rejects_stale_bearer_without_preview_fallback() -> None:
+    request = _mock_request(None)
+    request.method = "GET"
+    request.url.path = "/products/acme/overview"
+    request.headers = {
+        "Authorization": "Bearer stale-token",
+        "X-Preview-Token": "preview-token-1",
+    }
+    request.client = MagicMock(host="1.2.3.4")
+    db = AsyncMock()
+
+    with patch(
+        "src.core.tier_deps.clerk_auth_service.verify_token",
+        new=AsyncMock(side_effect=HTTPException(status_code=401, detail="Invalid token")),
+    ):
+        with patch("src.core.tier_deps._preview_usage_svc") as mock_preview_svc:
+            with pytest.raises(HTTPException) as exc_info:
+                await check_usage_limit(request=request, db=db)
+
+    assert exc_info.value.status_code == 401
+    mock_preview_svc.check_and_increment.assert_not_called()

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -33,6 +33,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { subscriptionApi } from "@/lib/api/subscriptions";
 import { PIPELINE_ERROR_CODE_MESSAGES } from "@/lib/pipeline-errors";
 import type {
   DocumentSummary,
@@ -142,6 +143,10 @@ export default function CompanyPage({
     "idle" | "submitting" | "success" | "error"
   >("idle");
   const [notifyError, setNotifyError] = useState<string | null>(null);
+  const [restoreStatus, setRestoreStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
+  const [restoreError, setRestoreError] = useState<string | null>(null);
 
   useEffect(() => {
     // If SSR pre-loaded both product and overview, skip client-side fetch entirely
@@ -405,6 +410,23 @@ export default function CompanyPage({
     }
   }
 
+  async function handleRestoreProAccess() {
+    setRestoreStatus("loading");
+    setRestoreError(null);
+    try {
+      await subscriptionApi.syncSubscription();
+      setRestoreStatus("success");
+      window.location.reload();
+    } catch (err) {
+      setRestoreStatus("error");
+      setRestoreError(
+        err instanceof Error
+          ? err.message
+          : "Could not restore your subscription.",
+      );
+    }
+  }
+
   if (loading || (!data && indexationMode === "unknown")) {
     return (
       <div className="space-y-8">
@@ -517,10 +539,23 @@ export default function CompanyPage({
               </h2>
               <p className="text-sm text-muted-foreground leading-relaxed max-w-2xl">
                 This report is unavailable right now because your monthly quota
-                is exhausted. Upgrade your plan for more analyses, or return
+                is exhausted. If you already have Pro, restore your subscription
+                below. Otherwise upgrade your plan for more analyses, or return
                 after your quota resets.
               </p>
+              {restoreError && (
+                <p className="text-sm text-destructive">{restoreError}</p>
+              )}
               <div className="pt-2 flex flex-col sm:flex-row gap-3">
+                <Button
+                  onClick={() => void handleRestoreProAccess()}
+                  disabled={restoreStatus === "loading"}
+                  className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+                >
+                  {restoreStatus === "loading"
+                    ? "Restoring..."
+                    : "Restore Pro access"}
+                </Button>
                 <Link href="/pricing">
                   <Button className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold">
                     View plans

--- a/packages/frontend/app/api/subscriptions/sync/route.ts
+++ b/packages/frontend/app/api/subscriptions/sync/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { subscriptionProxyError } from "@/lib/api/subscription-proxy";
+import { getBackendUrl } from "@/lib/config";
+import { httpJson } from "@/lib/http";
+
+export async function POST() {
+  try {
+    const data = await httpJson(getBackendUrl("/subscriptions/sync"), {
+      method: "POST",
+    });
+    return NextResponse.json(data);
+  } catch (error) {
+    return subscriptionProxyError(error);
+  }
+}

--- a/packages/frontend/lib/api/subscriptions.ts
+++ b/packages/frontend/lib/api/subscriptions.ts
@@ -64,6 +64,14 @@ class SubscriptionAPI {
     return this.fetchApi("/me");
   }
 
+  async syncSubscription(): Promise<{
+    tier: string;
+    status: string;
+    synced: boolean;
+  }> {
+    return this.fetchApi("/sync", { method: "POST" });
+  }
+
   async cancelSubscription(): Promise<{ success: boolean; message: string }> {
     return this.fetchApi("/cancel", { method: "POST" });
   }

--- a/packages/frontend/lib/http.ts
+++ b/packages/frontend/lib/http.ts
@@ -35,6 +35,7 @@ export async function http(
   } = options;
 
   const userAuth = await auth();
+  const userId = userAuth.userId;
   let token: string | null | undefined = undefined;
   try {
     token = await userAuth.getToken?.({ template: "default" });
@@ -62,7 +63,7 @@ export async function http(
   if (token) {
     (mergedHeaders as Record<string, string>)["Authorization"] =
       `Bearer ${token}`;
-  } else {
+  } else if (!userId) {
     const cookieStore = await cookies();
     const previewToken = cookieStore.get(PREVIEW_TOKEN_COOKIE)?.value;
     if (previewToken) {
@@ -115,7 +116,7 @@ export async function http(
 }
 
 function shouldRetry(status: number): boolean {
-  return status >= 500 || status === 429;
+  return status >= 500;
 }
 
 function delay(ms: number): Promise<void> {

--- a/packages/frontend/proxy.ts
+++ b/packages/frontend/proxy.ts
@@ -84,6 +84,13 @@ const clerkProxy = clerkMiddleware(async (auth, request) => {
     }
   }
 
+  if (userId) {
+    const response = NextResponse.next();
+    response.cookies.delete(PREVIEW_TOKEN_COOKIE);
+    response.cookies.delete(PV_COOKIE);
+    return response;
+  }
+
   return NextResponse.next();
 });
 


### PR DESCRIPTION
## Summary
- Honor Bearer JWT on public product GET routes so signed-in users are recognized instead of being metered as anonymous preview visitors (5-view limit).
- Resolve auth directly in usage-limit dependencies, bypass quotas for Pro tier, and return 401 (not 429) when a stale session token is sent with an exhausted preview cookie.
- Stop attaching preview tokens for signed-in sessions, clear stale preview cookies after login, and add subscription sync/recovery for desynced Paddle state.

## Test plan
- [ ] Sign in as a Pro user and open a product report that previously returned 429 — overview should load.
- [ ] Confirm Settings still shows Pro / Active.
- [ ] Sign out, browse 5+ product pages anonymously, confirm preview limit applies; sign in and confirm access is restored.
- [ ] Click "Restore Pro access" on the limit screen if subscription was desynced — tier should reconcile from Paddle.
- [ ] Run backend tests: `uv run pytest tests/unit/tier_access_test.py tests/unit/core/middleware_test.py tests/unit/subscription_sync_test.py`