### PR TITLE
improve(jazz): sharper, less noisy reviewer prompt

### DIFF
--- a/.github/jazz/workflows/code-review/WORKFLOW.md
+++ b/.github/jazz/workflows/code-review/WORKFLOW.md
@@ -163,6 +163,9 @@ Severity in comment bodies: **Critical** (blocks merge / user harm / security), 
 - **Performance**: stream large documents; bound memory; efficient MongoDB queries with indexes; pagination on list endpoints.
 - **Service layer**: business logic in services, not routes; testable units; no god functions.
 - **Maintainability**: prefer deletion over indirection; flag duplicate helpers, `any`-equivalent typing holes, and complexity moved but not removed.
+- **Test mock alignment**: when an implementation changes from multi-step operations (e.g. `find_one` + `update_one`) to an atomic call (e.g. `find_one_and_update`), verify that test mocks target the actual method now called. Mocks patching the old method silently pass while testing the wrong code path.
+- **Legacy data compatibility**: when a PR adds new enum values, status strings, or model fields, verify that all query paths and handler branches also handle existing documents in the DB that predate these additions. A handler correct for new records may silently misbehave on old ones.
+- **Hash/fingerprint migrations**: when a content fingerprint or hash computation changes (e.g. from plain text to markdown), flag that all existing hashes in the DB are now invalidated — deduplication and caching will break for existing records until they are re-processed. Note this explicitly in the verdict even if it is intentional.
 
 ### TypeScript (frontend + extension)
 
@@ -172,6 +175,7 @@ Severity in comment bodies: **Critical** (blocks merge / user harm / security), 
 - **Null safety**: optional chaining is not a substitute for explicit invariants; narrow before use.
 - **Generics**: use them where reuse would otherwise duplicate logic; avoid `Function` and overly wide generics.
 - **Imports**: prefer type-only imports; no unused exports; tree-shake friendly.
+- **Legacy status/enum handling**: when a PR adds new status values to a discriminated union or enum, check that **every** UI branch that renders on that value is updated — descriptions, headings, button conditions, ARIA labels. Also check whether legacy records in the DB can produce semantically equivalent states under a different field name or value (e.g. `allRobotsBlockedLegacy` vs `robots_blocked`) and that those are handled consistently everywhere the new status is handled.
 
 ### React 19
 
@@ -215,6 +219,25 @@ Severity in comment bodies: **Critical** (blocks merge / user harm / security), 
 - **Frontend**: bundle size; unnecessary client JS; waterfall requests; unbounded lists without virtualization; layout thrashing from animations.
 - **Backend**: N+1 queries; missing indexes; unbounded result sets; synchronous bottlenecks in hot paths.
 - **Core Web Vitals**: LCP, CLS, INP risks from the diff.
+
+### MongoDB queries (backend)
+
+Apply whenever the diff touches database query construction — in services, repositories, or scripts.
+
+- **Empty-list destructive queries**: any `$nin: [list]` or `$in: [list]` built from a runtime collection must guard against the empty-list case. `{"$nin": []}` matches **every document** — an empty `completed_ids` list will delete the entire collection. Always assert `if not list: return` or similar before executing the query.
+- **`to_list(length=N)` truncation**: `cursor.to_list(length=N)` with a fixed `N` silently drops results beyond `N`. If the result set can exceed `N` in production, flag it as a correctness bug — use async streaming (`async for doc in cursor`) or document why `N` is a safe upper bound.
+- **Missing indexes**: flag queries on fields without an index when the collection can be large; unindexed queries are full scans.
+- **Unbounded results**: any `find({})` or aggregate without a `$limit` on a collection that can grow unboundedly is a latent OOM risk.
+
+### One-off scripts and migration scripts (backend)
+
+One-off scripts (`scripts/`) and migration scripts get lighter review attention by default — apply **extra** scrutiny here precisely because they run once on production data with no second chance.
+
+- **Empty-input catastrophe**: what happens if the input cursor or ID list is empty? Check every `$in`, `$nin`, `delete_many`, `update_many` for the empty-list footgun.
+- **Partial failure handling**: if the script crashes halfway through, what is the DB state? Is re-running it safe (idempotent)? Flag if it is not.
+- **No dry-run mode**: destructive scripts that lack a `--dry-run` or equivalent preview mode should be flagged as Medium — operators cannot safely verify behavior before committing.
+- **Missing per-document error isolation**: scripts that iterate and mutate should wrap each iteration in `try/except` so one bad document does not abort the entire run.
+- **Unbounded `to_list` or `.find({})`**: same rules as MongoDB checklist apply, but more urgently — a script that OOMs at 10k documents is a production incident.
 
 ### Security
 

