### PR TITLE
feat(overview): retry LLM synthesis when validation guards reject draft

### DIFF
--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -2083,204 +2083,244 @@ Per-document analyses and extractions:
     if on_progress is not None:
         await _maybe_await(on_progress())
 
+    from src.analyzers.llm_review import llm_review_overview
+    from src.analyzers.overview_guards import (
+        MAX_OVERVIEW_RE_ROLLS,
+        OverviewValidationResult,
+        _collect_citations,
+        format_overview_retry_feedback,
+        merge_llm_review,
+        validate_overview,
+    )
+    from src.services.thin_evidence_gate import check_thin_evidence
+    from src.services.topic_evidence_fallback import attach_fallback_evidence
+
+    is_thin, thin_reason = check_thin_evidence(
+        [d.doc_type for d in core_docs if d.doc_type in OVERVIEW_CORE_DOC_TYPES]
+    )
+    if is_thin:
+        logger.warning(
+            "Thin evidence for %s: %s — overview may be incomplete",
+            product_slug,
+            thin_reason,
+        )
+
     try:
         async with usage_tracking(tracker_callback):
-            # Wrap the LLM call in a cancellable task
-            llm_task = asyncio.create_task(
-                acompletion_with_fallback(
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": PRODUCT_OVERVIEW_PROMPT,
-                        },
-                        {"role": "user", "content": prompt},
-                    ],
-                    model_priority=_OVERVIEW_PRIORITY,
-                    response_format={"type": "json_object"},
-                    temperature=0,
-                    heartbeat_callback=on_progress,
+            feedback_suffix = ""
+            meta_summary: MetaSummary | None = None
+            validation: OverviewValidationResult | None = None
+
+            for attempt in range(1, MAX_OVERVIEW_RE_ROLLS + 1):
+                if attempt > 1:
+                    logger.info(
+                        "Regenerating overview for %s after validation feedback (attempt %d/%d)",
+                        product_slug,
+                        attempt,
+                        MAX_OVERVIEW_RE_ROLLS,
+                    )
+                    await token.check_cancellation()
+                    if on_progress is not None:
+                        await _maybe_await(on_progress())
+
+                user_content = prompt + feedback_suffix
+
+                # Wrap the LLM call in a cancellable task
+                llm_task = asyncio.create_task(
+                    acompletion_with_fallback(
+                        messages=[
+                            {
+                                "role": "system",
+                                "content": PRODUCT_OVERVIEW_PROMPT,
+                            },
+                            {"role": "user", "content": user_content},
+                        ],
+                        model_priority=_OVERVIEW_PRIORITY,
+                        response_format={"type": "json_object"},
+                        temperature=0,
+                        heartbeat_callback=on_progress,
+                    )
                 )
-            )
 
