### PR TITLE
fix(crawler+overview): thin-evidence gate, trafilatura extraction, Sources UI

### DIFF
--- a/packages/backend/docs/CRAWLER.md
+++ b/packages/backend/docs/CRAWLER.md
@@ -242,7 +242,7 @@ Sitemap URLs are seeded only if they pass `should_crawl_url` *and* score ≥ `mi
 `_fetch_page_internal` (`src/crawler.py:3427`) is a three-stage pipeline per URL:
 
 1. **Static HTTP fetch** (`_static_fetch`): rate-limited, robots-checked, conditional-cached `aiohttp` GET. Follows redirects (the *resolved* URL is used downstream). Bodies capped at 5 MB. 404s and not-found landing pages short-circuit (no render).
-2. **Content extraction** (`_extract_page_content`): routed by content-type → HTML / Markdown / plain-text / XML / binary (PDF). HTML extraction isolates the main policy body and strips consent widgets (`_extract_main_content_soup`, `_is_consent_container`) so we capture the real policy text, not the cookie banner.
+2. **Content extraction** (`_extract_page_content`): routed by content-type → HTML / Markdown / plain-text / XML / binary (PDF). HTML extraction uses trafilatura for main-body isolation with a selector-based fallback (`_extract_main_content_soup`, `_strip_document_chrome`, `_is_consent_container`) so we capture policy text, not cookie banners.
 3. **Quality gate** (`_content_is_sufficient`, `src/crawler.py:1942`): the static result is "unusable" if it's garbled, has JS-required markers, is shorter than the length floor (`1000` chars for high-score URLs, else `500`), or its extracted markdown body is `< 400` chars (an SPA shell whose visible text is nav/JSON).
 
 If the static result is unusable **and** `use_browser` is on **and** the URL isn't a speculative guess **and** its relevance score ≥ `min_legal_score`:

--- a/packages/backend/pyproject.toml
+++ b/packages/backend/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "uvicorn>=0.34.2",
     "watchdog>=6.0.0",
     "tldextract>=5.3.1",
+    "trafilatura>=2.1.0",
 ]
 
 [project.scripts]

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -2092,7 +2092,7 @@ Per-document analyses and extractions:
         merge_llm_review,
         validate_overview,
     )
-    from src.services.thin_evidence_gate import check_thin_evidence
+    from src.services.thin_evidence_gate import check_thin_evidence, strip_overview_grading
     from src.services.topic_evidence_fallback import attach_fallback_evidence
 
     is_thin, thin_reason = check_thin_evidence(
@@ -2348,6 +2348,14 @@ Per-document analyses and extractions:
             for warning in validation.warnings:
                 logger.info("Overview warning for %s: %s", product_slug, warning)
 
+        if is_thin:
+            strip_overview_grading(meta_summary)
+            logger.info(
+                "Withholding overview grade for %s due to thin evidence: %s",
+                product_slug,
+                thin_reason,
+            )
+
         # Save to database (simple single-cache entry)
         await product_svc.save_product_overview(
             db,
@@ -2355,6 +2363,8 @@ Per-document analyses and extractions:
             meta_summary=meta_summary,
             job_id=job_id,
             product_id=product.id,
+            thin_evidence=is_thin,
+            thin_evidence_reason=thin_reason,
         )
         logger.info(f"✓ Saved product overview for {product_slug}")
 

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -2309,6 +2309,9 @@ Per-document analyses and extractions:
                     if attached:
                         logger.info("Attached %d fallback citations to %s", attached, product_slug)
 
+                if is_thin:
+                    strip_overview_grading(meta_summary)
+
                 overview_dict = meta_summary.model_dump(mode="json")
                 deterministic = validate_overview(overview_dict, has_adequate_evidence=not is_thin)
 
@@ -2349,7 +2352,6 @@ Per-document analyses and extractions:
                 logger.info("Overview warning for %s: %s", product_slug, warning)
 
         if is_thin:
-            strip_overview_grading(meta_summary)
             logger.info(
                 "Withholding overview grade for %s due to thin evidence: %s",
                 product_slug,

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -197,7 +197,7 @@ _RESPONSE_READ_CHUNK_SIZE = 65536
 async def _read_bounded_response_body(
     content: aiohttp.StreamReader, max_bytes: int
 ) -> tuple[bytes, bool]:
-    """Read response body in chunks up to *max_bytes* + 1 to detect oversize without OOM."""
+    """Read response body in chunks; may read up to max_bytes + 64KB before stopping."""
     chunks: list[bytes] = []
     total = 0
     while total <= max_bytes:
@@ -643,6 +643,7 @@ class ClauseaCrawler:
                     status_code=response.status,
                     content_type=content_type,
                     body=body,
+                    raw_bytes=raw,
                     headers=dict(response.headers.items()),
                     resolved_url=str(response.url),
                 )
@@ -699,7 +700,7 @@ class ClauseaCrawler:
         if traf is not None:
             text, markdown = traf
         else:
-            content_soup = self._extract_main_content_soup(soup)
+            content_soup = self._extract_main_content_soup(prepared)
             text = self._extract_text_from_soup(content_soup)
             markdown = markdownify.markdownify(str(content_soup), heading_style="ATX")
 

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -92,6 +92,7 @@ from src.crawler.constants import (
     locale_canonical_key,
 )
 from src.crawler.content_analyzer import ContentAnalyzer
+from src.crawler.html_extraction import extract_with_trafilatura
 from src.crawler.http_cache import AsyncFileLogHandler, HTTPCache
 from src.crawler.models import CrawlResult, CrawlStats, PageContent, StaticFetchResult
 from src.crawler.rate_limiter import DomainRateLimiter
@@ -691,9 +692,17 @@ class ClauseaCrawler:
         soup = BeautifulSoup(html, "html.parser")
         title_tag = soup.find("title")
         title = title_tag.get_text().strip() if title_tag else ""
-        content_soup = self._extract_main_content_soup(soup)
-        text = self._extract_text_from_soup(content_soup)
-        markdown = markdownify.markdownify(str(content_soup), heading_style="ATX")
+
+        prepared = BeautifulSoup(str(soup.body or soup), "html.parser")
+        self._strip_document_chrome(prepared)
+        traf = extract_with_trafilatura(str(prepared), url=url)
+        if traf is not None:
+            text, markdown = traf
+        else:
+            content_soup = self._extract_main_content_soup(soup)
+            text = self._extract_text_from_soup(content_soup)
+            markdown = markdownify.markdownify(str(content_soup), heading_style="ATX")
+
         metadata = self.extract_metadata(soup)
         links = self.extract_links(soup, url)
         return title, text, markdown, metadata, links
@@ -1042,58 +1051,7 @@ class ClauseaCrawler:
         match_set = set(elements)
         return [el for el in elements if not any(parent in match_set for parent in el.parents)]
 
-    def _extract_main_content_soup(self, soup: BeautifulSoup) -> BeautifulSoup:
-        selectors = (
-            "main",
-            "article",
-            '[role="main"]',
-            "#mw-content-text",
-            ".mw-parser-output",
-            "#bodyContent",
-            '[id*="content" i]',
-            '[class*="content" i]',
-            '[data-testid*="content" i]',
-            '[data-testid*="article" i]',
-            '[data-testid="CEPHtmlSection"]',
-            '[data-qa*="content" i]',
-            '[id*="legal" i]',
-            '[class*="legal" i]',
-            '[id*="privacy" i]',
-            '[class*="privacy" i]',
-            '[id*="terms" i]',
-            '[class*="terms" i]',
-            '[id*="policy" i]',
-            '[class*="policy" i]',
-        )
-
-        best_html: str | None = None
-        best_text_len = 0
-        for selector in selectors:
-            matches = self._top_level_elements(soup.select(selector))
-            matches = [
-                el
-                for el in matches
-                if el.name not in ("html", "body") and not self._is_consent_container(el)
-            ]
-            if not matches:
-                continue
-            combined_text_len = sum(len(el.get_text(" ", strip=True)) for el in matches)
-            min_len = 50 if "data-testid" in selector else 300
-            if combined_text_len < min_len or combined_text_len <= best_text_len:
-                continue
-            best_text_len = combined_text_len
-            best_html = (
-                str(matches[0])
-                if len(matches) == 1
-                else "<div>" + "".join(str(el) for el in matches) + "</div>"
-            )
-
-        if best_html is not None:
-            content_root: Any = BeautifulSoup(best_html, "html.parser")
-        else:
-            content_root = soup.body or soup
-        cleaned = BeautifulSoup(str(content_root), "html.parser")
-
+    def _strip_document_chrome(self, cleaned: BeautifulSoup) -> None:
         for tag in cleaned(["script", "style", "noscript", "template", "svg", "canvas", "iframe"]):
             tag.decompose()
 
@@ -1134,6 +1092,55 @@ class ClauseaCrawler:
                     continue
                 tag.decompose()
 
+    def _extract_main_content_soup(self, soup: BeautifulSoup) -> BeautifulSoup:
+        """Heuristic fallback when trafilatura cannot isolate substantive body content."""
+        selectors = (
+            "main",
+            "article",
+            '[role="main"]',
+            '[id*="content" i]',
+            '[class*="content" i]',
+            '[data-testid*="content" i]',
+            '[data-testid*="article" i]',
+            '[data-qa*="content" i]',
+            '[id*="legal" i]',
+            '[class*="legal" i]',
+            '[id*="privacy" i]',
+            '[class*="privacy" i]',
+            '[id*="terms" i]',
+            '[class*="terms" i]',
+            '[id*="policy" i]',
+            '[class*="policy" i]',
+        )
+
+        best_html: str | None = None
+        best_text_len = 0
+        for selector in selectors:
+            matches = self._top_level_elements(soup.select(selector))
+            matches = [
+                el
+                for el in matches
+                if el.name not in ("html", "body") and not self._is_consent_container(el)
+            ]
+            if not matches:
+                continue
+            combined_text_len = sum(len(el.get_text(" ", strip=True)) for el in matches)
+            min_len = 50 if "data-testid" in selector else 300
+            if combined_text_len < min_len or combined_text_len <= best_text_len:
+                continue
+            best_text_len = combined_text_len
+            best_html = (
+                str(matches[0])
+                if len(matches) == 1
+                else "<div>" + "".join(str(el) for el in matches) + "</div>"
+            )
+
+        if best_html is not None:
+            content_root: Any = BeautifulSoup(best_html, "html.parser")
+        else:
+            content_root = soup.body or soup
+        cleaned = BeautifulSoup(str(content_root), "html.parser")
+        self._strip_document_chrome(cleaned)
         return cleaned
 
     @classmethod

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -532,9 +532,18 @@ class ClauseaCrawler:
                 )
 
             if is_text:
-                raw = await response.content.read(MAX_RESPONSE_BYTES + 1)
+                raw = await response.read()
                 if len(raw) > MAX_RESPONSE_BYTES:
-                    raw = raw[:MAX_RESPONSE_BYTES]
+                    return StaticFetchResult(
+                        url=url,
+                        status_code=response.status,
+                        content_type=content_type,
+                        body="",
+                        raw_bytes=raw[:MAX_RESPONSE_BYTES],
+                        headers=resp_headers,
+                        resolved_url=final_url,
+                        error_message=f"Response too large ({len(raw)} bytes)",
+                    )
                 body = raw.decode(response.charset or "utf-8", errors="replace")
                 return StaticFetchResult(
                     url=url,
@@ -546,7 +555,7 @@ class ClauseaCrawler:
                     resolved_url=final_url,
                 )
             else:
-                raw_bytes = await response.content.read(MAX_RESPONSE_BYTES + 1)
+                raw_bytes = await response.read()
                 if len(raw_bytes) > MAX_RESPONSE_BYTES:
                     raw_bytes = raw_bytes[:MAX_RESPONSE_BYTES]
                 return StaticFetchResult(
@@ -590,9 +599,9 @@ class ClauseaCrawler:
                 ):
                     return None
 
-                raw = await response.content.read(MAX_RESPONSE_BYTES + 1)
+                raw = await response.read()
                 if len(raw) > MAX_RESPONSE_BYTES:
-                    raw = raw[:MAX_RESPONSE_BYTES]
+                    return None
                 body = raw.decode(response.charset or "utf-8", errors="replace")
                 return StaticFetchResult(
                     url=url,
@@ -1004,6 +1013,9 @@ class ClauseaCrawler:
             "main",
             "article",
             '[role="main"]',
+            "#mw-content-text",
+            ".mw-parser-output",
+            "#bodyContent",
             '[id*="content" i]',
             '[class*="content" i]',
             '[data-testid*="content" i]',
@@ -1024,7 +1036,11 @@ class ClauseaCrawler:
         best_text_len = 0
         for selector in selectors:
             matches = self._top_level_elements(soup.select(selector))
-            matches = [el for el in matches if not self._is_consent_container(el)]
+            matches = [
+                el
+                for el in matches
+                if el.name not in ("html", "body") and not self._is_consent_container(el)
+            ]
             if not matches:
                 continue
             combined_text_len = sum(len(el.get_text(" ", strip=True)) for el in matches)

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -193,6 +193,13 @@ def _is_pdf_response(content_type: str, url: str) -> bool:
 
 _RESPONSE_READ_CHUNK_SIZE = 65536
 
+_BOILERPLATE_PATTERN = re.compile(
+    r"(cookie|consent|banner|popup|modal|newsletter|subscribe|breadcrumb|"
+    r"social|share|tracking|advert|promo|sidebar|drawer|menu|navigation|"
+    r"footer|header|masthead|toolbar)",
+    re.IGNORECASE,
+)
+
 
 async def _read_bounded_response_body(
     content: aiohttp.StreamReader, max_bytes: int
@@ -556,12 +563,13 @@ class ClauseaCrawler:
                     response.content, MAX_RESPONSE_BYTES
                 )
                 if oversized:
+                    truncated = raw[:MAX_RESPONSE_BYTES]
                     return StaticFetchResult(
                         url=url,
                         status_code=response.status,
                         content_type=content_type,
                         body="",
-                        raw_bytes=b"",
+                        raw_bytes=truncated,
                         headers=resp_headers,
                         resolved_url=final_url,
                         error_message=f"Response too large (exceeds {MAX_RESPONSE_BYTES} bytes)",
@@ -632,7 +640,7 @@ class ClauseaCrawler:
                         status_code=response.status,
                         content_type=content_type,
                         body="",
-                        raw_bytes=b"",
+                        raw_bytes=raw[:MAX_RESPONSE_BYTES],
                         headers=dict(response.headers.items()),
                         resolved_url=str(response.url),
                         error_message=f"Response too large (exceeds {MAX_RESPONSE_BYTES} bytes)",
@@ -1067,13 +1075,6 @@ class ClauseaCrawler:
             if tag.attrs is not None and self._is_consent_container(tag):
                 tag.decompose()
 
-        boilerplate_pattern = re.compile(
-            r"(cookie|consent|banner|popup|modal|newsletter|subscribe|breadcrumb|"
-            r"social|share|tracking|advert|promo|sidebar|drawer|menu|navigation|"
-            r"footer|header|masthead|toolbar)",
-            re.IGNORECASE,
-        )
-
         for tag in cleaned.find_all(True):
             if tag.attrs is None:
                 continue
@@ -1087,7 +1088,7 @@ class ClauseaCrawler:
             attrs = " ".join(
                 str(value) for value in [tag.get("id", ""), classes, tag.get("aria-label", "")]
             )
-            if attrs and boilerplate_pattern.search(attrs):
+            if attrs and _BOILERPLATE_PATTERN.search(attrs):
                 tag_text = tag.get_text(" ", strip=True)
                 if self._is_substantive_legal_policy_container(attrs, tag_text):
                     continue

--- a/packages/backend/src/crawler/client.py
+++ b/packages/backend/src/crawler/client.py
@@ -190,6 +190,25 @@ def _is_pdf_response(content_type: str, url: str) -> bool:
 # ---- ClauseaCrawler ----------------------------------------------------------------
 
 
+_RESPONSE_READ_CHUNK_SIZE = 65536
+
+
+async def _read_bounded_response_body(
+    content: aiohttp.StreamReader, max_bytes: int
+) -> tuple[bytes, bool]:
+    """Read response body in chunks up to *max_bytes* + 1 to detect oversize without OOM."""
+    chunks: list[bytes] = []
+    total = 0
+    while total <= max_bytes:
+        chunk = await content.read(_RESPONSE_READ_CHUNK_SIZE)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+    body = b"".join(chunks)
+    return body, len(body) > max_bytes
+
+
 class ClauseaCrawler:
     """Powerful policy document crawler."""
 
@@ -532,17 +551,19 @@ class ClauseaCrawler:
                 )
 
             if is_text:
-                raw = await response.read()
-                if len(raw) > MAX_RESPONSE_BYTES:
+                raw, oversized = await _read_bounded_response_body(
+                    response.content, MAX_RESPONSE_BYTES
+                )
+                if oversized:
                     return StaticFetchResult(
                         url=url,
                         status_code=response.status,
                         content_type=content_type,
                         body="",
-                        raw_bytes=raw[:MAX_RESPONSE_BYTES],
+                        raw_bytes=b"",
                         headers=resp_headers,
                         resolved_url=final_url,
-                        error_message=f"Response too large ({len(raw)} bytes)",
+                        error_message=f"Response too large (exceeds {MAX_RESPONSE_BYTES} bytes)",
                     )
                 body = raw.decode(response.charset or "utf-8", errors="replace")
                 return StaticFetchResult(
@@ -555,8 +576,10 @@ class ClauseaCrawler:
                     resolved_url=final_url,
                 )
             else:
-                raw_bytes = await response.read()
-                if len(raw_bytes) > MAX_RESPONSE_BYTES:
+                raw_bytes, oversized = await _read_bounded_response_body(
+                    response.content, MAX_RESPONSE_BYTES
+                )
+                if oversized:
                     raw_bytes = raw_bytes[:MAX_RESPONSE_BYTES]
                 return StaticFetchResult(
                     url=url,
@@ -599,9 +622,20 @@ class ClauseaCrawler:
                 ):
                     return None
 
-                raw = await response.read()
-                if len(raw) > MAX_RESPONSE_BYTES:
-                    return None
+                raw, oversized = await _read_bounded_response_body(
+                    response.content, MAX_RESPONSE_BYTES
+                )
+                if oversized:
+                    return StaticFetchResult(
+                        url=url,
+                        status_code=response.status,
+                        content_type=content_type,
+                        body="",
+                        raw_bytes=b"",
+                        headers=dict(response.headers.items()),
+                        resolved_url=str(response.url),
+                        error_message=f"Response too large (exceeds {MAX_RESPONSE_BYTES} bytes)",
+                    )
                 body = raw.decode(response.charset or "utf-8", errors="replace")
                 return StaticFetchResult(
                     url=url,

--- a/packages/backend/src/crawler/html_extraction.py
+++ b/packages/backend/src/crawler/html_extraction.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+import re
+
 from trafilatura.core import bare_extraction, determine_returnstring
 from trafilatura.metadata import Document
 from trafilatura.settings import Extractor, use_config
 
 MIN_TRAFILATURA_CHARS = 200
+
+
+def _plain_text_from_markdown(markdown: str) -> str:
+    text = re.sub(r"<!--.*?-->", " ", markdown, flags=re.DOTALL)
+    text = re.sub(r"!\[[^\]]*\]\([^)]*\)", " ", text)
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    text = re.sub(r"`{1,3}[^`]*`{1,3}", " ", text)
+    text = re.sub(r"^\s{0,3}[>#\-\*\+]+\s*", "", text, flags=re.MULTILINE)
+    text = re.sub(r"[*_~]{1,3}", "", text)
+    text = re.sub(r"<[^>]+>", " ", text)
+    return re.sub(r"\n{3,}", "\n\n", text).strip()
 
 
 def extract_with_trafilatura(html: str, *, url: str | None = None) -> tuple[str, str] | None:
@@ -22,28 +35,18 @@ def extract_with_trafilatura(html: str, *, url: str | None = None) -> tuple[str,
     if not isinstance(doc, Document):
         return None
 
-    config = use_config()
-    text = determine_returnstring(
-        doc,
-        Extractor(
-            config=config,
-            output_format="txt",
-            recall=True,
-            links=True,
-            tables=True,
-        ),
-    ).strip()
-    if len(text) < MIN_TRAFILATURA_CHARS:
-        return None
-
     markdown = determine_returnstring(
         doc,
         Extractor(
-            config=config,
+            config=use_config(),
             output_format="markdown",
             recall=True,
             links=True,
             tables=True,
         ),
     ).strip()
-    return text, markdown or text
+    if len(markdown) < MIN_TRAFILATURA_CHARS:
+        return None
+
+    text = _plain_text_from_markdown(markdown)
+    return text, markdown

--- a/packages/backend/src/crawler/html_extraction.py
+++ b/packages/backend/src/crawler/html_extraction.py
@@ -1,0 +1,30 @@
+"""HTML main-content extraction via trafilatura."""
+
+from __future__ import annotations
+
+import trafilatura
+
+MIN_TRAFILATURA_CHARS = 200
+
+
+def extract_with_trafilatura(html: str, *, url: str | None = None) -> tuple[str, str] | None:
+    """Return (plain text, markdown) when trafilatura finds substantive body content."""
+    text = trafilatura.extract(
+        html,
+        url=url,
+        include_links=True,
+        include_tables=True,
+        favor_recall=True,
+    )
+    if not text or len(text.strip()) < MIN_TRAFILATURA_CHARS:
+        return None
+
+    markdown = trafilatura.extract(
+        html,
+        url=url,
+        output_format="markdown",
+        include_links=True,
+        include_tables=True,
+        favor_recall=True,
+    )
+    return text.strip(), (markdown or text).strip()

--- a/packages/backend/src/crawler/html_extraction.py
+++ b/packages/backend/src/crawler/html_extraction.py
@@ -2,29 +2,48 @@
 
 from __future__ import annotations
 
-import trafilatura
+from trafilatura.core import bare_extraction, determine_returnstring
+from trafilatura.metadata import Document
+from trafilatura.settings import Extractor, use_config
 
 MIN_TRAFILATURA_CHARS = 200
 
 
 def extract_with_trafilatura(html: str, *, url: str | None = None) -> tuple[str, str] | None:
     """Return (plain text, markdown) when trafilatura finds substantive body content."""
-    text = trafilatura.extract(
+    doc = bare_extraction(
         html,
         url=url,
         include_links=True,
         include_tables=True,
         favor_recall=True,
+        output_format="python",
     )
-    if not text or len(text.strip()) < MIN_TRAFILATURA_CHARS:
+    if not isinstance(doc, Document):
         return None
 
-    markdown = trafilatura.extract(
-        html,
-        url=url,
-        output_format="markdown",
-        include_links=True,
-        include_tables=True,
-        favor_recall=True,
-    )
-    return text.strip(), (markdown or text).strip()
+    config = use_config()
+    text = determine_returnstring(
+        doc,
+        Extractor(
+            config=config,
+            output_format="txt",
+            recall=True,
+            links=True,
+            tables=True,
+        ),
+    ).strip()
+    if len(text) < MIN_TRAFILATURA_CHARS:
+        return None
+
+    markdown = determine_returnstring(
+        doc,
+        Extractor(
+            config=config,
+            output_format="markdown",
+            recall=True,
+            links=True,
+            tables=True,
+        ),
+    ).strip()
+    return text, markdown or text

--- a/packages/backend/src/repositories/product_repository.py
+++ b/packages/backend/src/repositories/product_repository.py
@@ -285,6 +285,8 @@ class ProductRepository(BaseRepository):
         meta_summary: MetaSummary,
         job_id: str | None = None,
         product_id: str | None = None,
+        thin_evidence: bool = False,
+        thin_evidence_reason: str | None = None,
     ) -> None:
         if product_id is None:
             product = await self.find_by_slug(db, product_slug)
@@ -297,6 +299,8 @@ class ProductRepository(BaseRepository):
             product_slug=product_slug,
             meta_summary=meta_summary,
             job_id=job_id,
+            thin_evidence=thin_evidence,
+            thin_evidence_reason=thin_evidence_reason,
         )
         logger.info("Saved product overview for %s", product_slug)
 

--- a/packages/backend/src/services/product_intelligence_service.py
+++ b/packages/backend/src/services/product_intelligence_service.py
@@ -105,6 +105,8 @@ class ProductIntelligenceService:
         product_slug: str,
         meta_summary: MetaSummary,
         job_id: str | None = None,
+        thin_evidence: bool = False,
+        thin_evidence_reason: str | None = None,
     ) -> None:
         intelligence = await self.ensure_shell(db, product_id=product_id, product_slug=product_slug)
         overview_data = meta_summary.model_dump(mode="json")