--- a/.github/jazz/workflows/code-review/WORKFLOW.md
+++ b/.github/jazz/workflows/code-review/WORKFLOW.md
@@ -22,6 +22,10 @@ Find behavior regressions, correctness bugs, security risks, bad error handling,
 6. **Best practices over local convention** — Apply authoritative standards for TypeScript, React, Next.js App Router, Tailwind CSS, Python/FastAPI, accessibility (WCAG 2.1 AA), performance, and security — even when they exceed current repo norms.
 7. **Look it up when uncertain** — Do not guess at best practices, security guidance, or framework APIs from memory alone. When stakes or doubt are real, fetch primary sources before asserting a recommendation.
 8. **Empty output is rare** — Return `[]` only when the diff is genuinely excellent after a thorough pass. When in doubt, comment.
+9. **Prefer the optimal call** — Always ask whether a more correct, atomic, or efficient operation exists. Prefer atomic DB writes over multi-step read-then-write sequences (they eliminate race windows). Prefer bulk/batch operations over N sequential round-trips. Prefer streaming cursors over collecting into memory. This is a correctness concern, not a style preference.
+10. **Reason through degenerate inputs** — For any operation that mutates, deletes, or filters based on collected state, reason explicitly through the degenerate cases: empty list, zero count, null field, first-run condition. Code correct for the happy path can silently corrupt or wipe data when its inputs are empty or missing.
+11. **Coverage completeness** — When a PR introduces a new state, value, error code, or code path, audit every place in the codebase that branches on that concept. Missing a branch is a silent bug that waits for a user to hit that state. This applies to both backend handler logic and frontend rendering branches.
+12. **Stored data has history** — New code runs against old data. When a PR changes any computed or stored value (a hash, an enum, a field name, a serialized format), reason about what existing records look like and whether the new code handles them correctly. Flag silent invalidation or backward-incompatibility even when it is intentional.
 
 Only skip a finding when you cannot articulate a concrete improvement or failure mode.
 
@@ -163,9 +167,7 @@ Severity in comment bodies: **Critical** (blocks merge / user harm / security), 
 - **Performance**: stream large documents; bound memory; efficient MongoDB queries with indexes; pagination on list endpoints.
 - **Service layer**: business logic in services, not routes; testable units; no god functions.
 - **Maintainability**: prefer deletion over indirection; flag duplicate helpers, `any`-equivalent typing holes, and complexity moved but not removed.
-- **Test mock alignment**: when an implementation changes from multi-step operations (e.g. `find_one` + `update_one`) to an atomic call (e.g. `find_one_and_update`), verify that test mocks target the actual method now called. Mocks patching the old method silently pass while testing the wrong code path.
-- **Legacy data compatibility**: when a PR adds new enum values, status strings, or model fields, verify that all query paths and handler branches also handle existing documents in the DB that predate these additions. A handler correct for new records may silently misbehave on old ones.
-- **Hash/fingerprint migrations**: when a content fingerprint or hash computation changes (e.g. from plain text to markdown), flag that all existing hashes in the DB are now invalidated — deduplication and caching will break for existing records until they are re-processed. Note this explicitly in the verdict even if it is intentional.
+- **Test accuracy**: tests must model what the implementation actually calls. When a refactor changes the call chain, mocks and assertions must follow — mocks patching the old path silently pass while testing nothing.
 
 ### TypeScript (frontend + extension)
 
