### PR TITLE
Raise anonymous product preview limit to 15 with monthly reset

### DIFF
--- a/packages/backend/src/services/product_preview_usage.py
+++ b/packages/backend/src/services/product_preview_usage.py
@@ -4,16 +4,46 @@ from motor.core import AgnosticDatabase
 from pymongo import ReturnDocument
 from pymongo.errors import DuplicateKeyError
 
-ANONYMOUS_LIMIT = 5
+ANONYMOUS_LIMIT = 15
 
 
 class ProductPreviewUsageService:
     COLLECTION = "product_preview_usage"
 
+    @staticmethod
+    def _current_month_key() -> str:
+        return datetime.now(tz=UTC).strftime("%Y-%m")
+
     def _key_filter(self, *, token: str | None, ip: str) -> dict:
         if token:
             return {"token": token}
         return {"ip": ip, "token": {"$exists": False}}
+
+    def _effective_count(self, doc: dict | None, month_key: str) -> int:
+        if not doc:
+            return 0
+        if doc.get("month_key") != month_key:
+            return 0
+        return int(doc.get("count", 0))
+
+    async def _reset_month_if_needed(
+        self,
+        db: AgnosticDatabase,
+        key_filter: dict,
+        doc: dict | None,
+        month_key: str,
+        now: datetime,
+    ) -> int:
+        if doc is None:
+            return 0
+        if doc.get("month_key") == month_key:
+            return int(doc.get("count", 0))
+
+        await db[self.COLLECTION].update_one(
+            key_filter,
+            {"$set": {"count": 0, "month_key": month_key, "last_seen": now}},
+        )
+        return 0
 
     async def check_and_increment(
         self,
@@ -26,19 +56,20 @@ class ProductPreviewUsageService:
         """Return (allowed, current_count).
 
         Keyed by preview token when present; falls back to IP when token is missing.
-        IP is stored as metadata only when token is the primary key.
+        Counts reset on the first day of each UTC calendar month.
         """
         key_filter = self._key_filter(token=token, ip=ip)
+        month_key = self._current_month_key()
 
         if not increment:
-            doc = await db[self.COLLECTION].find_one(key_filter, {"count": 1})
-            current = doc["count"] if doc else 0
+            doc = await db[self.COLLECTION].find_one(key_filter, {"count": 1, "month_key": 1})
+            current = self._effective_count(doc, month_key)
             return current < ANONYMOUS_LIMIT, current
 
         now = datetime.now(tz=UTC)
         update_filter = {**key_filter, "count": {"$lt": ANONYMOUS_LIMIT}}
-        set_fields: dict = {"last_seen": now}
-        set_on_insert: dict = {"first_seen": now}
+        set_fields: dict = {"last_seen": now, "month_key": month_key}
+        set_on_insert: dict = {"first_seen": now, "month_key": month_key}
         if token:
             set_fields["ip"] = ip
             set_on_insert["token"] = token
@@ -46,8 +77,9 @@ class ProductPreviewUsageService:
             set_on_insert["ip"] = ip
 
         existing = await db[self.COLLECTION].find_one(key_filter)
+        current = await self._reset_month_if_needed(db, key_filter, existing, month_key, now)
+
         if existing:
-            current = existing.get("count", 0)
             if current >= ANONYMOUS_LIMIT:
                 return False, current
             doc = await db[self.COLLECTION].find_one_and_update(
@@ -56,9 +88,9 @@ class ProductPreviewUsageService:
                 return_document=ReturnDocument.AFTER,
             )
             if doc is not None:
-                return True, doc["count"]
-            existing = await db[self.COLLECTION].find_one(key_filter, {"count": 1})
-            current = existing["count"] if existing else ANONYMOUS_LIMIT
+                return True, int(doc["count"])
+            existing = await db[self.COLLECTION].find_one(key_filter, {"count": 1, "month_key": 1})
+            current = self._effective_count(existing, month_key)
             return False, current
 
         try:
@@ -73,10 +105,10 @@ class ProductPreviewUsageService:
                 return_document=ReturnDocument.AFTER,
             )
         except DuplicateKeyError:
-            existing = await db[self.COLLECTION].find_one(key_filter, {"count": 1})
-            current = existing["count"] if existing else ANONYMOUS_LIMIT
+            existing = await db[self.COLLECTION].find_one(key_filter, {"count": 1, "month_key": 1})
+            current = self._effective_count(existing, month_key)
             return False, current
 
         if doc is not None:
-            return True, doc["count"]
+            return True, int(doc["count"])
         return False, ANONYMOUS_LIMIT