@@ -151,6 +153,8 @@ class ProductIntelligenceService:
                 "overview": meta_summary.model_dump(mode="json"),
                 "overview_history": [snapshot.model_dump(mode="json") for snapshot in history],
                 "overview_generated_at": now,
+                "thin_evidence": thin_evidence,
+                "thin_evidence_reason": thin_evidence_reason if thin_evidence else None,
             },
         )
         await self.update_product_stats(db, product_id=product_id, product_slug=product_slug)
@@ -204,12 +208,20 @@ class ProductIntelligenceService:
         membership = {"$or": [{"product_id": product_id}, {"product_ids": product_id}]}
         document_count = await db.documents.count_documents(membership)
         intelligence = await self.get(db, product_id=product_id)
+        has_graded_overview = (
+            intelligence is not None
+            and intelligence.overview is not None
+            and not intelligence.thin_evidence
+            and intelligence.overview.grade is not None
+        )
         stats: dict[str, Any] = {
             "stats.document_count": document_count,
-            "stats.has_overview": intelligence is not None and intelligence.overview is not None,
+            "stats.has_overview": has_graded_overview,
             "stats.last_indexed_at": datetime.now(),
             "stats.grade": (
-                intelligence.overview.grade if intelligence and intelligence.overview else None
+                intelligence.overview.grade
+                if has_graded_overview and intelligence and intelligence.overview
+                else None
             ),
         }
         await db.products.update_one({"id": product_id}, {"$set": stats})