@@ -175,7 +177,7 @@ Severity in comment bodies: **Critical** (blocks merge / user harm / security), 
 - **Null safety**: optional chaining is not a substitute for explicit invariants; narrow before use.
 - **Generics**: use them where reuse would otherwise duplicate logic; avoid `Function` and overly wide generics.
 - **Imports**: prefer type-only imports; no unused exports; tree-shake friendly.
-- **Legacy status/enum handling**: when a PR adds new status values to a discriminated union or enum, check that **every** UI branch that renders on that value is updated — descriptions, headings, button conditions, ARIA labels. Also check whether legacy records in the DB can produce semantically equivalent states under a different field name or value (e.g. `allRobotsBlockedLegacy` vs `robots_blocked`) and that those are handled consistently everywhere the new status is handled.
+- **Branch completeness**: when a PR adds new discriminated union members or enum values, audit every rendering branch — descriptions, headings, button states, ARIA labels — for completeness. Pay equal attention to any legacy representation of the same semantic state that can come from existing data in the DB.
 
 ### React 19
 
@@ -220,24 +222,24 @@ Severity in comment bodies: **Critical** (blocks merge / user harm / security), 
 - **Backend**: N+1 queries; missing indexes; unbounded result sets; synchronous bottlenecks in hot paths.
 - **Core Web Vitals**: LCP, CLS, INP risks from the diff.
 
-### MongoDB queries (backend)
+### Database call quality (backend)
 
-Apply whenever the diff touches database query construction — in services, repositories, or scripts.
+Apply whenever the diff touches query construction, repositories, or scripts.
 
-- **Empty-list destructive queries**: any `$nin: [list]` or `$in: [list]` built from a runtime collection must guard against the empty-list case. `{"$nin": []}` matches **every document** — an empty `completed_ids` list will delete the entire collection. Always assert `if not list: return` or similar before executing the query.
-- **`to_list(length=N)` truncation**: `cursor.to_list(length=N)` with a fixed `N` silently drops results beyond `N`. If the result set can exceed `N` in production, flag it as a correctness bug — use async streaming (`async for doc in cursor`) or document why `N` is a safe upper bound.
-- **Missing indexes**: flag queries on fields without an index when the collection can be large; unindexed queries are full scans.
-- **Unbounded results**: any `find({})` or aggregate without a `$limit` on a collection that can grow unboundedly is a latent OOM risk.
+- **Prefer atomic over multi-step**: read-then-write sequences have race windows; prefer atomic operations when they exist.
+- **Prefer bulk over sequential**: N individual round-trips should be a batch query; flag loops that query inside them.
+- **Prefer streaming over in-memory collection**: gathering an unbounded cursor into a list is a latent OOM; prefer async iteration.
+- **Reason through degenerate inputs**: for any filter or ID list built at runtime, ask what happens when it is empty — an underspecified filter on a write or delete can affect unintended documents. Apply the same question to fixed-size limits: what happens when the real result set exceeds the cap?
+- **Missing indexes**: flag queries on fields without an index on collections that can grow; unindexed queries are full scans.
 
-### One-off scripts and migration scripts (backend)
+### Scripts and migrations (backend)
 
-One-off scripts (`scripts/`) and migration scripts get lighter review attention by default — apply **extra** scrutiny here precisely because they run once on production data with no second chance.
+One-off scripts (`scripts/`) run once on production data with no safety net. Apply the same rigor as production code — or more.
 