--- a/packages/backend/src/services/product_preview_usage.py
+++ b/packages/backend/src/services/product_preview_usage.py
@@ -26,24 +26,71 @@ class ProductPreviewUsageService:
             return 0
         return int(doc.get("count", 0))
 
-    async def _reset_month_if_needed(
+    def _count_after_increment(self, before: dict | None, month_key: str) -> int:
+        if before is None:
+            return 1
+        if before.get("month_key") != month_key:
+            return 1
+        return self._effective_count(before, month_key) + 1
+
+    def _build_increment_update(
         self,
-        db: AgnosticDatabase,
-        key_filter: dict,
-        doc: dict | None,
+        *,
         month_key: str,
         now: datetime,
-    ) -> int:
-        if doc is None:
-            return 0
-        if doc.get("month_key") == month_key:
-            return int(doc.get("count", 0))
+        token: str | None,
+        ip: str,
+    ) -> tuple[list[dict], dict]:
+        set_on_insert: dict = {"first_seen": now}
+        extra_set: dict = {"month_key": month_key, "last_seen": now}
+        if token:
+            set_on_insert["token"] = token
+            extra_set["ip"] = ip
+        else:
+            set_on_insert["ip"] = ip
 
-        await db[self.COLLECTION].update_one(
-            key_filter,
-            {"$set": {"count": 0, "month_key": month_key, "last_seen": now}},
-        )
-        return 0
+        pipeline = [
+            {
+                "$set": {
+                    **extra_set,
+                    "count": {
+                        "$cond": {
+                            "if": {
+                                "$lt": [
+                                    {
+                                        "$cond": {
+                                            "if": {
+                                                "$ne": [
+                                                    {"$ifNull": ["$month_key", ""]},
+                                                    month_key,
+                                                ]
+                                            },
+                                            "then": 0,
+                                            "else": {"$ifNull": ["$count", 0]},
+                                        }
+                                    },
+                                    ANONYMOUS_LIMIT,
+                                ]
+                            },
+                            "then": {
+                                "$cond": {
+                                    "if": {
+                                        "$ne": [
+                                            {"$ifNull": ["$month_key", ""]},
+                                            month_key,
+                                        ]
+                                    },
+                                    "then": 1,
+                                    "else": {"$add": ["$count", 1]},
+                                }
+                            },
+                            "else": {"$ifNull": ["$count", 0]},
+                        }
+                    },
+                }
+            }
+        ]
+        return pipeline, set_on_insert
 
     async def check_and_increment(
         self,
@@ -67,48 +114,33 @@ class ProductPreviewUsageService:
             return current < ANONYMOUS_LIMIT, current
 
         now = datetime.now(tz=UTC)
-        update_filter = {**key_filter, "count": {"$lt": ANONYMOUS_LIMIT}}
-        set_fields: dict = {"last_seen": now, "month_key": month_key}
-        set_on_insert: dict = {"first_seen": now, "month_key": month_key}
-        if token:
-            set_fields["ip"] = ip
-            set_on_insert["token"] = token
-        else:
-            set_on_insert["ip"] = ip
-
-        existing = await db[self.COLLECTION].find_one(key_filter)
-        current = await self._reset_month_if_needed(db, key_filter, existing, month_key, now)
-
-        if existing:
-            if current >= ANONYMOUS_LIMIT:
-                return False, current
-            doc = await db[self.COLLECTION].find_one_and_update(
-                update_filter,
-                {"$inc": {"count": 1}, "$set": set_fields},
-                return_document=ReturnDocument.AFTER,
-            )
-            if doc is not None:
-                return True, int(doc["count"])
-            existing = await db[self.COLLECTION].find_one(key_filter, {"count": 1, "month_key": 1})
-            current = self._effective_count(existing, month_key)
-            return False, current
+        pipeline, set_on_insert = self._build_increment_update(
+            month_key=month_key,
+            now=now,
+            token=token,
+            ip=ip,
+        )
 
         try:
-            doc = await db[self.COLLECTION].find_one_and_update(
+            before = await db[self.COLLECTION].find_one_and_update(
                 key_filter,
-                {
-                    "$inc": {"count": 1},
-                    "$set": set_fields,
-                    "$setOnInsert": set_on_insert,
-                },
+                pipeline,
                 upsert=True,
-                return_document=ReturnDocument.AFTER,
+                return_document=ReturnDocument.BEFORE,
+                set_on_insert=set_on_insert,
             )
         except DuplicateKeyError:
-            existing = await db[self.COLLECTION].find_one(key_filter, {"count": 1, "month_key": 1})
-            current = self._effective_count(existing, month_key)
-            return False, current
+            before = await db[self.COLLECTION].find_one_and_update(
+                key_filter,
+                pipeline,
+                return_document=ReturnDocument.BEFORE,
+            )
 
-        if doc is not None:
-            return True, int(doc["count"])
-        return False, ANONYMOUS_LIMIT
+        if before is None:
+            return True, 1
+
+        before_count = self._effective_count(before, month_key)
+        if before.get("month_key") == month_key and before_count >= ANONYMOUS_LIMIT:
+            return False, before_count
+
+        return True, self._count_after_increment(before, month_key)

--- a/packages/backend/tests/services/product_preview_usage_test.py
+++ b/packages/backend/tests/services/product_preview_usage_test.py
@@ -14,7 +14,6 @@ def mock_db():
     collection = MagicMock()
     collection.find_one_and_update = AsyncMock()
     collection.find_one = AsyncMock()
-    collection.update_one = AsyncMock()
     db.product_preview_usage = collection
     db.__getitem__ = MagicMock(return_value=collection)
     return db
@@ -22,11 +21,7 @@ def mock_db():
 
 @pytest.mark.asyncio
 async def test_allows_first_use_with_token(mock_db):
-    mock_db.product_preview_usage.find_one.side_effect = [None]
-    mock_db.product_preview_usage.find_one_and_update.return_value = {
-        "token": "uuid-1",
-        "count": 1,
-    }
+    mock_db.product_preview_usage.find_one_and_update.return_value = None
     svc = ProductPreviewUsageService()
     allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
     assert allowed is True
@@ -36,12 +31,9 @@ async def test_allows_first_use_with_token(mock_db):
 @pytest.mark.asyncio
 async def test_allows_up_to_limit(mock_db):
     with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
-        mock_db.product_preview_usage.find_one.side_effect = [
-            {"token": "uuid-1", "count": ANONYMOUS_LIMIT - 1, "month_key": "2026-06"},
-        ]
         mock_db.product_preview_usage.find_one_and_update.return_value = {
             "token": "uuid-1",
-            "count": ANONYMOUS_LIMIT,
+            "count": ANONYMOUS_LIMIT - 1,
             "month_key": "2026-06",
         }
         svc = ProductPreviewUsageService()
@@ -53,7 +45,7 @@ async def test_allows_up_to_limit(mock_db):
 @pytest.mark.asyncio
 async def test_blocks_over_limit(mock_db):
     with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
-        mock_db.product_preview_usage.find_one.return_value = {
+        mock_db.product_preview_usage.find_one_and_update.return_value = {
             "token": "uuid-1",
             "count": ANONYMOUS_LIMIT,
             "month_key": "2026-06",
@@ -67,29 +59,22 @@ async def test_blocks_over_limit(mock_db):
 @pytest.mark.asyncio
 async def test_resets_count_on_new_month(mock_db):
     with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-07"):
-        mock_db.product_preview_usage.find_one.side_effect = [
-            {"token": "uuid-1", "count": ANONYMOUS_LIMIT, "month_key": "2026-06"},
-        ]
         mock_db.product_preview_usage.find_one_and_update.return_value = {
             "token": "uuid-1",
-            "count": 1,
-            "month_key": "2026-07",
+            "count": ANONYMOUS_LIMIT,
+            "month_key": "2026-06",
         }
         svc = ProductPreviewUsageService()
         allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
 
     assert allowed is True
     assert count == 1
-    mock_db.product_preview_usage.update_one.assert_awaited_once()
+    mock_db.product_preview_usage.find_one_and_update.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_different_tokens_are_independent_on_same_ip(mock_db):
-    mock_db.product_preview_usage.find_one.side_effect = [None, None]
-    mock_db.product_preview_usage.find_one_and_update.return_value = {
-        "token": "uuid-A",
-        "count": 1,
-    }
+    mock_db.product_preview_usage.find_one_and_update.return_value = None
     svc = ProductPreviewUsageService()
     allowed_a, _ = await svc.check_and_increment(mock_db, token="uuid-A", ip="5.5.5.5")
     allowed_b, _ = await svc.check_and_increment(mock_db, token="uuid-B", ip="5.5.5.5")
@@ -99,11 +84,7 @@ async def test_different_tokens_are_independent_on_same_ip(mock_db):
 
 @pytest.mark.asyncio
 async def test_ip_fallback_when_no_token(mock_db):
-    mock_db.product_preview_usage.find_one.side_effect = [None]
-    mock_db.product_preview_usage.find_one_and_update.return_value = {
-        "ip": "9.9.9.9",
-        "count": 1,
-    }
+    mock_db.product_preview_usage.find_one_and_update.return_value = None
     svc = ProductPreviewUsageService()
     allowed, count = await svc.check_and_increment(mock_db, token=None, ip="9.9.9.9")
     assert allowed is True

--- a/packages/backend/tests/services/product_preview_usage_test.py
+++ b/packages/backend/tests/services/product_preview_usage_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -14,6 +14,7 @@ def mock_db():
     collection = MagicMock()
     collection.find_one_and_update = AsyncMock()
     collection.find_one = AsyncMock()
+    collection.update_one = AsyncMock()
     db.product_preview_usage = collection
     db.__getitem__ = MagicMock(return_value=collection)
     return db
@@ -34,29 +35,52 @@ async def test_allows_first_use_with_token(mock_db):
 
 @pytest.mark.asyncio
 async def test_allows_up_to_limit(mock_db):
-    mock_db.product_preview_usage.find_one.side_effect = [
-        {"token": "uuid-1", "count": ANONYMOUS_LIMIT - 1},
-    ]
-    mock_db.product_preview_usage.find_one_and_update.return_value = {
-        "token": "uuid-1",
-        "count": ANONYMOUS_LIMIT,
-    }
-    svc = ProductPreviewUsageService()
-    allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
-    assert allowed is True
-    assert count == ANONYMOUS_LIMIT
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
+        mock_db.product_preview_usage.find_one.side_effect = [
+            {"token": "uuid-1", "count": ANONYMOUS_LIMIT - 1, "month_key": "2026-06"},
+        ]
+        mock_db.product_preview_usage.find_one_and_update.return_value = {
+            "token": "uuid-1",
+            "count": ANONYMOUS_LIMIT,
+            "month_key": "2026-06",
+        }
+        svc = ProductPreviewUsageService()
+        allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
+        assert allowed is True
+        assert count == ANONYMOUS_LIMIT
 
 
 @pytest.mark.asyncio
 async def test_blocks_over_limit(mock_db):
-    mock_db.product_preview_usage.find_one.return_value = {
-        "token": "uuid-1",
-        "count": ANONYMOUS_LIMIT,
-    }
-    svc = ProductPreviewUsageService()
-    allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
-    assert allowed is False
-    assert count == ANONYMOUS_LIMIT
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
+        mock_db.product_preview_usage.find_one.return_value = {
+            "token": "uuid-1",
+            "count": ANONYMOUS_LIMIT,
+            "month_key": "2026-06",
+        }
+        svc = ProductPreviewUsageService()
+        allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
+        assert allowed is False
+        assert count == ANONYMOUS_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_resets_count_on_new_month(mock_db):
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-07"):
+        mock_db.product_preview_usage.find_one.side_effect = [
+            {"token": "uuid-1", "count": ANONYMOUS_LIMIT, "month_key": "2026-06"},
+        ]
+        mock_db.product_preview_usage.find_one_and_update.return_value = {
+            "token": "uuid-1",
+            "count": 1,
+            "month_key": "2026-07",
+        }
+        svc = ProductPreviewUsageService()
+        allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
+
+    assert allowed is True
+    assert count == 1
+    mock_db.product_preview_usage.update_one.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -88,27 +112,47 @@ async def test_ip_fallback_when_no_token(mock_db):
 
 @pytest.mark.asyncio
 async def test_check_without_increment_allows_when_under_limit(mock_db):
-    mock_db.product_preview_usage.find_one.return_value = {
-        "token": "uuid-1",
-        "count": 2,
-    }
-    svc = ProductPreviewUsageService()
-    allowed, count = await svc.check_and_increment(
-        mock_db, token="uuid-1", ip="1.2.3.4", increment=False
-    )
-    assert allowed is True
-    assert count == 2
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
+        mock_db.product_preview_usage.find_one.return_value = {
+            "token": "uuid-1",
+            "count": 2,
+            "month_key": "2026-06",
+        }
+        svc = ProductPreviewUsageService()
+        allowed, count = await svc.check_and_increment(
+            mock_db, token="uuid-1", ip="1.2.3.4", increment=False
+        )
+        assert allowed is True
+        assert count == 2
 
 
 @pytest.mark.asyncio
 async def test_check_without_increment_blocks_when_at_limit(mock_db):
-    mock_db.product_preview_usage.find_one.return_value = {
-        "token": "uuid-1",
-        "count": ANONYMOUS_LIMIT,
-    }
-    svc = ProductPreviewUsageService()
-    allowed, count = await svc.check_and_increment(
-        mock_db, token="uuid-1", ip="1.2.3.4", increment=False
-    )
-    assert allowed is False
-    assert count == ANONYMOUS_LIMIT
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
+        mock_db.product_preview_usage.find_one.return_value = {
+            "token": "uuid-1",
+            "count": ANONYMOUS_LIMIT,
+            "month_key": "2026-06",
+        }
+        svc = ProductPreviewUsageService()
+        allowed, count = await svc.check_and_increment(
+            mock_db, token="uuid-1", ip="1.2.3.4", increment=False
+        )
+        assert allowed is False
+        assert count == ANONYMOUS_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_check_without_increment_resets_on_new_month(mock_db):
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-07"):
+        mock_db.product_preview_usage.find_one.return_value = {
+            "token": "uuid-1",
+            "count": ANONYMOUS_LIMIT,
+            "month_key": "2026-06",
+        }
+        svc = ProductPreviewUsageService()
+        allowed, count = await svc.check_and_increment(
+            mock_db, token="uuid-1", ip="1.2.3.4", increment=False
+        )
+        assert allowed is True
+        assert count == 0

--- a/packages/frontend/proxy.ts
+++ b/packages/frontend/proxy.ts
@@ -25,7 +25,6 @@ function parsePreviewViewCount(cookieValue: string | undefined): number {
     return 0;
   }
 
-  // Legacy cookies stored only a count — start fresh with monthly tracking.
   if (!cookieValue.includes(":")) {
     return 0;
   }

--- a/packages/frontend/proxy.ts
+++ b/packages/frontend/proxy.ts
@@ -10,8 +10,38 @@ const CRAWLER_UA =
 // /products/[slug] — anything under /products/ with at least one more segment
 const PRODUCT_DETAIL_RE = /^\/products\/[^/]+/;
 
-const FREE_PRODUCT_VIEWS = 5;
+const FREE_PRODUCT_VIEWS = 15;
 const PV_COOKIE = "__pv";
+
+function currentPreviewMonthKey(): string {
+  const now = new Date();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${now.getUTCFullYear()}-${month}`;
+}
+
+function parsePreviewViewCount(cookieValue: string | undefined): number {
+  const monthKey = currentPreviewMonthKey();
+  if (!cookieValue) {
+    return 0;
+  }
+
+  // Legacy cookies stored only a count — start fresh with monthly tracking.
+  if (!cookieValue.includes(":")) {
+    return 0;
+  }
+
+  const [storedMonth, countPart] = cookieValue.split(":", 2);
+  if (storedMonth !== monthKey) {
+    return 0;
+  }
+
+  const count = Number.parseInt(countPart ?? "0", 10);
+  return Number.isNaN(count) ? 0 : count;
+}
+
+function formatPreviewViewCookie(count: number): string {
+  return `${currentPreviewMonthKey()}:${count}`;
+}
 
 const isProtectedRoute = createRouteMatcher([
   "/dashboard(.*)",
@@ -52,8 +82,9 @@ const clerkProxy = clerkMiddleware(async (auth, request) => {
         request.headers.get("purpose") === "prefetch";
       if (isPrefetch) return NextResponse.next();
 
-      const raw = parseInt(request.cookies.get(PV_COOKIE)?.value ?? "0", 10);
-      const count = isNaN(raw) ? 0 : raw;
+      const count = parsePreviewViewCount(
+        request.cookies.get(PV_COOKIE)?.value,
+      );
 
       if (count >= FREE_PRODUCT_VIEWS) {
         const signInUrl = new URL("/sign-in", request.url);
@@ -62,7 +93,7 @@ const clerkProxy = clerkMiddleware(async (auth, request) => {
       }
 
       const response = NextResponse.next();
-      response.cookies.set(PV_COOKIE, String(count + 1), {
+      response.cookies.set(PV_COOKIE, formatPreviewViewCookie(count + 1), {
         httpOnly: true,
         sameSite: "lax",
         path: "/",


### PR DESCRIPTION
## Summary
- Increase anonymous product page preview limit from 5 to 15 visits per month.
- Reset preview usage on the first of each UTC calendar month in both the backend (`product_preview_usage`) and frontend middleware cookie.
- Legacy preview cookies without a month key start fresh under the new tracking format.

## Test plan
- [ ] As a signed-out visitor, open 15 different product report pages — all should load.
- [ ] On the 16th product page, confirm redirect to sign-in (frontend) or 429 on API (backend).
- [ ] Simulate a new month (or wait until the 1st) and confirm the count resets to 0.
- [ ] Run `uv run pytest tests/services/product_preview_usage_test.py`