--- a/packages/backend/src/services/product_intelligence_service.py
+++ b/packages/backend/src/services/product_intelligence_service.py
@@ -154,7 +154,7 @@ class ProductIntelligenceService:
                 "overview_history": [snapshot.model_dump(mode="json") for snapshot in history],
                 "overview_generated_at": now,
                 "thin_evidence": thin_evidence,
-                "thin_evidence_reason": thin_evidence_reason if thin_evidence else None,
+                "thin_evidence_reason": (thin_evidence_reason or None) if thin_evidence else None,
             },
         )
         await self.update_product_stats(db, product_id=product_id, product_slug=product_slug)
@@ -218,11 +218,7 @@ class ProductIntelligenceService:
             "stats.document_count": document_count,
             "stats.has_overview": has_graded_overview,
             "stats.last_indexed_at": datetime.now(),
-            "stats.grade": (
-                intelligence.overview.grade
-                if has_graded_overview and intelligence and intelligence.overview
-                else None
-            ),
+            "stats.grade": intelligence.overview.grade if has_graded_overview else None,
         }
         await db.products.update_one({"id": product_id}, {"$set": stats})
 

--- a/packages/backend/src/services/product_service.py
+++ b/packages/backend/src/services/product_service.py
@@ -305,6 +305,8 @@ class ProductService:
         meta_summary: MetaSummary,
         job_id: str | None = None,
         product_id: str | None = None,