-- **Empty-input catastrophe**: what happens if the input cursor or ID list is empty? Check every `$in`, `$nin`, `delete_many`, `update_many` for the empty-list footgun.
-- **Partial failure handling**: if the script crashes halfway through, what is the DB state? Is re-running it safe (idempotent)? Flag if it is not.
-- **No dry-run mode**: destructive scripts that lack a `--dry-run` or equivalent preview mode should be flagged as Medium — operators cannot safely verify behavior before committing.
-- **Missing per-document error isolation**: scripts that iterate and mutate should wrap each iteration in `try/except` so one bad document does not abort the entire run.
-- **Unbounded `to_list` or `.find({})`**: same rules as MongoDB checklist apply, but more urgently — a script that OOMs at 10k documents is a production incident.
+- **Degenerate-input safety**: reason through what happens when collections are empty, IDs are missing, or filters match more than expected. A bug that corrupts 1 of 1000 documents in production code is bad; the same bug in a migration script is worse because it runs at scale before anyone notices.
+- **Idempotency**: if the script crashes halfway, re-running it should be safe. Flag if it is not.
+- **Error isolation**: one bad document should not abort the entire run; wrap per-item mutations.
+- **Dry-run mode**: destructive scripts without a preview or dry-run mode cannot be safely verified before execution.
 
 ### Security
 
@@ -360,11 +362,14 @@ The diff meets ambitious standards: behavior matches intent, types are strict, a
 5. Did every comment include severity, concrete lines, and a concrete fix or best practice?
 6. Did you only run checklists for areas actually touched by the diff?
 7. For large or specialized diffs, did you spawn subagents (batch or expert) instead of stopping at a shallow pass? Did you reconcile subagent findings into one consistent view?
-8. Did you emit exactly two blocks in order: `markdown`, then `json`?
-9. Did both outer blocks use four backticks?
-10. Did you avoid any trailing output after the JSON block?
-11. Are there any "no issues" category lines in the verdict (outside "Checked clean")? Remove them.
-12. Is every JSON comment's `line` confirmed to be in the diff hunk? Non-anchorable findings must be in the verdict markdown only.
+8. For every DB write, delete, or bulk operation — did you reason through what happens with degenerate inputs?
+9. For every new state, value, or code path introduced — did you audit that all branches that depend on it are complete?
+10. For any changed stored value or computation — did you reason about backward compatibility with existing data?
+11. Did you emit exactly two blocks in order: `markdown`, then `json`?
+12. Did both outer blocks use four backticks?
+13. Did you avoid any trailing output after the JSON block?
+14. Are there any "no issues" category lines in the verdict (outside "Checked clean")? Remove them.
+15. Is every JSON comment's `line` confirmed to be in the diff hunk? Non-anchorable findings must be in the verdict markdown only.
 
 ## Inline Comment Line Accuracy (critical)
 

--- a/.github/jazz/workflows/code-review/WORKFLOW.md
+++ b/.github/jazz/workflows/code-review/WORKFLOW.md
@@ -79,10 +79,12 @@ Use `http_request` to consult authoritative sources when you are not confident i
 
 1. **Load intent and prior discussion**
    - Read `/tmp/jazz-pr-context.json` when available.
-   - Extract intended product behavior and already-reported issues.
+   - Extract the PR's intended behavior from `title` and `body`.
+   - Extract already-reported issues from the `reviews` array. Identify which reviews come from `github-actions[bot]` (prior Jazz runs) and which are from humans. Build a deduplicated list of open issues — both Jazz-raised and human-raised. You will skip re-reporting these in Step 8.
 
 2. **Load full change scope**
    - `git_diff` with `nameOnly: true` to get all changed files.
+   - Classify the diff by area: backend-only, frontend-only, mixed, extension, infra. This determines which checklists (Step 6) apply.
    - Read diff content for all files (batched if large).
 
 3. **Read beyond hunks when needed**
@@ -100,19 +102,28 @@ Use `http_request` to consult authoritative sources when you are not confident i
    - Are normal paths and failure paths both coherent?
    - Could this degrade Clausea's document analysis quality or UX in real usage?
 
-6. **Run engineering quality check by area** (see detailed checklists below)
+6. **Run engineering quality check by area**
+   - Only run checklists for areas the diff actually touches. A backend-only diff does not get Tailwind or Next.js RSC checks. A copy-update diff does not get Python async checks.
+   - See detailed checklists below.
 
 7. **Spawn expert subagents when warranted**
    - Large PR → batch parallelism (see Parallel and Expert Subagents).
    - Specialized diff → delegate to a focused reviewer for that domain before finalizing.
    - If you skipped delegation and the diff clearly needed it, you did not finish the review.