-            # Wait for either completion or cancellation
-            cancellation_task = asyncio.create_task(token.cancelled.wait())
-            done, pending = await asyncio.wait(
-                [llm_task, cancellation_task],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-
-            # Cancel pending tasks
-            for pending_task in pending:
-                pending_task.cancel()
-                try:
-                    await pending_task
-                except asyncio.CancelledError:
-                    pass
-
-            # If cancellation was requested, cancel the LLM task
-            if token.is_cancelled():
-                llm_task.cancel()
-                try:
-                    await llm_task
-                except asyncio.CancelledError:
-                    pass
-                raise asyncio.CancelledError("Meta-summary generation cancelled")
-
-            # Get the response
-            response = await llm_task
-
-        choice = response.choices[0]
-        # Non-streaming responses always have message attribute
-        if not hasattr(choice, "message"):
-            raise ValueError("Unexpected response format: missing message attribute")
-        message = choice.message  # type: ignore[attr-defined]
-        if not message:
-            raise ValueError("Unexpected response format: message is None")
-        content = message.content  # type: ignore[attr-defined]
-        if not content:
-            raise ValueError("Empty response from LLM")
-
-        logger.debug(content)
-
-        # Parse the product overview
-        overview_dict = json.loads(content)
-        _merge_legacy_dimension_justifications(overview_dict)
-
-        # Parse contradictions before model validation
-        raw_contradictions = overview_dict.pop("contradictions", None)
-
-        meta_summary = MetaSummary.model_validate(overview_dict, strict=False)
-        meta_summary.coverage = hydrated_rollup.coverage
-        if meta_summary.dangers:
-            meta_summary.dangers = await filter_danger_strings_llm(meta_summary.dangers)
-
-        # Attach contradictions
-        if isinstance(raw_contradictions, list):
-            try:
-                meta_summary.contradictions = [
-                    ProductContradiction.model_validate(c)
-                    for c in raw_contradictions
-                    if isinstance(c, dict)
-                ]
-            except Exception as e:
-                logger.warning(f"Failed to parse contradictions: {e}")
-
-        # Attach deterministic topic stances used for both UI explainability and scoring.
-        meta_summary.topic_stances = []
-        for topic in topic_report.topics:
-            cited_document_ids: set[str] = set()
-            evidence_count = 0
-            for finding in topic.findings:
-                cited_document_ids.update(finding.document_ids)
-                evidence_count += len(finding.citations)
-            for conflict in topic.conflicts:
-                cited_document_ids.update(conflict.document_ids)
-                evidence_count += len(conflict.citations)
-            primary_finding = _headline_finding_for_topic(topic)
-            primary_conflict = topic.conflicts[0] if topic.conflicts else None
-            supporting_citations = _topic_supporting_citations(topic)
-            if primary_finding and primary_finding.value:
-                headline_claim = _truncate_text(primary_finding.value)
-            elif primary_conflict and primary_conflict.description:
-                headline_claim = _truncate_text(primary_conflict.description)
-            elif topic.status in {"missing", "not_disclosed"}:
-                headline_claim = "No verifiable disclosure found across analyzed documents."
-            else:
-                headline_claim = None
-
-            meta_summary.topic_stances.append(
-                TopicStanceBreakdown(
-                    topic=topic.topic,
-                    status=topic.status,
-                    stance=topic.stance,
-                    topic_score=topic.topic_score,
-                    rationale=topic.rationale,
-                    rationale_key=topic.rationale_key,
-                    rationale_params=topic.rationale_params,
-                    evidence_count=evidence_count,
-                    document_count=len(cited_document_ids),
-                    headline_claim=headline_claim,
-                    supporting_citations=supporting_citations,
-                    conflict_note=_truncate_text(
-                        primary_conflict.description if primary_conflict else None
-                    ),
-                    why_it_matters=_topic_why_it_matters(
-                        topic=str(topic.topic),
-                        status=str(topic.status),
-                        stance=str(topic.stance),
-                        conflict_count=len(topic.conflicts),
-                    ),
-                    recommended_action=_topic_recommended_action(
-                        topic=str(topic.topic),
-                        status=str(topic.status),
-                        stance=str(topic.stance),
-                    ),
+                # Wait for either completion or cancellation
+                cancellation_task = asyncio.create_task(token.cancelled.wait())
+                done, pending = await asyncio.wait(
+                    [llm_task, cancellation_task],
+                    return_when=asyncio.FIRST_COMPLETED,
                 )
-            )
 
-        topic_rows: dict[InsightCategory, dict[str, Any]] = {
-            topic.topic: {
-                "status": topic.status,
-                "topic_score": topic.topic_score,
-            }
-            for topic in topic_report.topics
-        }
-        topic_blended = compose_product_risk_from_topics(topic_rows)
-        legacy_blended = _weighted_product_risk_score(core_docs)
-        dimension_risk = _calculate_overview_risk_score(meta_summary.scores)
-        if legacy_blended is not None:
-            logger.info(
-                "overview scoring comparison for %s: legacy_doc=%s topic=%s dimension=%s",
-                product_slug,
-                legacy_blended,
-                topic_blended,
-                dimension_risk,
-            )
-        else:
-            logger.info(
-                "overview scoring comparison for %s: topic=%s dimension=%s",
-                product_slug,
-                topic_blended,
-                dimension_risk,
-            )
+                # Cancel pending tasks
+                for pending_task in pending:
+                    pending_task.cancel()
+                    try:
+                        await pending_task
+                    except asyncio.CancelledError:
+                        pass
 
-        _reconcile_meta_summary_risk(meta_summary)
+                # If cancellation was requested, cancel the LLM task
+                if token.is_cancelled():
+                    llm_task.cancel()
+                    try:
+                        await llm_task
+                    except asyncio.CancelledError:
+                        pass
+                    raise asyncio.CancelledError("Meta-summary generation cancelled")
 
-        from src.analyzers.llm_review import llm_review_overview
-        from src.analyzers.overview_guards import merge_llm_review, validate_overview
-        from src.services.thin_evidence_gate import check_thin_evidence
-        from src.services.topic_evidence_fallback import attach_fallback_evidence
+                # Get the response
+                response = await llm_task
 
-        is_thin, thin_reason = check_thin_evidence(
-            [d.doc_type for d in core_docs if d.doc_type in OVERVIEW_CORE_DOC_TYPES]
-        )
-        if is_thin:
-            logger.warning(
-                "Thin evidence for %s: %s — overview may be incomplete",
-                product_slug,
-                thin_reason,
-            )
+                choice = response.choices[0]
+                # Non-streaming responses always have message attribute
+                if not hasattr(choice, "message"):
+                    raise ValueError("Unexpected response format: missing message attribute")
+                message = choice.message  # type: ignore[attr-defined]
+                if not message:
+                    raise ValueError("Unexpected response format: message is None")
+                content = message.content  # type: ignore[attr-defined]
+                if not content:
+                    raise ValueError("Empty response from LLM")
 
-        if meta_summary.topic_stances:
-            attached = await attach_fallback_evidence(meta_summary.topic_stances, core_docs)
-            if attached:
-                logger.info("Attached %d fallback citations to %s", attached, product_slug)
+                logger.debug(content)
 
-        overview_dict = meta_summary.model_dump(mode="json")
-        deterministic = validate_overview(overview_dict, has_adequate_evidence=not is_thin)
+                # Parse the product overview
+                overview_dict = json.loads(content)
+                _merge_legacy_dimension_justifications(overview_dict)
 
-        from src.analyzers.overview_guards import _collect_citations
+                # Parse contradictions before model validation
+                raw_contradictions = overview_dict.pop("contradictions", None)
 
-        citations_for_review = _collect_citations(overview_dict.get("topic_stances") or [])
-        llm_result = await llm_review_overview(overview_dict, citations_for_review)
-        validation = merge_llm_review(deterministic, llm_result)
+                meta_summary = MetaSummary.model_validate(overview_dict, strict=False)
+                meta_summary.coverage = hydrated_rollup.coverage
+                if meta_summary.dangers:
+                    meta_summary.dangers = await filter_danger_strings_llm(meta_summary.dangers)
 
-        if validation.should_re_roll:
-            reasons = "; ".join(validation.re_roll_reasons)
-            logger.warning("Overview validation failed for %s: %s", product_slug, reasons)
-            raise ValueError(f"Overview validation failed for {product_slug}: {reasons}")
-        for warning in validation.warnings:
-            logger.info("Overview warning for %s: %s", product_slug, warning)
+                # Attach contradictions
+                if isinstance(raw_contradictions, list):
+                    try:
+                        meta_summary.contradictions = [
+                            ProductContradiction.model_validate(c)
+                            for c in raw_contradictions
+                            if isinstance(c, dict)
+                        ]
+                    except Exception as e:
+                        logger.warning(f"Failed to parse contradictions: {e}")
+
+                # Attach deterministic topic stances used for both UI explainability and scoring.
+                meta_summary.topic_stances = []
+                for topic in topic_report.topics:
+                    cited_document_ids: set[str] = set()
+                    evidence_count = 0
+                    for finding in topic.findings:
+                        cited_document_ids.update(finding.document_ids)
+                        evidence_count += len(finding.citations)
+                    for conflict in topic.conflicts:
+                        cited_document_ids.update(conflict.document_ids)
+                        evidence_count += len(conflict.citations)
+                    primary_finding = _headline_finding_for_topic(topic)
+                    primary_conflict = topic.conflicts[0] if topic.conflicts else None
+                    supporting_citations = _topic_supporting_citations(topic)
+                    if primary_finding and primary_finding.value:
+                        headline_claim = _truncate_text(primary_finding.value)
+                    elif primary_conflict and primary_conflict.description:
+                        headline_claim = _truncate_text(primary_conflict.description)
+                    elif topic.status in {"missing", "not_disclosed"}:
+                        headline_claim = "No verifiable disclosure found across analyzed documents."
+                    else:
+                        headline_claim = None
+
+                    meta_summary.topic_stances.append(
+                        TopicStanceBreakdown(
+                            topic=topic.topic,
+                            status=topic.status,
+                            stance=topic.stance,
+                            topic_score=topic.topic_score,
+                            rationale=topic.rationale,
+                            rationale_key=topic.rationale_key,
+                            rationale_params=topic.rationale_params,
+                            evidence_count=evidence_count,
+                            document_count=len(cited_document_ids),
+                            headline_claim=headline_claim,
+                            supporting_citations=supporting_citations,
+                            conflict_note=_truncate_text(
+                                primary_conflict.description if primary_conflict else None
+                            ),
+                            why_it_matters=_topic_why_it_matters(
+                                topic=str(topic.topic),
+                                status=str(topic.status),
+                                stance=str(topic.stance),
+                                conflict_count=len(topic.conflicts),
+                            ),
+                            recommended_action=_topic_recommended_action(
+                                topic=str(topic.topic),
+                                status=str(topic.status),
+                                stance=str(topic.stance),
+                            ),
+                        )
+                    )
+
+                topic_rows: dict[InsightCategory, dict[str, Any]] = {
+                    topic.topic: {
+                        "status": topic.status,
+                        "topic_score": topic.topic_score,
+                    }
+                    for topic in topic_report.topics
+                }
+                topic_blended = compose_product_risk_from_topics(topic_rows)
+                legacy_blended = _weighted_product_risk_score(core_docs)
+                dimension_risk = _calculate_overview_risk_score(meta_summary.scores)
+                if legacy_blended is not None:
+                    logger.info(
+                        "overview scoring comparison for %s: legacy_doc=%s topic=%s dimension=%s",
+                        product_slug,
+                        legacy_blended,
+                        topic_blended,
+                        dimension_risk,
+                    )
+                else:
+                    logger.info(
+                        "overview scoring comparison for %s: topic=%s dimension=%s",
+                        product_slug,
+                        topic_blended,
+                        dimension_risk,
+                    )
+
+                _reconcile_meta_summary_risk(meta_summary)
+
+                if meta_summary.topic_stances:
+                    attached = await attach_fallback_evidence(meta_summary.topic_stances, core_docs)
+                    if attached:
+                        logger.info("Attached %d fallback citations to %s", attached, product_slug)
+
+                overview_dict = meta_summary.model_dump(mode="json")
+                deterministic = validate_overview(overview_dict, has_adequate_evidence=not is_thin)
+
+                citations_for_review = _collect_citations(overview_dict.get("topic_stances") or [])
+                llm_result = await llm_review_overview(overview_dict, citations_for_review)
+                validation = merge_llm_review(deterministic, llm_result)
+
+                if validation.should_re_roll:
+                    reasons = "; ".join(validation.re_roll_reasons)
+                    logger.warning(
+                        "Overview validation failed for %s (attempt %d/%d): %s",
+                        product_slug,
+                        attempt,
+                        MAX_OVERVIEW_RE_ROLLS,
+                        reasons,
+                    )
+                    if attempt >= MAX_OVERVIEW_RE_ROLLS:
+                        raise ValueError(
+                            f"Overview validation failed for {product_slug}: {reasons}"
+                        )
+                    feedback_suffix = format_overview_retry_feedback(validation.re_roll_reasons)
+                    continue
+
+                break
+
+            if meta_summary is None or validation is None:
+                raise ValueError(f"Overview generation produced no result for {product_slug}")
+
+            for warning in validation.warnings:
+                logger.info("Overview warning for %s: %s", product_slug, warning)
 
         # Save to database (simple single-cache entry)
         await product_svc.save_product_overview(

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -2182,14 +2182,32 @@ Per-document analyses and extractions:
 
                 logger.debug(content)
 
-                # Parse the product overview
-                overview_dict = json.loads(content)
-                _merge_legacy_dimension_justifications(overview_dict)
+                try:
+                    overview_dict = json.loads(content)
+                    _merge_legacy_dimension_justifications(overview_dict)
+                    raw_contradictions = overview_dict.pop("contradictions", None)
+                    meta_summary = MetaSummary.model_validate(overview_dict, strict=False)
+                except (json.JSONDecodeError, ValueError) as parse_error:
+                    logger.warning(
+                        "Overview parsing failed for %s (attempt %d/%d): %s",
+                        product_slug,
+                        attempt,
+                        MAX_OVERVIEW_RE_ROLLS,
+                        parse_error,
+                    )
+                    if attempt >= MAX_OVERVIEW_RE_ROLLS:
+                        raise ValueError(
+                            f"Overview parsing failed for {product_slug}: {parse_error}"
+                        ) from parse_error
+                    feedback_suffix += format_overview_retry_feedback(
+                        [
+                            f"Invalid JSON or schema: {parse_error}. "
+                            "Output a valid JSON object matching the requested schema."
+                        ],
+                        attempt=attempt,
+                    )
+                    continue
 
-                # Parse contradictions before model validation
-                raw_contradictions = overview_dict.pop("contradictions", None)
-
-                meta_summary = MetaSummary.model_validate(overview_dict, strict=False)
                 meta_summary.coverage = hydrated_rollup.coverage
                 if meta_summary.dangers:
                     meta_summary.dangers = await filter_danger_strings_llm(meta_summary.dangers)
@@ -2294,9 +2312,14 @@ Per-document analyses and extractions:
                 overview_dict = meta_summary.model_dump(mode="json")
                 deterministic = validate_overview(overview_dict, has_adequate_evidence=not is_thin)
 
-                citations_for_review = _collect_citations(overview_dict.get("topic_stances") or [])
-                llm_result = await llm_review_overview(overview_dict, citations_for_review)
-                validation = merge_llm_review(deterministic, llm_result)
+                if deterministic.should_re_roll:
+                    validation = deterministic
+                else:
+                    citations_for_review = _collect_citations(
+                        overview_dict.get("topic_stances") or []
+                    )
+                    llm_result = await llm_review_overview(overview_dict, citations_for_review)
+                    validation = merge_llm_review(deterministic, llm_result)
 
                 if validation.should_re_roll:
                     reasons = "; ".join(validation.re_roll_reasons)
@@ -2311,7 +2334,10 @@ Per-document analyses and extractions:
                         raise ValueError(
                             f"Overview validation failed for {product_slug}: {reasons}"
                         )
-                    feedback_suffix = format_overview_retry_feedback(validation.re_roll_reasons)
+                    feedback_suffix += format_overview_retry_feedback(
+                        validation.re_roll_reasons,
+                        attempt=attempt,
+                    )
                     continue
 
                 break

--- a/packages/backend/src/analyzers/overview_guards.py
+++ b/packages/backend/src/analyzers/overview_guards.py
@@ -50,6 +50,23 @@ class OverviewValidationResult(BaseModel):
     checks_passed: dict[str, bool]
 
 
+MAX_OVERVIEW_RE_ROLLS = 3
+
+
+def format_overview_retry_feedback(reasons: list[str]) -> str:
+    """User-prompt appendix telling the overview LLM how to fix a rejected draft."""
+    if not reasons:
+        return ""
+    bullets = "\n".join(f"- {reason}" for reason in reasons)
+    return (
+        "\n\nYour previous JSON response was rejected by quality review. "
+        "Revise the overview to fix every issue below. Keep headline and summary "
+        "strictly evidence-backed — do not overgeneralize optional features or "
+        "use stronger wording than the policy supports:\n"
+        f"{bullets}\n"
+    )
+
+
 def _get_field(obj: Any, name: str) -> Any:
     if isinstance(obj, dict):
         return obj.get(name)

--- a/packages/backend/src/analyzers/overview_guards.py
+++ b/packages/backend/src/analyzers/overview_guards.py
@@ -53,16 +53,30 @@ class OverviewValidationResult(BaseModel):
 MAX_OVERVIEW_RE_ROLLS = 3
 
 
-def format_overview_retry_feedback(reasons: list[str]) -> str:
+def format_overview_retry_feedback(
+    reasons: list[str],
+    *,
+    attempt: int = 1,
+    max_attempts: int = MAX_OVERVIEW_RE_ROLLS,
+) -> str:
     """User-prompt appendix telling the overview LLM how to fix a rejected draft."""
     if not reasons:
         return ""
     bullets = "\n".join(f"- {reason}" for reason in reasons)
+    final_note = ""
+    if attempt + 1 >= max_attempts:
+        final_note = (
+            "Your next response is your FINAL attempt — fix every issue below or "
+            "the overview will be rejected.\n"
+        )
     return (
         "\n\nYour previous JSON response was rejected by quality review. "
-        "Revise the overview to fix every issue below. Keep headline and summary "
-        "strictly evidence-backed — do not overgeneralize optional features or "
-        "use stronger wording than the policy supports:\n"
+        "Revise the overview to fix every issue below. Only change what is "
+        "necessary to address these issues; preserve all other correct parts. "
+        "Keep headline and summary strictly evidence-backed — do not "
+        "overgeneralize optional features or use stronger wording than the "
+        "policy supports:\n"
+        f"{final_note}"
         f"{bullets}\n"
     )
 

--- a/packages/backend/tests/overview_guards_test.py
+++ b/packages/backend/tests/overview_guards_test.py
@@ -6,6 +6,7 @@ from src.analyzers.overview_guards import (
     check_e_grade_on_silence,
     check_rights_have_paths,
     find_long_sentences,
+    format_overview_retry_feedback,
     merge_llm_review,
     validate_headline_length,
     validate_headline_not_empty,
@@ -372,3 +373,16 @@ def test_merge_llm_review_all_pass_no_changes() -> None:
     assert merged.re_roll_reasons == []
     assert merged.warnings == ["summary too long"]
     assert merged.checks_passed["llm_unsupported_claims"] is True
+
+
+def test_format_overview_retry_feedback_empty_reasons() -> None:
+    assert format_overview_retry_feedback([]) == ""
+
+
+def test_format_overview_retry_feedback_includes_reasons() -> None:
+    text = format_overview_retry_feedback(
+        ["UNSUPPORTED_CLAIMS: headline overclaims voice recordings"]
+    )
+    assert "Your previous JSON response was rejected" in text
+    assert "UNSUPPORTED_CLAIMS: headline overclaims voice recordings" in text
+    assert text.startswith("\n\n")

--- a/packages/backend/tests/overview_guards_test.py
+++ b/packages/backend/tests/overview_guards_test.py
@@ -385,4 +385,14 @@ def test_format_overview_retry_feedback_includes_reasons() -> None:
     )
     assert "Your previous JSON response was rejected" in text
     assert "UNSUPPORTED_CLAIMS: headline overclaims voice recordings" in text
+    assert "Only change what is necessary" in text
     assert text.startswith("\n\n")
+
+
+def test_format_overview_retry_feedback_final_attempt_note() -> None:
+    text = format_overview_retry_feedback(
+        ["Headline is empty despite adequate evidence."],
+        attempt=2,
+        max_attempts=3,
+    )
+    assert "FINAL attempt" in text

--- a/packages/backend/tests/unit/product_overview_fixes_test.py
+++ b/packages/backend/tests/unit/product_overview_fixes_test.py
@@ -7,6 +7,7 @@ import pytest
 from litellm import ModelResponse
 
 from src.analyser import generate_product_overview
+from src.analyzers.overview_guards import OverviewValidationResult
 from src.models.document import (
     Document,
     DocumentAnalysis,
@@ -331,3 +332,99 @@ async def test_generate_product_overview_headline_claim_none_when_llm_omits_it()
         )
 
     assert result.headline_claim is None
+
+
+def _validation_result(
+    *, should_re_roll: bool, reasons: list[str] | None = None
+) -> OverviewValidationResult:
+    return OverviewValidationResult(
+        should_re_roll=should_re_roll,
+        re_roll_reasons=reasons or [],
+        warnings=[],
+        checks_passed={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_product_overview_retries_after_validation_failure() -> None:
+    """Failed overview validation should feed back to the LLM and retry."""
+    product_svc, document_svc = _services()
+    rollup_service = MagicMock()
+    rollup_service.build_product_rollup = AsyncMock(
+        return_value=MagicMock(
+            findings=[],
+            coverage=[],
+            conflicts=[],
+            product_id="p1",
+            product_slug="example",
+        )
+    )
+    llm_mock = AsyncMock(return_value=_llm_response(_base_llm_payload()))
+    merge_mock = MagicMock(
+        side_effect=[
+            _validation_result(
+                should_re_roll=True,
+                reasons=["UNSUPPORTED_CLAIMS: headline overclaims retention"],
+            ),
+            _validation_result(should_re_roll=False),
+        ]
+    )
+
+    with (
+        patch("src.analyser.ProductRollupService", return_value=rollup_service),
+        patch("src.analyser.acompletion_with_fallback", llm_mock),
+        patch("src.analyzers.overview_guards.merge_llm_review", merge_mock),
+    ):
+        await generate_product_overview(
+            MagicMock(),
+            "example",
+            force_regenerate=True,
+            product_svc=product_svc,
+            document_svc=document_svc,
+        )
+
+    assert llm_mock.await_count == 2
+    second_user_message = llm_mock.await_args_list[1].kwargs["messages"][1]["content"]
+    assert "Your previous JSON response was rejected" in second_user_message
+    assert "UNSUPPORTED_CLAIMS: headline overclaims retention" in second_user_message
+    product_svc.save_product_overview.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_product_overview_raises_after_max_validation_retries() -> None:
+    """Overview generation must fail only after exhausting validation retries."""
+    product_svc, document_svc = _services()
+    rollup_service = MagicMock()
+    rollup_service.build_product_rollup = AsyncMock(
+        return_value=MagicMock(
+            findings=[],
+            coverage=[],
+            conflicts=[],
+            product_id="p1",
+            product_slug="example",
+        )
+    )
+    llm_mock = AsyncMock(return_value=_llm_response(_base_llm_payload()))
+    merge_mock = MagicMock(
+        return_value=_validation_result(
+            should_re_roll=True,
+            reasons=["UNSUPPORTED_CLAIMS: headline overclaims retention"],
+        )
+    )
+
+    with (
+        patch("src.analyser.ProductRollupService", return_value=rollup_service),
+        patch("src.analyser.acompletion_with_fallback", llm_mock),
+        patch("src.analyzers.overview_guards.merge_llm_review", merge_mock),
+        pytest.raises(RuntimeError, match="Overview validation failed for example"),
+    ):
+        await generate_product_overview(
+            MagicMock(),
+            "example",
+            force_regenerate=True,
+            product_svc=product_svc,
+            document_svc=document_svc,
+        )
+
+    assert llm_mock.await_count == 3
+    product_svc.save_product_overview.assert_not_awaited()


### PR DESCRIPTION
## What this PR delivers

Product overview generation no longer hard-fails on the first quality-guard rejection. When deterministic or LLM semantic review flags a draft (e.g. `UNSUPPORTED_CLAIMS` on an overstrong headline), the synthesis prompt is retried with explicit feedback from the guard, up to three attempts, before the pipeline fails.

This replaces the previous one-shot behaviour where products like Netflix could fail overview generation despite otherwise successful crawl and analysis.

## Why this matters

**For operators:** Tier regen and backfill jobs should recover from fixable overview quality issues instead of leaving products stuck with stale overviews or failed jobs. Guard feedback is actionable — the synthesis LLM gets bullet-pointed reasons to revise wording.

**For maintainers:** Retry logic is centralized in `generate_product_overview` with a shared `format_overview_retry_feedback()` helper and `MAX_OVERVIEW_RE_ROLLS = 3`, keeping guard semantics unchanged while making the synthesis loop resilient.

## How overview generation behaviour changes

| Path | Change |
|---|---|
| First-pass validation passes | No change — single LLM synthesis call, save as before. |
| Validation fails (deterministic or high-severity LLM) | Regenerate with feedback appended to user prompt; up to 3 total attempts. Pinned by `product_overview_fixes_test.py`. |
| All 3 attempts fail | Hard-fail with same error message as before (wrapped in `RuntimeError`). No partial save. |
| LLM review call fails (fail-open) | No change — deterministic checks only, no retry triggered unless they fail. |

## UX changes operators will notice

- Pipeline logs show `Overview validation failed for {slug} (attempt N/3)` on retries, then either success or final failure.
- Products that previously failed on a single guard rejection (e.g. Netflix `UNSUPPORTED_CLAIMS`) may succeed on attempt 2 or 3 without manual requeue.

## Tests

- Pre-commit: ruff, ty, backend tests passing on this branch.
- `tests/overview_guards_test.py` — `format_overview_retry_feedback` empty and populated cases.
- `tests/unit/product_overview_fixes_test.py` — retry on first failure (2 LLM calls, feedback in second prompt); fail only after 3 attempts.

### Edge cases to verify in a staging session

1. Regenerate a product known to trigger `UNSUPPORTED_CLAIMS` (e.g. Netflix) — expected: succeeds within 3 attempts or fails with clear guard reasons after exhaustion.
2. Product with empty headline + adequate evidence — expected: deterministic guard triggers retry with "Headline is empty" feedback.
3. Product passing all guards on first attempt — expected: exactly one synthesis LLM call, no retry logs.

## Notes for reviewers

- Retry feedback is appended to the **user** prompt only; system prompt unchanged.
- `merge_llm_review` semantics unchanged — high-severity LLM failures still trigger re-roll; medium-severity remain warnings only.
- `MAX_OVERVIEW_RE_ROLLS = 3` is the single knob for attempt cap.