+        thin_evidence: bool = False,
+        thin_evidence_reason: str | None = None,
     ) -> None:
         """Save the product overview payload to the database.
 
@@ -314,9 +316,17 @@ class ProductService:
             meta_summary: Overview payload (MetaSummary shape)
             job_id: Optional pipeline job that produced this overview
             product_id: Product identifier for the owning product record
+            thin_evidence: When True, overview is stored without a consumer grade
+            thin_evidence_reason: Human-readable reason grading was withheld
         """
         await self._product_repo.save_product_overview(
-            db, product_slug, meta_summary, job_id=job_id, product_id=product_id
+            db,
+            product_slug,
+            meta_summary,
+            job_id=job_id,
+            product_id=product_id,
+            thin_evidence=thin_evidence,
+            thin_evidence_reason=thin_evidence_reason,
         )
 
     # ============================================================================

--- a/packages/backend/src/services/thin_evidence_gate.py
+++ b/packages/backend/src/services/thin_evidence_gate.py
@@ -1,7 +1,8 @@
-"""Thin-evidence gate: blocks overview generation when evidence is insufficient."""
+"""Thin-evidence gate: suppresses grading when evidence is insufficient."""
 
 from __future__ import annotations
 
+from src.models.document import MetaSummary
 from src.prompts.analysis_prompts import OVERVIEW_CORE_DOC_TYPES
 
 MIN_DISTINCT_CORE_TYPES = 2
@@ -28,3 +29,11 @@ def check_thin_evidence(analyzed_core_docs: list[str]) -> tuple[bool, str | None
         )
 
     return False, None
+
+
+def strip_overview_grading(meta_summary: MetaSummary) -> None:
+    """Remove consumer-facing grades from an overview saved under thin evidence."""
+    meta_summary.grade = None
+    meta_summary.verdict = None
+    meta_summary.risk_score = None
+    meta_summary.grade_justification = None

--- a/packages/backend/tests/thin_evidence_gate_test.py
+++ b/packages/backend/tests/thin_evidence_gate_test.py
@@ -1,4 +1,5 @@
-from src.services.thin_evidence_gate import check_thin_evidence
+from src.models.document import MetaSummary
+from src.services.thin_evidence_gate import check_thin_evidence, strip_overview_grading
 
 
 def test_zero_docs_is_thin() -> None:
@@ -53,3 +54,29 @@ def test_mixed_core_and_non_core_docs() -> None:
     )
     assert is_thin is False
     assert reason is None
+
+
+def test_strip_overview_grading_clears_consumer_scores() -> None:
+    meta = MetaSummary.model_validate(
+        {
+            "summary": "partial",
+            "scores": {
+                "transparency": {"score": 5, "justification": "ok"},
+                "data_collection_scope": {"score": 5, "justification": "ok"},
+                "user_control": {"score": 5, "justification": "ok"},
+                "third_party_sharing": {"score": 5, "justification": "ok"},
+            },
+            "grade": "D",
+            "verdict": "pervasive",
+            "risk_score": 7,
+            "grade_justification": "Too harsh for one doc",
+        }
+    )
+
+    strip_overview_grading(meta)
+
+    assert meta.grade is None
+    assert meta.verdict is None
+    assert meta.risk_score is None
+    assert meta.grade_justification is None
+    assert meta.summary == "partial"

--- a/packages/backend/tests/unit/analyser_topic_scoring_test.py
+++ b/packages/backend/tests/unit/analyser_topic_scoring_test.py
@@ -9,7 +9,7 @@ from src.models.document import Document, DocumentAnalysis, DocumentAnalysisScor
 from src.models.finding import AggregatedFinding, HydratedRollup
 
 