+   - **After subagents complete:** reconcile all findings into one unified view before emitting. Resolve any conflicting severity ratings — the final verdict must be a single authoritative assessment. Do not repeat the same finding from multiple subagents.
 
 8. **De-duplicate and calibrate**
-   - Do not repeat issues already clearly raised in human review comments unless unresolved and still important.
+   - Cross-reference every finding against the list of already-reported issues (built in Step 1).
+   - **Skip any finding that was already clearly raised** in a prior Jazz review or human comment, unless it was marked resolved but the code still shows the problem.
+   - When a prior finding remains unresolved and important, mention it once in the verdict: _"Prior finding still unresolved: [brief description]"_ — do not re-file it as a new inline comment.
    - Keep findings that have concrete improvement paths — including maintainability, typing, a11y, and performance.
 
-9. **Emit final output in required format**
-   - Exactly two fenced blocks in the required order (see Output Format).
+9. **Validate all inline comment line numbers before emitting**
+   - For every finding you intend to include in the JSON array, verify the `line` number appears in the diff hunk for that file (see "Inline Comment Line Accuracy" below).
+   - **If the line is not in the diff:** include the finding in the verdict markdown only (not in the JSON). Use the compact format: `- **path/to/file:NN** — **[Severity]**: [finding body]`. Do not create a separate `### Comments on lines outside the diff` section — fold these directly into the verdict under the relevant finding category.
+
+10. **Emit final output in required format**
+    - Exactly two fenced blocks in the required order (see Output Format).
 
 ### Parallel and Expert Subagents
 
@@ -139,7 +150,9 @@ When delegating:
 
 ## Engineering Quality Checklists
 
-Apply **all** relevant sections. Severity in comment bodies: **Critical** (blocks merge / user harm / security), **High** (real bug or significant debt), **Medium** (clear improvement), **Low** (still worth fixing if diff touches it).
+Apply **only the sections relevant to the diff**. If the changed files are backend-only, skip TypeScript, React, Next.js, Tailwind, and extension checklists. If the changed files are frontend-only, skip Python and MongoDB checklists. Use judgment — a mixed PR applies all relevant sections.
+
+Severity in comment bodies: **Critical** (blocks merge / user harm / security), **High** (real bug or significant debt), **Medium** (clear improvement), **Low** (still worth fixing if diff touches it).
 
 ### Python (backend)
 
@@ -226,6 +239,7 @@ A valid finding does **not**:
 - dismiss issues because existing code does the same thing
 - hide behind "style preference" when a named best practice applies
 - speculate without a reachable failure mode or improvement path
+- repeat an issue already clearly raised by a prior Jazz review or human comment
 
 ## Output Format (strict)
 
@@ -238,14 +252,26 @@ No text before, between, or after those blocks.
 
 ### Block 1: Markdown verdict (required, non-empty)
 
-This is a review verdict, not a PR summary.
+Structure the verdict as follows — in this order:
 
-Must include:
+```
+**[N] files reviewed** | **[area]**: backend / frontend / mixed / extension
 
-- files reviewed (count or short list)
-- overall quality assessment (strict — "acceptable" requires justification)
-- what you found (or a clear "excellent" verdict with what you verified)
-- categories checked (correctness, security, TypeScript, Next.js/RSC, Tailwind, a11y, performance)
+**Merge readiness**: LGTM | SOFT BLOCK | NEEDS WORK
+
+[If SOFT BLOCK or NEEDS WORK: bulleted list of findings by severity]
+[If any non-anchorable findings: inline as "- **path/file.py:NN** — **Severity**: ..."]
+[If any prior findings still open: "Prior finding unresolved: [brief]"]
+
+**Checked clean**: [comma-separated list of areas with no issues found — only areas that were checked]
+```
+
+**Merge readiness** definitions:
+- **LGTM** — no issues found; the diff meets ambitious standards
+- **SOFT BLOCK** — Medium/Low issues only; mergeable after author review, not a hard blocker
+- **NEEDS WORK** — one or more Critical or High issues found; should not merge until resolved
+
+**Do not** list per-category "No issues" lines for areas without findings. Do not include boilerplate like "Tailwind/Styling: No issues — uses existing design tokens." Fold all clean areas into the single "Checked clean" line at the end. If a checklist section was not applicable to this diff (e.g. no frontend files changed), omit it from "Checked clean" entirely.
 
 ### Block 2: JSON inline comments (required, may be empty)
 
@@ -263,9 +289,17 @@ Outer fences must use four backticks to avoid collisions with triple-backtick sn
 
 ### Example (issues found)
 
-```markdown
-Reviewed 4 files. Found 3 issues: one Critical async I/O bug in document parsing, one High unnecessary `"use client"` boundary, and one Medium Tailwind token bypass using hardcoded colors instead of `@theme` variables.
-```
+````markdown
+**4 files reviewed** | **area**: mixed (backend + frontend)
+
+**Merge readiness**: NEEDS WORK
+
+- **Critical** — `packages/backend/src/services/document_service.py:42`: can throw when `document` is None in the retry path (see inline comment)
+- **High** — `packages/frontend/app/page.tsx:18`: unnecessary `"use client"` boundary causes full subtree to hydrate on the client
+- **packages/backend/src/routes/paddle.py:60** — **High**: `subscription.get("started_at").replace(...)` raises `AttributeError` when the field is absent; use `_parse_paddle_datetime` instead
+
+**Checked clean**: correctness (normal paths), TypeScript, a11y, performance
+````
 
 ````json
 [
@@ -280,9 +314,15 @@ Reviewed 4 files. Found 3 issues: one Critical async I/O bug in document parsing
 
 ### Example (no issues)
 
-```markdown
-Reviewed 6 files. The diff meets ambitious standards: behavior matches intent, types are strict, RSC/client boundaries are correct, Tailwind uses design tokens, and a11y attributes are present on interactive elements. Verified call sites, error paths, and security boundaries. No issues found.
-```
+````markdown
+**6 files reviewed** | **area**: backend
+
+**Merge readiness**: LGTM
+
+The diff meets ambitious standards: behavior matches intent, types are strict, async hygiene is correct, MongoDB queries use existing indexes, and error paths are coherent.
+
+**Checked clean**: correctness, Python async, error handling, security, performance, MongoDB
+````
 
 ```json
 []
@@ -291,21 +331,24 @@ Reviewed 6 files. The diff meets ambitious standards: behavior matches intent, t
 ## Self-check Before Emitting
 
 1. Did you prioritize intent and behavior, not feature description?
-2. Did you challenge weak patterns instead of deferring to existing code?
-3. For unfamiliar patterns or "better practice" recommendations, did you verify against authoritative sources when doubt remained?
-4. Did every comment include severity, concrete lines, and a concrete fix or best practice?
-5. Did you run the TypeScript, Next.js, Tailwind, React, a11y, performance, and security checklists for touched areas?
-6. For large or specialized diffs, did you spawn subagents (batch or expert) instead of stopping at a shallow pass?
-7. Did you emit exactly two blocks in order: `markdown`, then `json`?
-8. Did both outer blocks use four backticks?
-9. Did you avoid any trailing output after the JSON block?
+2. Did you check prior Jazz reviews and human comments and skip already-reported issues?
+3. Did you challenge weak patterns instead of deferring to existing code?
+4. For unfamiliar patterns or "better practice" recommendations, did you verify against authoritative sources when doubt remained?
+5. Did every comment include severity, concrete lines, and a concrete fix or best practice?
+6. Did you only run checklists for areas actually touched by the diff?
+7. For large or specialized diffs, did you spawn subagents (batch or expert) instead of stopping at a shallow pass? Did you reconcile subagent findings into one consistent view?
+8. Did you emit exactly two blocks in order: `markdown`, then `json`?
+9. Did both outer blocks use four backticks?
+10. Did you avoid any trailing output after the JSON block?
+11. Are there any "no issues" category lines in the verdict (outside "Checked clean")? Remove them.
+12. Is every JSON comment's `line` confirmed to be in the diff hunk? Non-anchorable findings must be in the verdict markdown only.
 
 ## Inline Comment Line Accuracy (critical)
 
-GitHub rejects comments on lines not present in diff hunks.
+GitHub rejects comments on lines not present in diff hunks. A comment placed on a wrong line fails silently and wastes reviewer attention.
 
-Before outputting each comment:
+**Before including any comment in the JSON array:**
 
-1. Confirm `line` exists in the diff hunk.
+1. Run `git_diff` for the specific file and confirm the `line` number appears in a `@@` hunk.
 2. Prefer commenting on changed (`+`) lines when possible.
-3. If relevant code is outside hunks, attach to the nearest valid line in the hunk and explain context in `body`.
+3. If the relevant code is outside the diff (context lines, unchanged functions, other files): **do not include it in the JSON.** Instead, put the finding in the verdict markdown as `- **path/file.py:NN** — **Severity**: [body]`. Do not create a `### Comments on lines outside the diff` section — that pattern creates a confusing duplicate structure in the review body. Just put it in the verdict inline with your other findings.

--- a/.github/jazz/workflows/code-review/WORKFLOW.md
+++ b/.github/jazz/workflows/code-review/WORKFLOW.md
@@ -280,12 +280,12 @@ No text before, between, or after those blocks.
 Structure the verdict as follows — in this order:
 
 ```
-**[N] files reviewed** | **[area]**: backend / frontend / mixed / extension
+**[N] files reviewed** | **area**: [backend / frontend / mixed / extension]
 
 **Merge readiness**: LGTM | SOFT BLOCK | NEEDS WORK
 
 [If SOFT BLOCK or NEEDS WORK: bulleted list of findings by severity]
-[If any non-anchorable findings: inline as "- **path/file.py:NN** — **Severity**: ..."]
+[If any non-anchorable findings: inline as "- **path/file.py:NN** — **[Severity]**: ..."]
 [If any prior findings still open: "Prior finding unresolved: [brief]"]
 
 **Checked clean**: [comma-separated list of areas with no issues found — only areas that were checked]
@@ -319,8 +319,8 @@ Outer fences must use four backticks to avoid collisions with triple-backtick sn
 
 **Merge readiness**: NEEDS WORK
 
-- **Critical** — `packages/backend/src/services/document_service.py:42`: can throw when `document` is None in the retry path (see inline comment)
-- **High** — `packages/frontend/app/page.tsx:18`: unnecessary `"use client"` boundary causes full subtree to hydrate on the client
+- **packages/backend/src/services/document_service.py:42** — **Critical**: can throw when `document` is None in the retry path (see inline comment)
+- **packages/frontend/app/page.tsx:18** — **High**: unnecessary `"use client"` boundary causes full subtree to hydrate on the client
 - **packages/backend/src/routes/paddle.py:60** — **High**: `subscription.get("started_at").replace(...)` raises `AttributeError` when the field is absent; use `_parse_paddle_datetime` instead
 
 **Checked clean**: correctness (normal paths), TypeScript, a11y, performance
@@ -377,6 +377,6 @@ GitHub rejects comments on lines not present in diff hunks. A comment placed on 
 
 **Before including any comment in the JSON array:**
 
-1. Run `git_diff` for the specific file and confirm the `line` number appears in a `@@` hunk.
+1. Confirm the `line` number appears in a `@@` hunk in the already-loaded diff content — do not re-run `git_diff`.
 2. Prefer commenting on changed (`+`) lines when possible.
-3. If the relevant code is outside the diff (context lines, unchanged functions, other files): **do not include it in the JSON.** Instead, put the finding in the verdict markdown as `- **path/file.py:NN** — **Severity**: [body]`. Do not create a `### Comments on lines outside the diff` section — that pattern creates a confusing duplicate structure in the review body. Just put it in the verdict inline with your other findings.
+3. If the relevant code is outside the diff (context lines, unchanged functions, other files): **do not include it in the JSON.** Instead, put the finding in the verdict markdown as `- **path/file.py:NN** — **[Severity]**: [body]`. Do not create a `### Comments on lines outside the diff` section — that pattern creates a confusing duplicate structure in the review body. Just put it in the verdict inline with your other findings.


### PR DESCRIPTION
## Summary

Analysis of the last 20 PRs revealed 6 systematic problems with the Jazz reviewer prompt. This PR fixes all of them.

## What was wrong (evidence from PRs #164–#188)

### 1. Repeated findings on every push (most impactful)
Prior Jazz reviews were not explicitly checked, so the same issues were re-filed on every synchronize event. PR #180 had 4 Jazz reviews all flagging the same Critical gap. PR #164 accumulated 11 reviews in 56 minutes. Jazz now reads `github-actions[bot]` reviews from `/tmp/jazz-pr-context.json` and explicitly skips already-reported open issues — tracking them as "Prior finding unresolved: …" instead.

### 2. `### Comments on lines outside the diff` anti-pattern
High-severity findings that couldn't be placed as inline comments were being dumped into a confusing `### Comments on lines outside the diff` section within the review body. This looked like a list of failed inline comments rather than readable findings. Jazz now places non-anchorable findings directly in the verdict markdown as `- **path/file.py:NN** — Severity: body`, and the section header is explicitly forbidden.

### 3. Per-category "no issues" boilerplate
Every review listed "Tailwind/Styling: No issues — uses existing design tokens" and "Performance: No issues" even on Python-only diffs. On a backend-only PR, TypeScript/React/Tailwind/a11y checklists are now skipped entirely. All clean areas are folded into a single `**Checked clean**: X, Y, Z` line at the end.

### 4. Checklist scope bleed
Checklists were applied to every PR regardless of what changed. Now: classify the diff area (backend / frontend / mixed / extension) immediately after loading the file list, and only run checklists for areas actually touched.

### 5. Subagent inconsistency on large PRs
Parallel batch subagents produced conflicting severity ratings on the same issue. PR #164 had one review call something "Critical auth bypass" and another mark the same code as sound. Added an explicit reconciliation step: after all subagents complete, resolve conflicts before emitting — the final verdict must be a single authoritative assessment.

### 6. No merge readiness signal
Jazz never indicated whether a PR should be held. Developers had no quick way to tell if Jazz found anything blocking. Every verdict now includes a `**Merge readiness**: LGTM | SOFT BLOCK | NEEDS WORK` line with clear definitions.

## Changes

Single file changed: `.github/jazz/workflows/code-review/WORKFLOW.md`

- **Mandatory review flow step 1**: explicitly extract and index prior Jazz + human reviews from the PR context
- **Step 2**: classify diff area immediately after loading files
- **Step 6**: scope checklists to diff area only
- **Step 7**: add subagent reconciliation requirement
- **Step 8**: rewrite deduplication to cover prior Jazz reviews, not just human comments
- **New step 9**: validate all JSON line numbers before emitting; route non-anchorable findings to verdict markdown
- **Output Format**: replace freeform summary with a structured template (files | area | merge readiness | findings | checked clean)
- **Self-check**: added checks for prior-review deduplication, checklist scoping, subagent reconciliation, and "no issues" boilerplate removal
- **Inline Comment Line Accuracy**: tightened wording; explicitly forbid `### Comments on lines outside the diff`; redirect to verdict inline

## Test plan

- [ ] Trigger Jazz on a backend-only PR and verify no Tailwind/Next.js/a11y checklist items appear
- [ ] Trigger Jazz on a PR that had a prior Jazz review and verify already-reported issues are not re-filed
- [ ] Verify the verdict includes `**Merge readiness**` on every review
- [ ] Verify no `### Comments on lines outside the diff` section appears in any new review