-def _core_doc() -> Document:
+def _core_doc(*, doc_id: str = "doc_1", doc_type: str = "privacy_policy") -> Document:
     analysis = DocumentAnalysis(
         summary="x",
         scores={
@@ -26,19 +26,28 @@ def _core_doc() -> Document:
         critical_clauses=[],
     )
     return Document(
-        id="doc_1",
+        id=doc_id,
         title="Privacy Policy",
         url="https://example.com/privacy",
         product_id="p1",
-        doc_type="privacy_policy",  # type: ignore[arg-type]
+        doc_type=doc_type,  # type: ignore[arg-type]
         markdown="",
         analysis=analysis,
     )
 
 
+def _adequate_core_docs() -> list[Document]:
+    return [
+        _core_doc(doc_id="doc_1", doc_type="privacy_policy"),
+        _core_doc(doc_id="doc_2", doc_type="privacy_policy"),
+        _core_doc(doc_id="doc_3", doc_type="terms_of_service"),
+    ]
+
+
 def _overview_response() -> ModelResponse:
     payload = {
         "summary": "ok",
+        "headline_claim": "Example shares data with advertising partners.",
         "grade": "C",
         "grade_justification": "Mixed practices across documents.",
         "scores": {
@@ -66,7 +75,7 @@ def _services() -> tuple[MagicMock, MagicMock]:
     product_svc.get_product_by_slug = AsyncMock(return_value=product)
     product_svc.save_product_overview = AsyncMock(return_value=True)
     document_svc = MagicMock()
-    document_svc.get_product_documents_by_slug = AsyncMock(return_value=[_core_doc()])
+    document_svc.get_product_documents_by_slug = AsyncMock(return_value=_adequate_core_docs())
     return product_svc, document_svc
 
 

--- a/packages/backend/tests/unit/crawler/binary_parsing_test.py
+++ b/packages/backend/tests/unit/crawler/binary_parsing_test.py
@@ -11,9 +11,17 @@ from src.document_processor import DocumentProcessor
 class _FakeContent:
     def __init__(self, data: bytes) -> None:
         self._data = data
+        self._offset = 0
 
     async def read(self, n: int = -1) -> bytes:
-        return self._data if n < 0 else self._data[:n]
+        if n < 0:
+            n = len(self._data) - self._offset
+        if n == 0:
+            return b""
+        end = min(self._offset + n, len(self._data))
+        chunk = self._data[self._offset : end]
+        self._offset = end
+        return chunk
 
 
 @pytest.mark.asyncio

--- a/packages/backend/tests/unit/crawler/content_pipeline_test.py
+++ b/packages/backend/tests/unit/crawler/content_pipeline_test.py
@@ -14,9 +14,17 @@ class _FakeContent:
 
     def __init__(self, data: bytes) -> None:
         self._data = data
+        self._offset = 0
 
     async def read(self, n: int = -1) -> bytes:
-        return self._data if n < 0 else self._data[:n]
+        if n < 0:
+            n = len(self._data) - self._offset
+        if n == 0:
+            return b""
+        end = min(self._offset + n, len(self._data))
+        chunk = self._data[self._offset : end]
+        self._offset = end
+        return chunk
 
 
 # ---------------------------------------------------------------------------

--- a/packages/backend/tests/unit/crawler/content_pipeline_test.py
+++ b/packages/backend/tests/unit/crawler/content_pipeline_test.py
@@ -194,6 +194,9 @@ class TestFetchPageInternalOrchestration:
                 self.charset = "utf-8"
                 self.content = _FakeContent(html.encode())
 
+            async def read(self) -> bytes:
+                return await self.content.read()
+
             async def text(self):
                 return html
 
@@ -238,6 +241,9 @@ class TestFetchPageInternalOrchestration:
                 self.url = url
                 self.charset = "utf-8"
                 self.content = _FakeContent(thin_html.encode())
+
+            async def read(self) -> bytes:
+                return await self.content.read()
 
             async def text(self):
                 return thin_html
@@ -290,6 +296,9 @@ class TestFetchPageInternalOrchestration:
                 self.charset = "utf-8"
                 self.content = _FakeContent(thin_html.encode())
 
+            async def read(self) -> bytes:
+                return await self.content.read()
+
             async def text(self):
                 return thin_html
 
@@ -336,6 +345,9 @@ class TestFetchPageInternalOrchestration:
                 self.url = url
                 self.charset = "utf-8"
                 self.content = _FakeContent(thin_html.encode())
+
+            async def read(self) -> bytes:
+                return await self.content.read()
 
             async def text(self):
                 return thin_html
@@ -384,6 +396,9 @@ class TestFetchPageInternalOrchestration:
                 self.url = url
                 self.charset = "utf-8"
                 self.content = _FakeContent(b"")
+
+            async def read(self) -> bytes:
+                return await self.content.read()
 
             async def text(self):
                 return ""
@@ -437,6 +452,9 @@ class TestFetchPageInternalOrchestration:
                 self.charset = None
                 self.content = _FakeContent(b"")
 
+            async def read(self) -> bytes:
+                return await self.content.read()
+
             async def text(self):
                 return ""
 
@@ -477,6 +495,9 @@ class TestFetchPageInternalOrchestration:
                 self.charset = "utf-8"
                 self.content = _FakeContent(thin_html.encode())
 
+            async def read(self) -> bytes:
+                return await self.content.read()
+
             async def text(self):
                 return thin_html
 
@@ -509,6 +530,9 @@ class TestFetchPageInternalOrchestration:
                 self.url = YarlURL("https://example.com/missing")
                 self.charset = "utf-8"
                 self.content = _FakeContent(b"<html><body>Not found</body></html>")
+
+            async def read(self) -> bytes:
+                return await self.content.read()
 
             async def text(self):
                 return "<html><body>Not found</body></html>"
@@ -557,6 +581,9 @@ class TestFetchPageInternalOrchestration:
                 self.url = YarlURL(final_url)
                 self.charset = "utf-8"
                 self.content = _FakeContent(thin_html.encode())
+
+            async def read(self) -> bytes:
+                return await self.content.read()
 
             async def text(self):
                 return thin_html

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -10,9 +10,17 @@ from src.crawler import ClauseaCrawler, PageContent
 class _FakeContent:
     def __init__(self, data: bytes) -> None:
         self._data = data
+        self._offset = 0
 
     async def read(self, n: int = -1) -> bytes:
-        return self._data if n < 0 else self._data[:n]
+        if n < 0:
+            n = len(self._data) - self._offset
+        if n == 0:
+            return b""
+        end = min(self._offset + n, len(self._data))
+        chunk = self._data[self._offset : end]
+        self._offset = end
+        return chunk
 
 
 def test_extract_links_various_sources():
@@ -466,9 +474,10 @@ class _MappedResponse:
         self.url = url
         self.status = 200 if self._body is not None else 404
         self.headers: dict[str, str] = {}
+        self.content = _FakeContent((self._body or "").encode())
 
     async def read(self) -> bytes:
-        return (self._body or "").encode()
+        return await self.content.read()
 
     async def text(self) -> str:
         return self._body or ""
@@ -478,10 +487,6 @@ class _MappedResponse:
 
     async def __aexit__(self, *args):
         return None
-
-    @property
-    def content(self) -> _FakeContent:
-        return _FakeContent((self._body or "").encode())
 
 
 class _MappedSession:

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -284,12 +284,7 @@ def test_extract_main_content_preserves_cookie_policy_wrapper():
 
 
 def test_extract_main_content_combines_split_blocks_over_small_sidebar():
-    """Airbnb help/legal pages split the body across many sibling
-    ``data-testid="CEPHtmlSection"`` blocks while a small "Related articles"
-    widget (``data-testid="...article..."``) appears earlier in the DOM.
-
-    The extractor must pick the rich combined body, not the tiny sidebar.
-    """
+    """Fallback selector path still combines sibling content blocks when trafilatura is skipped."""
     body_para = (
         "This Terms of Service section explains the legal agreement between you and "
         "the company. It describes your rights, obligations, liability, dispute "
@@ -328,8 +323,7 @@ def test_extract_main_content_combines_split_blocks_over_small_sidebar():
 
 
 def test_extract_main_content_ignores_html_vector_content_class_false_positive():
-    """MediaWiki Vector skin puts 'content' in <html> class names; do not treat
-    the root element as the article body."""
+    """Fallback selectors must not treat the root ``html`` element as article body."""
     html = """
     <html class="client-nojs vector-feature-limited-width-content-enabled">
       <body>

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -322,16 +322,14 @@ def test_extract_main_content_combines_split_blocks_over_small_sidebar():
     assert len(text) > 1000
 
 
-def test_extract_main_content_ignores_html_vector_content_class_false_positive():
+def test_extract_main_content_ignores_html_content_class_false_positive():
     """Fallback selectors must not treat the root ``html`` element as article body."""
     html = """
-    <html class="client-nojs vector-feature-limited-width-content-enabled">
+    <html class="site-feature-limited-width-content-enabled">
       <body>
         <main id="content">
-          <div id="mw-content-text" class="mw-parser-output">
-            <h1>Terms of Use</h1>
-            <p>These terms govern your use of Wikimedia projects and services.</p>
-          </div>
+          <h1>Terms of Use</h1>
+          <p>These terms govern your use of our products and services.</p>
         </main>
       </body>
     </html>
@@ -342,7 +340,7 @@ def test_extract_main_content_ignores_html_vector_content_class_false_positive()
     text = cleaned.get_text(" ", strip=True)
 
     assert "Terms of Use" in text
-    assert "Wikimedia projects" in text
+    assert "products and services" in text
 
 
 def test_decode_sitemap_bytes_inflates_gzip():

--- a/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
+++ b/packages/backend/tests/unit/crawler/extraction_and_sitemap_test.py
@@ -319,6 +319,30 @@ def test_extract_main_content_combines_split_blocks_over_small_sidebar():
     assert len(text) > 1000
 
 
+def test_extract_main_content_ignores_html_vector_content_class_false_positive():
+    """MediaWiki Vector skin puts 'content' in <html> class names; do not treat
+    the root element as the article body."""
+    html = """
+    <html class="client-nojs vector-feature-limited-width-content-enabled">
+      <body>
+        <main id="content">
+          <div id="mw-content-text" class="mw-parser-output">
+            <h1>Terms of Use</h1>
+            <p>These terms govern your use of Wikimedia projects and services.</p>
+          </div>
+        </main>
+      </body>
+    </html>
+    """
+    crawler = ClauseaCrawler()
+    soup = BeautifulSoup(html, "html.parser")
+    cleaned = crawler._extract_main_content_soup(soup)
+    text = cleaned.get_text(" ", strip=True)
+
+    assert "Terms of Use" in text
+    assert "Wikimedia projects" in text
+
+
 def test_decode_sitemap_bytes_inflates_gzip():
     """``.xml.gz`` sitemap indexes arrive as gzip file bodies; aiohttp does not
     transparently inflate them, so a naive .text() decode raised
@@ -385,6 +409,9 @@ async def test_static_html_fallback_uses_main_content_and_keeps_jsonld_links():
             self.charset = "utf-8"
             self.content = _FakeContent(body.encode())
 
+        async def read(self) -> bytes:
+            return self._body.encode()
+
         async def text(self) -> str:
             return self._body
 
@@ -439,6 +466,9 @@ class _MappedResponse:
         self.url = url
         self.status = 200 if self._body is not None else 404
         self.headers: dict[str, str] = {}
+
+    async def read(self) -> bytes:
+        return (self._body or "").encode()
 
     async def text(self) -> str:
         return self._body or ""

--- a/packages/backend/tests/unit/crawler/html_extraction_test.py
+++ b/packages/backend/tests/unit/crawler/html_extraction_test.py
@@ -4,28 +4,26 @@ from src.crawler import ClauseaCrawler
 from src.crawler.html_extraction import extract_with_trafilatura
 
 
-def test_extract_with_trafilatura_mediawiki_terms():
+def test_extract_with_trafilatura_terms_of_service():
     html = """
-    <html class="client-nojs vector-feature-limited-width-content-enabled">
+    <html>
       <body>
-        <main id="content">
-          <div id="mw-content-text" class="mw-parser-output">
+        <main>
+          <article>
             <h1>Terms of Use</h1>
-            <p>These terms govern your use of Wikimedia projects and services.</p>
+            <p>These terms govern your use of our products and services.</p>
             <p>Users must comply with applicable law and respect community guidelines.</p>
-            <p>Content may be reused under free licenses when attribution requirements are met.</p>
-          </div>
+            <p>Content may be reused only when attribution requirements are met.</p>
+          </article>
         </main>
       </body>
     </html>
     """
-    result = extract_with_trafilatura(
-        html, url="https://foundation.wikimedia.org/wiki/Policy:Terms_of_Use"
-    )
+    result = extract_with_trafilatura(html, url="https://example.com/legal/terms")
     assert result is not None
     text, _markdown = result
     assert "Terms of Use" in text
-    assert "Wikimedia projects" in text
+    assert "products and services" in text
 
 
 def test_parse_html_string_prefers_trafilatura_over_selectors():

--- a/packages/backend/tests/unit/crawler/html_extraction_test.py
+++ b/packages/backend/tests/unit/crawler/html_extraction_test.py
@@ -1,0 +1,96 @@
+"""Tests for trafilatura-based HTML extraction."""
+
+from src.crawler import ClauseaCrawler
+from src.crawler.html_extraction import extract_with_trafilatura
+
+
+def test_extract_with_trafilatura_mediawiki_terms():
+    html = """
+    <html class="client-nojs vector-feature-limited-width-content-enabled">
+      <body>
+        <main id="content">
+          <div id="mw-content-text" class="mw-parser-output">
+            <h1>Terms of Use</h1>
+            <p>These terms govern your use of Wikimedia projects and services.</p>
+            <p>Users must comply with applicable law and respect community guidelines.</p>
+            <p>Content may be reused under free licenses when attribution requirements are met.</p>
+          </div>
+        </main>
+      </body>
+    </html>
+    """
+    result = extract_with_trafilatura(
+        html, url="https://foundation.wikimedia.org/wiki/Policy:Terms_of_Use"
+    )
+    assert result is not None
+    text, _markdown = result
+    assert "Terms of Use" in text
+    assert "Wikimedia projects" in text
+
+
+def test_parse_html_string_prefers_trafilatura_over_selectors():
+    body_para = (
+        "This Terms of Service section explains the legal agreement between you and "
+        "the company. It describes your rights, obligations, liability, dispute "
+        "resolution, governing law, and the conditions under which the service is "
+        "provided. "
+    )
+    sections = "".join(
+        f'<div data-testid="CEPHtmlSection"><h2>Section {i}</h2><p>{body_para}</p></div>'
+        for i in range(8)
+    )
+    html = f"""
+    <!doctype html>
+    <html>
+      <body>
+        <div data-testid="related-articles-card">
+          <h3>Related articles</h3>
+          <a href="/help/article/1">About the updates to our Terms</a>
+        </div>
+        <div data-testid="article-body-container">
+          {sections}
+        </div>
+      </body>
+    </html>
+    """
+    crawler = ClauseaCrawler()
+    title, text, _markdown, _metadata, _links = crawler._parse_html_string(
+        html, "https://example.com/terms"
+    )
+
+    assert title == ""
+    assert text.count("This Terms of Service section explains") == 8
+    assert "Section 7" in text
+    assert len(text) > 1000
+
+
+def test_parse_html_string_strips_cookie_banner_with_trafilatura():
+    html = """
+    <!doctype html>
+    <html>
+      <body>
+        <div id="cookie-banner">Accept cookies</div>
+        <section class="cookie-policy legal-content">
+          <h1>Cookie Policy</h1>
+          <p>
+            This Cookie Policy explains how we use cookies, similar technologies,
+            and related tracking tools. We process personal data for analytics,
+            security, and service improvement. You can manage your consent
+            preferences, and you have rights under applicable privacy laws.
+          </p>
+          <p>
+            We may update this policy from time to time. Please review this
+            policy periodically for changes affecting data protection and usage.
+          </p>
+        </section>
+      </body>
+    </html>
+    """
+    crawler = ClauseaCrawler()
+    _title, text, _markdown, _metadata, _links = crawler._parse_html_string(
+        html, "https://example.com/cookies"
+    )
+
+    assert "Cookie Policy" in text
+    assert "data protection" in text.lower()
+    assert "Accept cookies" not in text

--- a/packages/backend/tests/unit/crawler/politeness_and_browser_tuning_test.py
+++ b/packages/backend/tests/unit/crawler/politeness_and_browser_tuning_test.py
@@ -95,8 +95,19 @@ async def test_static_fetch_sends_accept_language() -> None:
     html = b"<html><body>privacy policy terms of service we collect your data</body></html>"
 
     class FakeContent:
-        async def read(self, _limit: int) -> bytes:
-            return html
+        def __init__(self) -> None:
+            self._data = html
+            self._offset = 0
+
+        async def read(self, n: int = -1) -> bytes:
+            if n < 0:
+                n = len(self._data) - self._offset
+            if n == 0:
+                return b""
+            end = min(self._offset + n, len(self._data))
+            chunk = self._data[self._offset : end]
+            self._offset = end
+            return chunk
 
     class FakeResponse:
         def __init__(self) -> None:
@@ -107,7 +118,7 @@ async def test_static_fetch_sends_accept_language() -> None:
             self.content = FakeContent()
 
         async def read(self) -> bytes:
-            return await self.content.read(0)
+            return await self.content.read()
 
         async def __aenter__(self):
             return self

--- a/packages/backend/tests/unit/crawler/politeness_and_browser_tuning_test.py
+++ b/packages/backend/tests/unit/crawler/politeness_and_browser_tuning_test.py
@@ -106,6 +106,9 @@ async def test_static_fetch_sends_accept_language() -> None:
             self.url = YarlURL("https://example.com/legal/terms")
             self.content = FakeContent()
 
+        async def read(self) -> bytes:
+            return await self.content.read(0)
+
         async def __aenter__(self):
             return self
 

--- a/packages/backend/tests/unit/overview_heartbeat_test.py
+++ b/packages/backend/tests/unit/overview_heartbeat_test.py
@@ -20,7 +20,7 @@ from src.analyser import generate_product_overview
 from src.models.document import Document, DocumentAnalysis, DocumentAnalysisScores
 
 
-def _core_doc() -> Document:
+def _core_doc(*, doc_id: str = "doc_1", doc_type: str = "privacy_policy") -> Document:
     analysis = DocumentAnalysis(
         summary="x",
         scores={
@@ -37,17 +37,27 @@ def _core_doc() -> Document:
         critical_clauses=[],
     )
     return Document(
+        id=doc_id,
         url="https://example.com/privacy",
         product_id="p1",
-        doc_type="privacy_policy",  # type: ignore[arg-type]
+        doc_type=doc_type,  # type: ignore[arg-type]
         markdown="",
         analysis=analysis,
     )
 
 
+def _adequate_core_docs() -> list[Document]:
+    return [
+        _core_doc(doc_id="doc_1", doc_type="privacy_policy"),
+        _core_doc(doc_id="doc_2", doc_type="privacy_policy"),
+        _core_doc(doc_id="doc_3", doc_type="terms_of_service"),
+    ]
+
+
 def _overview_response() -> ModelResponse:
     payload = {
         "summary": "ok",
+        "headline_claim": "Example collects account and usage data for service delivery.",
         "scores": {
             "transparency": {"score": 5, "justification": ""},
             "data_collection_scope": {"score": 5, "justification": ""},
@@ -75,7 +85,7 @@ def _services() -> tuple[MagicMock, MagicMock]:
     product_svc.get_product_by_slug = AsyncMock(return_value=product)
     product_svc.save_product_overview = AsyncMock(return_value=True)
     document_svc = MagicMock()
-    document_svc.get_product_documents_by_slug = AsyncMock(return_value=[_core_doc()])
+    document_svc.get_product_documents_by_slug = AsyncMock(return_value=_adequate_core_docs())
     return product_svc, document_svc
 
 

--- a/packages/backend/tests/unit/product_overview_fixes_test.py
+++ b/packages/backend/tests/unit/product_overview_fixes_test.py
@@ -40,6 +40,33 @@ def _make_meta_summary(**extra: object) -> MetaSummary:
     return MetaSummary.model_validate(base)
 
 
+def _community_guidelines_doc() -> Document:
+    analysis = DocumentAnalysis(
+        summary="Transparency report summary",
+        scores={
+            "transparency": DocumentAnalysisScores(score=5, justification=""),
+            "data_collection_scope": DocumentAnalysisScores(score=5, justification=""),
+            "user_control": DocumentAnalysisScores(score=5, justification=""),
+            "third_party_sharing": DocumentAnalysisScores(score=5, justification=""),
+            "data_retention_score": DocumentAnalysisScores(score=5, justification=""),
+            "security_score": DocumentAnalysisScores(score=5, justification=""),
+        },
+        risk_score=4,
+        verdict="moderate",
+        keypoints=[],
+        critical_clauses=[],
+    )
+    return Document(
+        id="doc_cg",
+        title="Transparency report",
+        url="https://example.com/transparency",
+        product_id="p1",
+        doc_type="community_guidelines",  # type: ignore[arg-type]
+        markdown="",
+        analysis=analysis,
+    )
+
+
 def _core_doc() -> Document:
     analysis = DocumentAnalysis(
         summary="x",
@@ -428,3 +455,55 @@ async def test_generate_product_overview_raises_after_max_validation_retries() -
 
     assert llm_mock.await_count == 3
     product_svc.save_product_overview.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generate_product_overview_withholds_grade_when_thin_evidence() -> None:
+    """Non-core-only evidence must not produce a consumer-facing grade."""
+    product_svc, document_svc = _services()
+    document_svc.get_product_documents_by_slug = AsyncMock(
+        return_value=[_community_guidelines_doc()]
+    )
+    rollup_service = MagicMock()
+    rollup_service.build_product_rollup = AsyncMock(
+        return_value=MagicMock(
+            findings=[],
+            coverage=[],
+            conflicts=[],
+            product_id="p1",
+            product_slug="example",
+        )
+    )
+    llm_payload = _base_llm_payload(
+        grade="D",
+        grade_justification="Overclaims from transparency report",
+        verdict="pervasive",
+        risk_score=7,
+    )
+
+    with (
+        patch("src.analyser.ProductRollupService", return_value=rollup_service),
+        patch(
+            "src.analyser.acompletion_with_fallback",
+            AsyncMock(return_value=_llm_response(llm_payload)),
+        ),
+    ):
+        result = await generate_product_overview(
+            MagicMock(),
+            "example",
+            force_regenerate=True,
+            product_svc=product_svc,
+            document_svc=document_svc,
+        )
+
+    assert result.grade is None
+    assert result.verdict is None
+    assert result.risk_score is None
+    product_svc.save_product_overview.assert_awaited_once()
+    save_kwargs = product_svc.save_product_overview.call_args.kwargs
+    assert save_kwargs["thin_evidence"] is True
+    assert save_kwargs["thin_evidence_reason"] is not None
+    assert "No core" in save_kwargs["thin_evidence_reason"]
+    saved_meta = save_kwargs["meta_summary"]
+    assert saved_meta.grade is None
+    assert saved_meta.verdict is None

--- a/packages/backend/uv.lock
+++ b/packages/backend/uv.lock
@@ -222,6 +222,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backports-zstd"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -604,6 +613,7 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
     { name = "tldextract" },
+    { name = "trafilatura" },
     { name = "uvicorn" },
     { name = "watchdog" },
 ]
@@ -649,6 +659,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "tldextract", specifier = ">=5.3.1" },
+    { name = "trafilatura", specifier = ">=2.1.0" },
     { name = "uvicorn", specifier = ">=0.34.2" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
@@ -683,6 +694,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "courlan"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/16/2a771612ee0b3acaa95ac21cc7e8a3319e815d6360f8ffc5987d1ce28499/courlan-1.4.0.tar.gz", hash = "sha256:fbbac7b7fcde2195ea08e707609503c81cf39c891e8d26cdb1fed4585782d63d", size = 208997, upload-time = "2026-06-01T17:30:17.306Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/38/ce65091ff20a16e06d17418c4353af5f56d3190821b1a06983c79ae79274/courlan-1.4.0-py3-none-any.whl", hash = "sha256:ad1dbdefd912ca7238d4607dc855df5df097f56bac175dd662c84eed3802f49e", size = 34193, upload-time = "2026-06-01T17:30:14.984Z" },
 ]
 
 [[package]]
@@ -753,6 +778,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/78/668ef887621f68255feddd482dbcdcf5788b6c91227dd35bd17f128f827b/cython-3.2.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a636c8b7824f3cb587eb2fdde59d8f4a14d433565508081cc290198e37567910", size = 2981525, upload-time = "2026-05-23T19:34:58.445Z" },
     { url = "https://files.pythonhosted.org/packages/a3/de/e3e0cf5704fe569d54b8cd5dc316c9fbf08b1b74728732f86e90168b7a3f/cython-3.2.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:224149d18d980e6ea5001b70fc7ce096c1891d59035dfa9cc5ede50f55804913", size = 2879054, upload-time = "2026-05-23T19:35:18.265Z" },
     { url = "https://files.pythonhosted.org/packages/d4/5c/9cd909e6a8bb178e4e0f9a2a9227c8201a2be38abe45ada4a4c3e9154277/cython-3.2.5-py3-none-any.whl", hash = "sha256:dc1c8cebb7df5bce37f5f8dc1e5bf04313272a5973d50a55c0ec76c83812911b", size = 1257622, upload-time = "2026-05-23T19:34:05.163Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/f4/561c49bca97af561d34eed27e3e831135eb5cb88e754c1150be41820f5c6/dateparser-1.4.1.tar.gz", hash = "sha256:f265df13c0380e2e07543ba74b67c0681aaa1096981ffcd35227e1aa0cb81c7c", size = 314734, upload-time = "2026-06-15T08:45:47.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/7c/2e5dcf53909deddd0bf38cbe277ad9806be038276b1c6c436561b4d9b2e2/dateparser-1.4.1-py3-none-any.whl", hash = "sha256:f25d4e051a84be27a35bd297e3e1dc59ff78373701b89be352ba80372d22d0d0", size = 300503, upload-time = "2026-06-15T08:45:45.951Z" },
 ]
 
 [[package]]
@@ -1330,6 +1370,22 @@ wheels = [
 ]
 
 [[package]]
+name = "htmldate"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/1f/e7cf83e23d7b68105de8b874a8b36ba23b450d6f71388583e4ca3ce475ca/htmldate-1.10.0.tar.gz", hash = "sha256:a38df10772ab5d7dbb11896e3f6a852a8491fb1b0965465bc174e23fc2baae58", size = 44455, upload-time = "2026-06-01T17:43:53.437Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/17/d3356233c826c641f940983d9479eab27faec59d49f4070bc58e80fcc021/htmldate-1.10.0-py3-none-any.whl", hash = "sha256:9211dae35ab94147c8ed9e5fc2c9287a5cf31d2394cb7857e7f5dd814eb2aad6", size = 31561, upload-time = "2026-06-01T17:43:51.797Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1623,6 +1679,18 @@ wheels = [
 ]
 
 [[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload-time = "2025-02-25T20:21:44.179Z" },
+]
+
+[[package]]
 name = "language-tags"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1768,6 +1836,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
     { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
     { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/63/195dfdde380a84df309e3bccf4384b034b745dba43426886f7ae623b4fba/lxml_html_clean-0.4.5.tar.gz", hash = "sha256:e2a4c7d5beedd17cd7b484d848a0571e54baa239a4f9df5546e3acba7f990560", size = 24142, upload-time = "2026-05-20T12:17:53.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/bd/6e2b76a6c5dee10397db9c929f0c5066766ec1036046f0335b7ca7ca08b8/lxml_html_clean-0.4.5-py3-none-any.whl", hash = "sha256:c76fcadd1e5bfb9b8bafc2200d51e4e78eb0dad67f56881c21dfb6484c7e7746", size = 14573, upload-time = "2026-05-20T12:17:52.215Z" },
 ]
 
 [[package]]
@@ -3097,7 +3182,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -3251,6 +3336,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
 ]
 
 [[package]]
@@ -3997,6 +4091,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
+]
+
+[[package]]
 name = "tldextract"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4057,6 +4160,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "trafilatura"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/19/24833e905df2d80e3bb67424f95febcc17709a1f61a522120bc438afca70/trafilatura-2.1.0.tar.gz", hash = "sha256:f689e2116fc89c7bc0b9a296d01dcfe2eb0b5455f8c371a77dc0db1f06a05643", size = 263876, upload-time = "2026-06-07T17:43:31.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/78/4ad99d79aee2784f49f20fd0a29058ce4c032fe4439047924c43521cd211/trafilatura-2.1.0-py3-none-any.whl", hash = "sha256:0eded5207a806445ddebbe36eae30b9035fe6a2f233c36f6fe82663fca8b9d30", size = 134600, upload-time = "2026-06-07T17:43:28.404Z" },
 ]
 
 [[package]]
@@ -4127,6 +4248,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
 ]
 
 [[package]]

--- a/packages/frontend/components/dashboard/evidence-list.tsx
+++ b/packages/frontend/components/dashboard/evidence-list.tsx
@@ -222,16 +222,6 @@ export function EvidenceList({
 
   return (
     <div className="space-y-6">
-      {hasTopics && (
-        <TopicEvidencePanel
-          topicStances={topicStances}
-          topicReport={topicReport}
-          title="Evidence by Policy Topic"
-          showCitations={true}
-          collapsibleTopics={true}
-        />
-      )}
-
       {documents.length > 0 ? (
         <Card
           variant="default"
@@ -244,9 +234,7 @@ export function EvidenceList({
                   <FileText className="h-5 w-5 text-foreground" />
                 </div>
                 <div>
-                  <CardTitle className="text-lg">
-                    Policy Document Library
-                  </CardTitle>
+                  <CardTitle className="text-lg">Sources</CardTitle>
                   <p className="text-sm text-muted-foreground mt-0.5">
                     Original policies we analyzed, with document-level findings
                     and supporting quotes.
@@ -808,9 +796,19 @@ export function EvidenceList({
           className="border-border bg-background shadow-none overflow-hidden"
         >
           <CardContent className="py-8 text-center text-sm text-muted-foreground">
-            No policy document library is available yet.
+            No sources are available yet.
           </CardContent>
         </Card>
+      )}
+
+      {hasTopics && (
+        <TopicEvidencePanel
+          topicStances={topicStances}
+          topicReport={topicReport}
+          title="Evidence by Policy Topic"
+          showCitations={true}
+          collapsibleTopics={true}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- **Thin-evidence gate:** Products with fewer than 2 core doc types or fewer than 3 core docs still get an overview saved, but consumer grades (`grade`, `verdict`, `risk_score`) are stripped and `thin_evidence` is persisted. Grades are cleared before validation so guards do not emit spurious warnings. `stats.has_overview` reflects graded overviews only.
- **Crawler HTML extraction:** Add **trafilatura** as the primary main-content extractor (after chrome/consent stripping), with the existing selector-based path as fallback. Removes site-specific selector hacks in favor of a general extraction strategy.
- **Crawler fetch safety:** Read response bodies in 64KB chunks capped at `MAX_RESPONSE_BYTES` so gzip-compressed pages decode fully without unbounded memory use.
- **Frontend:** Move document library above topic evidence and rename the section to **Sources**.

## Test plan

- [x] `uv run pytest tests/thin_evidence_gate_test.py tests/unit/product_overview_fixes_test.py`
- [x] `uv run pytest tests/unit/crawler/` (247 passed)
- [x] Pre-commit hooks (ruff, ty, backend tests, frontend lint)

## Deploy notes

After merge, re-run pipeline jobs for products that were indexed with thin evidence (e.g. Wikipedia) so crawls pick up full policy content under the new extractor.