### PR TITLE
feat(migrations): auto-run versioned migrations on FastAPI startup

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -27,6 +27,7 @@ from src.routes import (
     subscription,
     users,
 )
+from src.services.migration_service import MigrationService
 
 setup_logging()
 logger = structlog.get_logger(service="main")
@@ -46,6 +47,9 @@ async def _initialize_database() -> None:
             return
 
         async with db_session() as db:
+            # Migrations first: they may create/rename collections that the
+            # index step below then builds against.
+            await MigrationService().run_pending(db)
             await ensure_all_indexes(db)
             # Reap orphaned jobs first (frees the active slot), THEN build the partial
             # unique index that enforces at-most-one active job per product.

--- a/packages/backend/scripts/migrate_topic_stances.py
+++ b/packages/backend/scripts/migrate_topic_stances.py
@@ -1,0 +1,90 @@
+"""Migrate topic stance labels from risk-tier names to qualitative adjectives.
+
+Old → New:
+  low_risk       → fair
+  moderate_risk  → concerning
+  high_risk      → harmful
+  mixed          → conflicting
+  not_disclosed  → not_disclosed (unchanged)
+
+Also removes topic_score from overview.topic_stances entries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+from motor.motor_asyncio import AsyncIOMotorClient
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+MONGO_URI = os.environ["PRODUCTION_MONGO_URI"]
+
+_STANCE_MAP = {
+    "low_risk": "fair",
+    "moderate_risk": "concerning",
+    "high_risk": "harmful",
+    "mixed": "conflicting",
+}
+
+COLLECTION = "product_intelligence"
+
+
+async def run(*, dry_run: bool = False) -> None:
+    client: AsyncIOMotorClient = AsyncIOMotorClient(MONGO_URI)
+    try:
+        default_db = client.get_default_database()
+        db_name = default_db.name if default_db is not None else "clausea"
+    except Exception:
+        db_name = "clausea"
+    db = client[db_name]
+    col = db[COLLECTION]
+
+    total = await col.count_documents({})
+    print(f"Collection '{COLLECTION}': {total} documents")
+
+    affected = await col.count_documents({"overview.topic_stances": {"$exists": True}})
+    print(f"Documents with overview.topic_stances: {affected}")
+
+    if dry_run:
+        print("Dry run — no changes written.")
+        client.close()
+        return
+
+    updated = 0
+    async for doc in col.find(
+        {"overview.topic_stances": {"$exists": True}},
+        {"_id": 1, "product_slug": 1, "overview.topic_stances": 1},
+    ):
+        stances = doc.get("overview", {}).get("topic_stances") or []
+        new_stances = []
+        changed = False
+        for s in stances:
+            entry = dict(s)
+            old = entry.get("stance")
+            if old in _STANCE_MAP:
+                entry["stance"] = _STANCE_MAP[old]
+                changed = True
+            if "topic_score" in entry:
+                del entry["topic_score"]
+                changed = True
+            new_stances.append(entry)
+
+        if changed:
+            await col.update_one(
+                {"_id": doc["_id"]},
+                {"$set": {"overview.topic_stances": new_stances}},
+            )
+            updated += 1
+
+    print(f"Updated {updated} documents.")
+    client.close()
+
+
+if __name__ == "__main__":
+    dry_run = "--dry-run" in sys.argv
+    asyncio.run(run(dry_run=dry_run))

--- a/packages/backend/src/migrations/000_rename_companies_to_products.py
+++ b/packages/backend/src/migrations/000_rename_companies_to_products.py
@@ -62,7 +62,7 @@ async def migrate_companies_to_products(db: AgnosticDatabase) -> dict[str, Any]:
 
 
 class MigrateCompaniesToProducts(Migration):
-    migration_id = "20260214_000001_rename_companies_to_products"
+    migration_id = "000_rename_companies_to_products"
     description = "Rename companies collection to products and remap company_* fields"
 
     async def upgrade(self, db: AgnosticDatabase) -> dict[str, Any]:

--- a/packages/backend/src/migrations/000_rename_companies_to_products.py
+++ b/packages/backend/src/migrations/000_rename_companies_to_products.py
@@ -6,7 +6,8 @@
 4. Updates any remaining 'company_id' references in product_intelligence.
 
 Idempotent: the rename is skipped once 'products' exists, and every ``$rename``
-is guarded by ``$exists`` so re-runs touch zero documents.
+is guarded by ``$exists`` on the source AND ``$exists: False`` on the target so
+re-runs touch zero documents and partial migrations don't fail on pre-patched docs.
 """
 
 from __future__ import annotations
@@ -40,19 +41,19 @@ async def migrate_companies_to_products(db: AgnosticDatabase) -> dict[str, Any]:
         detail["renamed_collection"] = False
 
     result = await db.documents.update_many(
-        {"company_id": {"$exists": True}},
+        {"company_id": {"$exists": True}, "product_id": {"$exists": False}},
         {"$rename": {"company_id": "product_id"}},
     )
     detail["documents_renamed"] = result.modified_count
 
     result = await db.product_intelligence.update_many(
-        {"company_slug": {"$exists": True}},
+        {"company_slug": {"$exists": True}, "product_slug": {"$exists": False}},
         {"$rename": {"company_slug": "product_slug"}},
     )
     detail["product_intelligence_slug_renamed"] = result.modified_count
 
     result = await db.product_intelligence.update_many(
-        {"company_id": {"$exists": True}},
+        {"company_id": {"$exists": True}, "product_id": {"$exists": False}},
         {"$rename": {"company_id": "product_id"}},
     )
     detail["product_intelligence_id_renamed"] = result.modified_count

--- a/packages/backend/src/migrations/001_fix_thin_evidence_products.py
+++ b/packages/backend/src/migrations/001_fix_thin_evidence_products.py
@@ -99,7 +99,7 @@ async def fix_thin_evidence_products(db: AgnosticDatabase) -> dict[str, Any]:
 
 
 class FixThinEvidenceProducts(Migration):
-    migration_id = "20260624_000001_fix_thin_evidence_products"
+    migration_id = "001_fix_thin_evidence_products"
     description = "Patch crawl configs (robots/denied domains) for thin-evidence audit products"
 
     async def upgrade(self, db: AgnosticDatabase) -> dict[str, Any]:

--- a/packages/backend/src/migrations/002_backfill_orphan_citations.py
+++ b/packages/backend/src/migrations/002_backfill_orphan_citations.py
@@ -85,7 +85,7 @@ async def backfill_orphan_citations(db: AgnosticDatabase) -> dict[str, Any]:
 
 
 class BackfillOrphanCitations(Migration):
-    migration_id = "20260624_000002_backfill_orphan_citations"
+    migration_id = "002_backfill_orphan_citations"
     description = "Flag overview citations pointing at deleted documents as stale"
 
     async def upgrade(self, db: AgnosticDatabase) -> dict[str, Any]:

--- a/packages/backend/src/migrations/003_migrate_topic_stances.py
+++ b/packages/backend/src/migrations/003_migrate_topic_stances.py
@@ -19,6 +19,7 @@ import asyncio
 from typing import Any
 
 from motor.core import AgnosticDatabase
+from pymongo import UpdateOne
 
 from src.core.database import db_session
 from src.core.logging import get_logger
@@ -34,6 +35,7 @@ _STANCE_MAP = {
 }
 
 COLLECTION = "product_intelligence"
+_BULK_BATCH_SIZE = 500
 
 
 async def migrate_topic_stances(db: AgnosticDatabase) -> dict[str, Any]:
@@ -44,6 +46,7 @@ async def migrate_topic_stances(db: AgnosticDatabase) -> dict[str, Any]:
     affected = await col.count_documents({"overview.topic_stances": {"$exists": True}})
 
     updated = 0
+    updates: list[UpdateOne] = []
     async for doc in col.find(
         {"overview.topic_stances": {"$exists": True}},
         {"_id": 1, "product_slug": 1, "overview.topic_stances": 1},
@@ -63,11 +66,20 @@ async def migrate_topic_stances(db: AgnosticDatabase) -> dict[str, Any]:
             new_stances.append(entry)
 
         if changed:
-            await col.update_one(
-                {"_id": doc["_id"]},
-                {"$set": {"overview.topic_stances": new_stances}},
+            updates.append(
+                UpdateOne(
+                    {"_id": doc["_id"]},
+                    {"$set": {"overview.topic_stances": new_stances}},
+                )
             )
-            updated += 1
+            if len(updates) >= _BULK_BATCH_SIZE:
+                result = await col.bulk_write(updates)
+                updated += result.modified_count
+                updates = []
+
+    if updates:
+        result = await col.bulk_write(updates)
+        updated += result.modified_count
 
     logger.info(
         "topic_stances migration complete",

--- a/packages/backend/src/migrations/003_migrate_topic_stances.py
+++ b/packages/backend/src/migrations/003_migrate_topic_stances.py
@@ -7,22 +7,24 @@ Old → New:
   mixed          → conflicting
   not_disclosed  → not_disclosed (unchanged)
 
-Also removes topic_score from overview.topic_stances entries.
+Also removes ``topic_score`` from ``overview.topic_stances`` entries.
+
+Idempotent: re-running finds no entries matching the old stance labels and
+no entries still carrying ``topic_score``, so zero documents are modified.
 """
 
 from __future__ import annotations
 
 import asyncio
-import os
-import sys
-from pathlib import Path
+from typing import Any
 
-from dotenv import load_dotenv
-from motor.motor_asyncio import AsyncIOMotorClient
+from motor.core import AgnosticDatabase
 
-load_dotenv(Path(__file__).parent.parent / ".env")
+from src.core.database import db_session
+from src.core.logging import get_logger
+from src.migrations.base import Migration
 
-MONGO_URI = os.environ["PRODUCTION_MONGO_URI"]
+logger = get_logger(__name__)
 
 _STANCE_MAP = {
     "low_risk": "fair",
@@ -34,26 +36,12 @@ _STANCE_MAP = {
 COLLECTION = "product_intelligence"
 
 
-async def run(*, dry_run: bool = False) -> None:
-    client: AsyncIOMotorClient = AsyncIOMotorClient(MONGO_URI)
-    try:
-        default_db = client.get_default_database()
-        db_name = default_db.name if default_db is not None else "clausea"
-    except Exception:
-        db_name = "clausea"
-    db = client[db_name]
+async def migrate_topic_stances(db: AgnosticDatabase) -> dict[str, Any]:
+    """Rename stance labels and strip topic_score from product_intelligence overviews."""
     col = db[COLLECTION]
 
     total = await col.count_documents({})
-    print(f"Collection '{COLLECTION}': {total} documents")
-
     affected = await col.count_documents({"overview.topic_stances": {"$exists": True}})
-    print(f"Documents with overview.topic_stances: {affected}")
-
-    if dry_run:
-        print("Dry run — no changes written.")
-        client.close()
-        return
 
     updated = 0
     async for doc in col.find(
@@ -63,8 +51,8 @@ async def run(*, dry_run: bool = False) -> None:
         stances = doc.get("overview", {}).get("topic_stances") or []
         new_stances = []
         changed = False
-        for s in stances:
-            entry = dict(s)
+        for stance in stances:
+            entry = dict(stance)
             old = entry.get("stance")
             if old in _STANCE_MAP:
                 entry["stance"] = _STANCE_MAP[old]
@@ -81,10 +69,27 @@ async def run(*, dry_run: bool = False) -> None:
             )
             updated += 1
 
-    print(f"Updated {updated} documents.")
-    client.close()
+    logger.info(
+        "topic_stances migration complete",
+        total=total,
+        with_stances=affected,
+        updated=updated,
+    )
+    return {"total": total, "with_stances": affected, "updated": updated}
+
+
+class MigrateTopicStances(Migration):
+    migration_id = "003_migrate_topic_stances"
+    description = "Rename stance labels (low_risk→fair etc.) and strip topic_score"
+
+    async def upgrade(self, db: AgnosticDatabase) -> dict[str, Any]:
+        return await migrate_topic_stances(db)
 
 
 if __name__ == "__main__":
-    dry_run = "--dry-run" in sys.argv
-    asyncio.run(run(dry_run=dry_run))
+
+    async def _run() -> None:
+        async with db_session() as db:
+            await migrate_topic_stances(db)
+
+    asyncio.run(_run())

--- a/packages/backend/src/migrations/__init__.py
+++ b/packages/backend/src/migrations/__init__.py
@@ -1,29 +1,32 @@
 """Migration framework.
 
-Importing this package registers every auto-runnable migration with the
-:data:`src.migrations.registry.registry`. The :class:`src.services.migration_service.MigrationService`
-applies pending entries on FastAPI startup.
+Importing this package auto-discovers every ``NNN_*.py`` module in this
+package, instantiates its :class:`~src.migrations.base.Migration` subclass, and
+registers it with :data:`src.migrations.registry.registry`. The
+:class:`src.services.migration_service.MigrationService` applies pending
+entries on FastAPI startup.
+
+To add a new migration: create ``NNN_description.py`` with a ``Migration``
+subclass whose ``migration_id`` matches the filename stem. No other
+registration needed.
 
 Manual/interactive ops scripts (e.g. ``fix_product_names``, which prompts for
-confirmation and targets a separate production URI) are intentionally NOT
-registered here — they must be run by hand.
+confirmation and targets a separate production URI) do NOT use the ``NNN_``
+prefix and are therefore not auto-discovered — they must be run by hand.
 """
 
 from __future__ import annotations
 
-from src.migrations.backfill_orphan_citations import BackfillOrphanCitations
 from src.migrations.base import Migration, MigrationResult
-from src.migrations.fix_thin_evidence_products import FixThinEvidenceProducts
-from src.migrations.migrate_companies_to_products import MigrateCompaniesToProducts
-from src.migrations.registry import MigrationRegistry, registry
+from src.migrations.registry import MigrationRegistry, autodiscover, registry
 
-registry.register(MigrateCompaniesToProducts())
-registry.register(FixThinEvidenceProducts())
-registry.register(BackfillOrphanCitations())
+for _migration in autodiscover():
+    registry.register(_migration)
 
 __all__ = [
     "Migration",
     "MigrationResult",
     "MigrationRegistry",
+    "autodiscover",
     "registry",
 ]

--- a/packages/backend/src/migrations/__init__.py
+++ b/packages/backend/src/migrations/__init__.py
@@ -1,0 +1,29 @@
+"""Migration framework.
+
+Importing this package registers every auto-runnable migration with the
+:data:`src.migrations.registry.registry`. The :class:`src.services.migration_service.MigrationService`
+applies pending entries on FastAPI startup.
+
+Manual/interactive ops scripts (e.g. ``fix_product_names``, which prompts for
+confirmation and targets a separate production URI) are intentionally NOT
+registered here — they must be run by hand.
+"""
+
+from __future__ import annotations
+
+from src.migrations.backfill_orphan_citations import BackfillOrphanCitations
+from src.migrations.base import Migration, MigrationResult
+from src.migrations.fix_thin_evidence_products import FixThinEvidenceProducts
+from src.migrations.migrate_companies_to_products import MigrateCompaniesToProducts
+from src.migrations.registry import MigrationRegistry, registry
+
+registry.register(MigrateCompaniesToProducts())
+registry.register(FixThinEvidenceProducts())
+registry.register(BackfillOrphanCitations())
+
+__all__ = [
+    "Migration",
+    "MigrationResult",
+    "MigrationRegistry",
+    "registry",
+]

--- a/packages/backend/src/migrations/backfill_orphan_citations.py
+++ b/packages/backend/src/migrations/backfill_orphan_citations.py
@@ -7,74 +7,95 @@ scans every ``product_intelligence`` overview, finds citations whose
 ``document_id`` is missing from ``documents``, and flags them ``stale: True``
 so the UI filter can hide them.
 
-Run with:  uv run python -m src.migrations.backfill_orphan_citations
+Idempotent: re-running re-scans orphans and re-marks them stale (a no-op on
+already-stale citations).
 """
 
 from __future__ import annotations
 
 import asyncio
+from typing import Any
+
+from motor.core import AgnosticDatabase
 
 from src.core.database import db_session
 from src.core.logging import get_logger
+from src.migrations.base import Migration
 from src.repositories.product_intelligence_repository import ProductIntelligenceRepository
 
 logger = get_logger(__name__)
 
 
-async def backfill_orphan_citations() -> int:
+async def backfill_orphan_citations(db: AgnosticDatabase) -> dict[str, Any]:
     """Mark stale every overview citation pointing at a deleted document.
 
-    Returns the total number of citations flagged stale.
+    Returns a detail dict with the reference counts and the total number of
+    citations flagged stale.
     """
     repo = ProductIntelligenceRepository()
     total_marked = 0
 
-    async with db_session() as db:
-        cursor = db[repo.COLLECTION].find(
-            {"overview": {"$exists": True, "$ne": None}},
-            {"_id": 0, "overview.topic_stances.supporting_citations.document_id": 1},
-        )
+    cursor = db[repo.COLLECTION].find(
+        {"overview": {"$exists": True, "$ne": None}},
+        {"_id": 0, "overview.topic_stances.supporting_citations.document_id": 1},
+    )
 
-        referenced_ids: set[str] = set()
-        async for row in cursor:
-            for stance in (row.get("overview") or {}).get("topic_stances") or []:
-                for cite in stance.get("supporting_citations") or []:
-                    document_id = cite.get("document_id")
-                    if isinstance(document_id, str) and document_id:
-                        referenced_ids.add(document_id)
+    referenced_ids: set[str] = set()
+    async for row in cursor:
+        for stance in (row.get("overview") or {}).get("topic_stances") or []:
+            for cite in stance.get("supporting_citations") or []:
+                document_id = cite.get("document_id")
+                if isinstance(document_id, str) and document_id:
+                    referenced_ids.add(document_id)
 
-        if not referenced_ids:
-            logger.info("No citations found across product_intelligence overviews.")
-            return 0
+    if not referenced_ids:
+        logger.info("No citations found across product_intelligence overviews.")
+        return {"referenced": 0, "existing": 0, "orphan": 0, "marked_stale": 0}
 
-        existing_ids: set[str] = set()
-        async for row in db.documents.find(
-            {"id": {"$in": list(referenced_ids)}}, {"_id": 0, "id": 1}
-        ):
-            if row.get("id"):
-                existing_ids.add(row["id"])
+    existing_ids: set[str] = set()
+    async for row in db.documents.find({"id": {"$in": list(referenced_ids)}}, {"_id": 0, "id": 1}):
+        if row.get("id"):
+            existing_ids.add(row["id"])
 
-        orphan_ids = referenced_ids - existing_ids
-        logger.info(
-            "Referenced document_ids: %d | existing: %d | orphan: %d",
-            len(referenced_ids),
-            len(existing_ids),
-            len(orphan_ids),
-        )
+    orphan_ids = referenced_ids - existing_ids
+    logger.info(
+        "Referenced document_ids: %d | existing: %d | orphan: %d",
+        len(referenced_ids),
+        len(existing_ids),
+        len(orphan_ids),
+    )
 
-        for orphan_id in sorted(orphan_ids):
-            marked = await repo.mark_citations_stale_for_document(db, orphan_id)
-            if marked:
-                logger.info(
-                    "Marked %d citation(s) stale for orphan document_id=%s",
-                    marked,
-                    orphan_id,
-                )
-                total_marked += marked
+    for orphan_id in sorted(orphan_ids):
+        marked = await repo.mark_citations_stale_for_document(db, orphan_id)
+        if marked:
+            logger.info(
+                "Marked %d citation(s) stale for orphan document_id=%s",
+                marked,
+                orphan_id,
+            )
+            total_marked += marked
 
-        logger.info("Backfill complete. Total citations marked stale: %d", total_marked)
-        return total_marked
+    logger.info("Backfill complete. Total citations marked stale: %d", total_marked)
+    return {
+        "referenced": len(referenced_ids),
+        "existing": len(existing_ids),
+        "orphan": len(orphan_ids),
+        "marked_stale": total_marked,
+    }
+
+
+class BackfillOrphanCitations(Migration):
+    migration_id = "20260624_000002_backfill_orphan_citations"
+    description = "Flag overview citations pointing at deleted documents as stale"
+
+    async def upgrade(self, db: AgnosticDatabase) -> dict[str, Any]:
+        return await backfill_orphan_citations(db)
 
 
 if __name__ == "__main__":
-    asyncio.run(backfill_orphan_citations())
+
+    async def _run() -> None:
+        async with db_session() as db:
+            await backfill_orphan_citations(db)
+
+    asyncio.run(_run())

--- a/packages/backend/src/migrations/base.py
+++ b/packages/backend/src/migrations/base.py
@@ -1,0 +1,68 @@
+"""Base class for versioned MongoDB data migrations.
+
+Each migration is an idempotent, ordered transformation applied to the database
+on FastAPI startup by :mod:`src.services.migration_service`. Migrations are
+tracked in the ``_migrations`` collection so each runs exactly once per
+environment. MongoDB is schemaless, so these are data migrations (renames,
+backfills, config fixes) rather than DDL schema migrations — but the ordering
+and exactly-once guarantees are just as important.
+
+To add a new migration:
+    1. Subclass :class:`Migration` with a unique, sortable ``migration_id``
+       (format ``YYYYMMDD_NNNNNN_slug``) and a human-readable ``description``.
+    2. Implement :meth:`upgrade` — it MUST be safe to re-run (idempotent).
+    3. Register an instance in ``src/migrations/__init__.py``.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from motor.core import AgnosticDatabase
+
+
+@dataclass
+class MigrationResult:
+    """Outcome of a single migration attempt, recorded in ``_migrations``."""
+
+    migration_id: str
+    description: str
+    status: str  # "applied" | "failed"
+    applied_at: datetime
+    duration_ms: int
+    detail: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+class Migration(abc.ABC):
+    """A single idempotent, ordered data migration applied to MongoDB.
+
+    ``migration_id`` must be globally unique and sort lexicographically in the
+    order migrations should be applied (e.g. ``20260214_000001_rename_companies``).
+    """
+
+    migration_id: str = ""
+    description: str = ""
+
+    @abc.abstractmethod
+    async def upgrade(self, db: AgnosticDatabase) -> dict[str, Any]:
+        """Apply the migration. Must be idempotent.
+
+        Args:
+            db: The database session to operate on.
+
+        Returns:
+            A detail dict (counts, changed slugs, etc.) stored alongside the
+            migration record for auditability.
+        """
+        ...
+
+    async def downgrade(self, db: AgnosticDatabase) -> None:
+        """Optional rollback. Not invoked by the startup runner.
+
+        Provided for manual ops recovery only.
+        """
+        raise NotImplementedError(f"{self.migration_id} has no downgrade")

--- a/packages/backend/src/migrations/fix_thin_evidence_products.py
+++ b/packages/backend/src/migrations/fix_thin_evidence_products.py
@@ -13,7 +13,8 @@ the right scope:
 - ``amazon``   : ``aws.amazon.com`` drifted into the crawl via the old subdomain matcher.
                  Deny it explicitly via crawl_denied_domains.
 
-Run with:  uv run python -m src.migrations.fix_thin_evidence_products
+Idempotent: every write is a ``$set`` to a target value or ``$addToSet``, so re-runs
+converge on the same desired state with no-op modifications.
 """
 
 from __future__ import annotations
@@ -21,8 +22,11 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from motor.core import AgnosticDatabase
+
 from src.core.database import db_session
 from src.core.logging import get_logger
+from src.migrations.base import Migration
 
 logger = get_logger(__name__)
 
@@ -30,7 +34,7 @@ ROBLOX_PRIVACY_URL = "https://www.roblox.com/info/privacy"
 
 
 async def _apply(
-    db,
+    db: AgnosticDatabase,
     slug: str,
     set_fields: dict[str, Any],
     add_to_set: dict[str, list[str]] | None = None,
@@ -50,48 +54,62 @@ async def _apply(
     }
 
 
-async def fix_thin_evidence_products() -> None:
-    """Apply the per-product crawl-config fixes and log a summary of changes."""
-    async with db_session() as db:
-        results: list[dict[str, Any]] = []
+async def fix_thin_evidence_products(db: AgnosticDatabase) -> dict[str, Any]:
+    """Apply the per-product crawl-config fixes and return a summary."""
+    results: list[dict[str, Any]] = []
 
-        results.append(await _apply(db, "booking", {"crawl_ignore_robots": False}))
-        results.append(
-            await _apply(
-                db,
-                "roblox",
-                {"name": "Roblox", "crawl_ignore_robots": True},
-                {"crawl_base_urls": [ROBLOX_PRIVACY_URL]},
-            )
+    results.append(await _apply(db, "booking", {"crawl_ignore_robots": False}))
+    results.append(
+        await _apply(
+            db,
+            "roblox",
+            {"name": "Roblox", "crawl_ignore_robots": True},
+            {"crawl_base_urls": [ROBLOX_PRIVACY_URL]},
         )
-        results.append(await _apply(db, "messenger", {"crawl_ignore_robots": True}))
-        results.append(
-            await _apply(
-                db,
-                "amazon",
-                {},
-                {"crawl_denied_domains": ["aws.amazon.com"]},
-            )
+    )
+    results.append(await _apply(db, "messenger", {"crawl_ignore_robots": True}))
+    results.append(
+        await _apply(
+            db,
+            "amazon",
+            {},
+            {"crawl_denied_domains": ["aws.amazon.com"]},
         )
+    )
 
-        logger.info("Thin-evidence product config fixes — summary:")
-        for row in results:
-            slug = row["slug"]
-            matched = row["matched"]
-            if not matched:
-                logger.warning("  %s: NOT FOUND in products collection", slug)
-                continue
-            before = row["before"] or {}
-            after = row["after"] or {}
-            changed: list[str] = []
-            for field in ("crawl_ignore_robots", "crawl_denied_domains", "crawl_base_urls", "name"):
-                if before.get(field) != after.get(field):
-                    changed.append(f"{field}: {before.get(field)!r} -> {after.get(field)!r}")
-            if changed:
-                logger.info("  %s: %s", slug, "; ".join(changed))
-            else:
-                logger.info("  %s: no change (already correct)", slug)
+    summary: dict[str, Any] = {"products": {}}
+    for row in results:
+        slug = row["slug"]
+        if not row["matched"]:
+            logger.warning("  %s: NOT FOUND in products collection", slug)
+            summary["products"][slug] = {"found": False}
+            continue
+        before = row["before"] or {}
+        after = row["after"] or {}
+        changed: list[str] = []
+        for field in ("crawl_ignore_robots", "crawl_denied_domains", "crawl_base_urls", "name"):
+            if before.get(field) != after.get(field):
+                changed.append(f"{field}: {before.get(field)!r} -> {after.get(field)!r}")
+        if changed:
+            logger.info("  %s: %s", slug, "; ".join(changed))
+        else:
+            logger.info("  %s: no change (already correct)", slug)
+        summary["products"][slug] = {"found": True, "changed": changed}
+    return summary
+
+
+class FixThinEvidenceProducts(Migration):
+    migration_id = "20260624_000001_fix_thin_evidence_products"
+    description = "Patch crawl configs (robots/denied domains) for thin-evidence audit products"
+
+    async def upgrade(self, db: AgnosticDatabase) -> dict[str, Any]:
+        return await fix_thin_evidence_products(db)
 
 
 if __name__ == "__main__":
-    asyncio.run(fix_thin_evidence_products())
+
+    async def _run() -> None:
+        async with db_session() as db:
+            await fix_thin_evidence_products(db)
+
+    asyncio.run(_run())

--- a/packages/backend/src/migrations/migrate_companies_to_products.py
+++ b/packages/backend/src/migrations/migrate_companies_to_products.py
@@ -1,80 +1,78 @@
-"""Migration script to rename companies collection to products and update company_id to product_id in documents.
+"""Rename companies collection to products and remap company_* field references.
 
-This script:
-1. Renames the 'companies' collection to 'products'
-2. Updates all 'company_id' fields to 'product_id' in the 'documents' collection
-3. Updates all 'company_slug' fields to 'product_slug' in product_intelligence
+1. Renames the 'companies' collection to 'products'.
+2. Updates all 'company_id' fields to 'product_id' in the 'documents' collection.
+3. Updates all 'company_slug' fields to 'product_slug' in product_intelligence.
+4. Updates any remaining 'company_id' references in product_intelligence.
+
+Idempotent: the rename is skipped once 'products' exists, and every ``$rename``
+is guarded by ``$exists`` so re-runs touch zero documents.
 """
 
+from __future__ import annotations
+
 import asyncio
+from typing import Any
 
-from motor.motor_asyncio import AsyncIOMotorClient
+from motor.core import AgnosticDatabase
 
-from src.core.config import config
+from src.core.database import db_session
 from src.core.logging import get_logger
+from src.migrations.base import Migration
 
 logger = get_logger(__name__)
 
-MONGO_URI = config.database.mongodb_uri
-DATABASE_NAME = "clausea"
+
+async def migrate_companies_to_products(db: AgnosticDatabase) -> dict[str, Any]:
+    """Perform the migration from companies to products against ``db``."""
+    detail: dict[str, Any] = {}
+
+    collections = await db.list_collection_names()
+    if "companies" in collections:
+        logger.info("Renaming 'companies' collection to 'products'...")
+        await db.companies.rename("products")
+        detail["renamed_collection"] = True
+    elif "products" in collections:
+        logger.info("'products' collection already exists, skipping rename")
+        detail["renamed_collection"] = False
+    else:
+        logger.warning("Neither 'companies' nor 'products' collection found")
+        detail["renamed_collection"] = False
+
+    result = await db.documents.update_many(
+        {"company_id": {"$exists": True}},
+        {"$rename": {"company_id": "product_id"}},
+    )
+    detail["documents_renamed"] = result.modified_count
+
+    result = await db.product_intelligence.update_many(
+        {"company_slug": {"$exists": True}},
+        {"$rename": {"company_slug": "product_slug"}},
+    )
+    detail["product_intelligence_slug_renamed"] = result.modified_count
+
+    result = await db.product_intelligence.update_many(
+        {"company_id": {"$exists": True}},
+        {"$rename": {"company_id": "product_id"}},
+    )
+    detail["product_intelligence_id_renamed"] = result.modified_count
+
+    logger.info("companies -> products migration complete", **detail)
+    return detail
 
 
-async def migrate_companies_to_products():
-    """Perform the migration from companies to products."""
-    client = AsyncIOMotorClient(MONGO_URI)
-    db = client[DATABASE_NAME]
+class MigrateCompaniesToProducts(Migration):
+    migration_id = "20260214_000001_rename_companies_to_products"
+    description = "Rename companies collection to products and remap company_* fields"
 
-    try:
-        logger.info("Starting migration: companies -> products")
-
-        # Step 1: Rename companies collection to products
-        collections = await db.list_collection_names()
-        if "companies" in collections:
-            logger.info("Renaming 'companies' collection to 'products'...")
-            await db.companies.rename("products")
-            logger.info("✓ Renamed 'companies' collection to 'products'")
-        elif "products" in collections:
-            logger.info("'products' collection already exists, skipping rename")
-        else:
-            logger.warning("Neither 'companies' nor 'products' collection found")
-
-        # Step 2: Update company_id to product_id in documents
-        logger.info("Updating 'company_id' to 'product_id' in documents collection...")
-        result = await db.documents.update_many(
-            {"company_id": {"$exists": True}},
-            {"$rename": {"company_id": "product_id"}},
-        )
-        logger.info(f"✓ Updated {result.modified_count} documents")
-
-        # Step 3: Update company_slug to product_slug in product_intelligence
-        logger.info(
-            "Updating 'company_slug' to 'product_slug' in product_intelligence collection..."
-        )
-        result = await db.product_intelligence.update_many(
-            {"company_slug": {"$exists": True}},
-            {"$rename": {"company_slug": "product_slug"}},
-        )
-        logger.info(f"✓ Updated {result.modified_count} product_intelligence docs")
-
-        # Step 4: Update company_id references in product_intelligence if they exist
-        logger.info("Checking for company_id references in product_intelligence...")
-        result = await db.product_intelligence.update_many(
-            {"company_id": {"$exists": True}},
-            {"$rename": {"company_id": "product_id"}},
-        )
-        if result.modified_count > 0:
-            logger.info(
-                f"✓ Updated {result.modified_count} product_intelligence docs with company_id"
-            )
-
-        logger.info("✅ Migration completed successfully!")
-
-    except Exception as e:
-        logger.error(f"❌ Migration failed: {e}", exc_info=True)
-        raise
-    finally:
-        client.close()
+    async def upgrade(self, db: AgnosticDatabase) -> dict[str, Any]:
+        return await migrate_companies_to_products(db)
 
 
 if __name__ == "__main__":
-    asyncio.run(migrate_companies_to_products())
+
+    async def _run() -> None:
+        async with db_session() as db:
+            await migrate_companies_to_products(db)
+
+    asyncio.run(_run())

--- a/packages/backend/src/migrations/registry.py
+++ b/packages/backend/src/migrations/registry.py
@@ -1,12 +1,43 @@
 """Registry of all migrations known to the system.
 
-Migrations are registered in :mod:`src.migrations.__init__` at import time and
-ordered by ``migration_id`` so the runner applies them deterministically.
+Migrations live as ``NNN_description.py`` files inside this package. Each file
+defines a :class:`~src.migrations.base.Migration` subclass.
+:func:`autodiscover` imports every matching module, instantiates the subclass,
+and registers it — so adding a migration is just dropping in a new file.
 """
 
 from __future__ import annotations
 
+import importlib
+import inspect
+import pkgutil
+import re
+
 from src.migrations.base import Migration
+
+_MIGRATION_FILE_RE = re.compile(r"^\d{3}_.+\.py$")
+
+
+def autodiscover(package_name: str | None = __package__) -> list[Migration]:
+    """Import every ``NNN_*.py`` module in *package_name* and collect Migration subclasses."""
+    if package_name is None:
+        return []
+    package = importlib.import_module(package_name)
+    discovered: list[Migration] = []
+
+    for module_info in sorted(pkgutil.iter_modules(package.__path__), key=lambda m: m.name):
+        if not _MIGRATION_FILE_RE.match(f"{module_info.name}.py"):
+            continue
+        module = importlib.import_module(f"{package_name}.{module_info.name}")
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                issubclass(obj, Migration)
+                and obj is not Migration
+                and obj.__module__ == module.__name__
+            ):
+                discovered.append(obj())
+
+    return discovered
 
 
 class MigrationRegistry:

--- a/packages/backend/src/migrations/registry.py
+++ b/packages/backend/src/migrations/registry.py
@@ -1,0 +1,34 @@
+"""Registry of all migrations known to the system.
+
+Migrations are registered in :mod:`src.migrations.__init__` at import time and
+ordered by ``migration_id`` so the runner applies them deterministically.
+"""
+
+from __future__ import annotations
+
+from src.migrations.base import Migration
+
+
+class MigrationRegistry:
+    """Collects migrations and serves them in deterministic apply order."""
+
+    def __init__(self) -> None:
+        self._migrations: dict[str, Migration] = {}
+
+    def register(self, migration: Migration) -> None:
+        migration_id = migration.migration_id
+        if not migration_id:
+            raise ValueError("Migration is missing a migration_id")
+        if migration_id in self._migrations:
+            raise ValueError(f"Duplicate migration_id registered: {migration_id}")
+        self._migrations[migration_id] = migration
+
+    def all(self) -> list[Migration]:
+        return sorted(self._migrations.values(), key=lambda m: m.migration_id)
+
+    def pending(self, applied_ids: set[str]) -> list[Migration]:
+        """Return registered migrations whose id is not in ``applied_ids``, in order."""
+        return [m for m in self.all() if m.migration_id not in applied_ids]
+
+
+registry = MigrationRegistry()

--- a/packages/backend/src/services/migration_service.py
+++ b/packages/backend/src/services/migration_service.py
@@ -69,6 +69,7 @@ class MigrationService:
         try:
             applied_count = 0
             for migration in self._registry.pending(await self._applied_ids(db)):
+                await self._refresh_lock(db)
                 await self._run_one(db, migration)
                 applied_count += 1
             logger.info("Migrations complete", applied=applied_count)
@@ -139,7 +140,7 @@ class MigrationService:
             )
         except Exception as exc:
             if "already exists" not in str(exc).lower():
-                logger.debug("Could not create migration_id index: %s", exc)
+                logger.warning("Could not create migration_id index: %s", exc)
 
         try:
             await db[LOCK_COLLECTION].create_index(
@@ -149,7 +150,7 @@ class MigrationService:
             )
         except Exception as exc:
             if "already exists" not in str(exc).lower():
-                logger.debug("Could not create migration lock index: %s", exc)
+                logger.warning("Could not create migration lock index: %s", exc)
 
     async def _acquire_lock(self, db: AgnosticDatabase) -> bool:
         now = datetime.now(UTC)
@@ -165,5 +166,14 @@ class MigrationService:
         except DuplicateKeyError:
             return False
 
+    async def _refresh_lock(self, db: AgnosticDatabase) -> None:
+        """Touch the lock's locked_at so the TTL doesn't expire mid-migration."""
+        await db[LOCK_COLLECTION].update_one(
+            {"_id": LOCK_ID, "host": _host_id()},
+            {"$set": {"locked_at": datetime.now(UTC)}},
+        )
+
     async def _release_lock(self, db: AgnosticDatabase) -> None:
-        await db[LOCK_COLLECTION].delete_one({"_id": LOCK_ID})
+        # Only delete the lock if we still own it — avoids deleting another
+        # replica's lock if ours expired mid-migration.
+        await db[LOCK_COLLECTION].delete_one({"_id": LOCK_ID, "host": _host_id()})

--- a/packages/backend/src/services/migration_service.py
+++ b/packages/backend/src/services/migration_service.py
@@ -1,0 +1,169 @@
+"""Migration orchestrator: discovers and applies pending migrations on startup.
+
+Applied migrations are recorded in the ``_migrations`` collection (one document
+per migration, keyed by ``migration_id``) so each runs exactly once per
+environment. A short-lived lock document in ``_migrations_lock`` prevents two
+replicas from running migrations concurrently — important on Railway where a
+new replica can spin up while another is mid-migration.
+
+A failed migration is recorded with ``status="failed"`` and re-raised, which
+halts the startup sequence (readiness stays 503 until the failure is resolved).
+On the next boot the failed migration is retried, because only
+``status="applied"`` entries count as done.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from motor.core import AgnosticDatabase
+from pymongo import ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+from src.core.logging import get_logger
+from src.migrations import registry as default_registry
+from src.migrations.registry import MigrationRegistry
+
+logger = get_logger(__name__, component="migration")
+
+MIGRATIONS_COLLECTION = "_migrations"
+LOCK_COLLECTION = "_migrations_lock"
+LOCK_ID = "migration-runner"
+LOCK_TTL_SECONDS = 300
+
+
+def _host_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+class MigrationService:
+    """Apply pending migrations in deterministic order, exactly once each."""
+
+    def __init__(self, registry: MigrationRegistry = default_registry) -> None:
+        self._registry = registry
+
+    async def run_pending(self, db: AgnosticDatabase) -> dict[str, Any]:
+        """Run every registered migration not yet recorded as applied.
+
+        Returns a summary dict with the counts of applied and skipped migrations.
+        Safe to call on every startup.
+        """
+        await self._ensure_schema(db)
+
+        pending_before_lock = self._registry.pending(await self._applied_ids(db))
+        if not pending_before_lock:
+            logger.info("No pending migrations")
+            return {"applied": 0, "skipped": 0}
+
+        if not await self._acquire_lock(db):
+            logger.info(
+                "Migration lock held by another instance — skipping",
+                pending=[m.migration_id for m in pending_before_lock],
+            )
+            return {"applied": 0, "skipped": len(pending_before_lock)}
+
+        try:
+            applied_count = 0
+            for migration in self._registry.pending(await self._applied_ids(db)):
+                await self._run_one(db, migration)
+                applied_count += 1
+            logger.info("Migrations complete", applied=applied_count)
+            return {"applied": applied_count, "skipped": 0}
+        finally:
+            await self._release_lock(db)
+
+    async def _run_one(self, db: AgnosticDatabase, migration: Any) -> None:
+        start = time.monotonic()
+        started_at = datetime.now(UTC)
+        logger.info(
+            "Applying migration", id=migration.migration_id, description=migration.description
+        )
+        try:
+            detail = await migration.upgrade(db) or {}
+            duration_ms = int((time.monotonic() - start) * 1000)
+            await self._record(
+                db,
+                migration_id=migration.migration_id,
+                description=migration.description,
+                status="applied",
+                applied_at=started_at,
+                duration_ms=duration_ms,
+                detail=detail,
+            )
+            logger.info(
+                "Migration applied",
+                id=migration.migration_id,
+                duration_ms=duration_ms,
+                detail=detail,
+            )
+        except Exception as exc:
+            duration_ms = int((time.monotonic() - start) * 1000)
+            await self._record(
+                db,
+                migration_id=migration.migration_id,
+                description=migration.description,
+                status="failed",
+                applied_at=started_at,
+                duration_ms=duration_ms,
+                error=repr(exc),
+            )
+            logger.exception("Migration failed", id=migration.migration_id)
+            raise
+
+    async def _record(self, db: AgnosticDatabase, **fields: Any) -> None:
+        migration_id = fields["migration_id"]
+        await db[MIGRATIONS_COLLECTION].find_one_and_update(
+            {"_id": migration_id},
+            {"$set": fields},
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+
+    async def _applied_ids(self, db: AgnosticDatabase) -> set[str]:
+        cursor = db[MIGRATIONS_COLLECTION].find(
+            {"status": "applied"}, {"_id": 1, "migration_id": 1}
+        )
+        applied: set[str] = set()
+        async for row in cursor:
+            applied.add(row.get("migration_id") or row["_id"])
+        return applied
+
+    async def _ensure_schema(self, db: AgnosticDatabase) -> None:
+        try:
+            await db[MIGRATIONS_COLLECTION].create_index(
+                "migration_id", unique=True, name="uniq_migration_id"
+            )
+        except Exception as exc:
+            if "already exists" not in str(exc).lower():
+                logger.debug("Could not create migration_id index: %s", exc)
+
+        try:
+            await db[LOCK_COLLECTION].create_index(
+                "locked_at",
+                expireAfterSeconds=LOCK_TTL_SECONDS,
+                name="ttl_migration_lock",
+            )
+        except Exception as exc:
+            if "already exists" not in str(exc).lower():
+                logger.debug("Could not create migration lock index: %s", exc)
+
+    async def _acquire_lock(self, db: AgnosticDatabase) -> bool:
+        now = datetime.now(UTC)
+        cutoff = now - timedelta(seconds=LOCK_TTL_SECONDS)
+        # Clear any stale lock left by a crashed runner so a new instance can
+        # take over immediately instead of waiting for the TTL reaper.
+        await db[LOCK_COLLECTION].delete_many({"locked_at": {"$lt": cutoff}})
+        try:
+            await db[LOCK_COLLECTION].insert_one(
+                {"_id": LOCK_ID, "locked_at": now, "host": _host_id()}
+            )
+            return True
+        except DuplicateKeyError:
+            return False
+
+    async def _release_lock(self, db: AgnosticDatabase) -> None:
+        await db[LOCK_COLLECTION].delete_one({"_id": LOCK_ID})

--- a/packages/backend/tests/unit/migration_service_test.py
+++ b/packages/backend/tests/unit/migration_service_test.py
@@ -1,0 +1,243 @@
+"""Tests for the MigrationService orchestrator.
+
+Covers the exactly-once, ordering, lock, and failure-recording guarantees
+without touching a real MongoDB — the service is driven entirely through the
+AgnosticDatabase protocol, so a MagicMock stand-in is sufficient.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from src.migrations.base import Migration
+from src.migrations.registry import MigrationRegistry
+from src.services.migration_service import (
+    LOCK_COLLECTION,
+    MIGRATIONS_COLLECTION,
+    MigrationService,
+)
+
+
+class _StubMigration(Migration):
+    def __init__(self, migration_id: str, *, fail: bool = False) -> None:
+        self.migration_id = migration_id
+        self.description = f"stub {migration_id}"
+        self.fail = fail
+        self.call_count = 0
+        self.last_db: object | None = None
+
+    async def upgrade(self, db: object) -> dict[str, object]:
+        self.call_count += 1
+        self.last_db = db
+        if self.fail:
+            raise RuntimeError("boom")
+        return {"ok": True}
+
+
+class _AsyncIter:
+    """Minimal async iterator over a list — substitutes for a Motor cursor."""
+
+    def __init__(self, items: list[dict]) -> None:
+        self._it = iter(items)
+
+    def __aiter__(self) -> _AsyncIter:
+        return self
+
+    async def __anext__(self) -> dict:
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+def _build_mock_db(applied_docs: list[dict] | None = None) -> MagicMock:
+    """A MagicMock database that records migration/lock writes."""
+    db = MagicMock()
+
+    # _migrations collection
+    migrations_col = MagicMock()
+    migrations_col.find_one_and_update = AsyncMock(return_value={"_id": "x"})
+    # `find` must return a fresh async iterator each call — the service iterates
+    # the applied-ids cursor more than once.
+    migrations_col.find.side_effect = lambda *_a, **_kw: _AsyncIter(applied_docs or [])
+
+    # lock collection
+    lock_col = MagicMock()
+    lock_col.insert_one = AsyncMock(return_value={"insertedId": "lock"})
+    lock_col.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
+    lock_col.delete_many = AsyncMock(return_value=MagicMock(deleted_count=0))
+
+    def _getitem(name: str) -> MagicMock:
+        if name == MIGRATIONS_COLLECTION:
+            return migrations_col
+        if name == LOCK_COLLECTION:
+            return lock_col
+        return MagicMock()
+
+    db.__getitem__.side_effect = _getitem
+    return db
+
+
+def _registry(*migrations: Migration) -> MigrationRegistry:
+    reg = MigrationRegistry()
+    for m in migrations:
+        reg.register(m)
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_applies_all_pending_migrations_in_order():
+    a = _StubMigration("20260101_000001_a")
+    b = _StubMigration("20260101_000002_b")
+    c = _StubMigration("20260101_000003_c")
+    service = MigrationService(_registry(a, b, c))
+    db = _build_mock_db(applied_docs=[])
+
+    summary = await service.run_pending(db)
+
+    assert summary == {"applied": 3, "skipped": 0}
+    assert a.call_count == 1
+    assert b.call_count == 1
+    assert c.call_count == 1
+    # Each migration received the db handle.
+    for migration in (a, b, c):
+        assert migration.last_db is db
+
+
+@pytest.mark.asyncio
+async def test_skips_already_applied_migrations():
+    a = _StubMigration("20260101_000001_a")
+    b = _StubMigration("20260101_000002_b")
+    service = MigrationService(_registry(a, b))
+    db = _build_mock_db(
+        applied_docs=[{"_id": "20260101_000001_a", "migration_id": "20260101_000001_a"}]
+    )
+
+    summary = await service.run_pending(db)
+
+    assert summary == {"applied": 1, "skipped": 0}
+    assert a.call_count == 0
+    assert b.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_records_failure_and_reraises():
+    bad = _StubMigration("20260101_000001_bad", fail=True)
+    service = MigrationService(_registry(bad))
+    db = _build_mock_db(applied_docs=[])
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await service.run_pending(db)
+
+    migrations_col = db[MIGRATIONS_COLLECTION]
+    status_seen = [
+        call.args[1]["$set"]["status"]
+        for call in migrations_col.find_one_and_update.await_args_list
+    ]
+    assert "failed" in status_seen
+    # And it was NOT also recorded as applied
+    assert "applied" not in status_seen
+
+
+@pytest.mark.asyncio
+async def test_failed_migration_is_retried_on_next_boot():
+    flaky = _StubMigration("20260101_000001_flaky", fail=True)
+    service = MigrationService(_registry(flaky))
+
+    # First boot: fails, recorded as "failed"
+    db1 = _build_mock_db(applied_docs=[])
+    with pytest.raises(RuntimeError):
+        await service.run_pending(db1)
+
+    # Second boot: only "applied" docs count as done, so the failed one is pending again.
+    # Simulate it failing again to prove it was retried.
+    db2 = _build_mock_db(applied_docs=[])
+    with pytest.raises(RuntimeError):
+        await service.run_pending(db2)
+    assert flaky.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_pending_migrations_returns_zero():
+    a = _StubMigration("20260101_000001_a")
+    service = MigrationService(_registry(a))
+    db = _build_mock_db(applied_docs=[{"_id": "a", "migration_id": "20260101_000001_a"}])
+
+    summary = await service.run_pending(db)
+
+    assert summary == {"applied": 0, "skipped": 0}
+    assert a.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_lock_held_skips_without_running():
+    a = _StubMigration("20260101_000001_a")
+    service = MigrationService(_registry(a))
+    db = _build_mock_db(applied_docs=[])
+    # Pre-occupy the lock: insert_one raises DuplicateKeyError
+    db[LOCK_COLLECTION].insert_one = AsyncMock(side_effect=DuplicateKeyError("taken"))
+
+    summary = await service.run_pending(db)
+
+    assert summary == {"applied": 0, "skipped": 1}
+    assert a.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_lock_released_after_success():
+    a = _StubMigration("20260101_000001_a")
+    service = MigrationService(_registry(a))
+    db = _build_mock_db(applied_docs=[])
+
+    await service.run_pending(db)
+
+    db[LOCK_COLLECTION].delete_one.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lock_released_after_failure():
+    bad = _StubMigration("20260101_000001_bad", fail=True)
+    service = MigrationService(_registry(bad))
+    db = _build_mock_db(applied_docs=[])
+
+    with pytest.raises(RuntimeError):
+        await service.run_pending(db)
+
+    db[LOCK_COLLECTION].delete_one.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_records_applied_with_detail_and_timing():
+    a = _StubMigration("20260101_000001_a")
+    service = MigrationService(_registry(a))
+    db = _build_mock_db(applied_docs=[])
+
+    await service.run_pending(db)
+
+    call = db[MIGRATIONS_COLLECTION].find_one_and_update.await_args
+    fields = call.args[1]["$set"]
+    assert fields["status"] == "applied"
+    assert fields["migration_id"] == "20260101_000001_a"
+    assert fields["detail"] == {"ok": True}
+    assert isinstance(fields["applied_at"], datetime)
+    assert fields["applied_at"].tzinfo is UTC
+    assert fields["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_registry_orders_by_migration_id_lexicographically():
+    reg = _registry(
+        _StubMigration("20260624_000002_late"),
+        _StubMigration("20260214_000001_early"),
+        _StubMigration("20260624_000001_mid"),
+    )
+    ids = [m.migration_id for m in reg.all()]
+    assert ids == [
+        "20260214_000001_early",
+        "20260624_000001_mid",
+        "20260624_000002_late",
+    ]

--- a/packages/backend/tests/unit/migration_service_test.py
+++ b/packages/backend/tests/unit/migration_service_test.py
@@ -14,7 +14,7 @@ import pytest
 from pymongo.errors import DuplicateKeyError
 
 from src.migrations.base import Migration
-from src.migrations.registry import MigrationRegistry
+from src.migrations.registry import MigrationRegistry, autodiscover
 from src.services.migration_service import (
     LOCK_COLLECTION,
     MIGRATIONS_COLLECTION,
@@ -91,9 +91,9 @@ def _registry(*migrations: Migration) -> MigrationRegistry:
 
 @pytest.mark.asyncio
 async def test_applies_all_pending_migrations_in_order():
-    a = _StubMigration("20260101_000001_a")
-    b = _StubMigration("20260101_000002_b")
-    c = _StubMigration("20260101_000003_c")
+    a = _StubMigration("000_a")
+    b = _StubMigration("001_b")
+    c = _StubMigration("002_c")
     service = MigrationService(_registry(a, b, c))
     db = _build_mock_db(applied_docs=[])
 
@@ -110,12 +110,10 @@ async def test_applies_all_pending_migrations_in_order():
 
 @pytest.mark.asyncio
 async def test_skips_already_applied_migrations():
-    a = _StubMigration("20260101_000001_a")
-    b = _StubMigration("20260101_000002_b")
+    a = _StubMigration("000_a")
+    b = _StubMigration("001_b")
     service = MigrationService(_registry(a, b))
-    db = _build_mock_db(
-        applied_docs=[{"_id": "20260101_000001_a", "migration_id": "20260101_000001_a"}]
-    )
+    db = _build_mock_db(applied_docs=[{"_id": "000_a", "migration_id": "000_a"}])
 
     summary = await service.run_pending(db)
 
@@ -126,7 +124,7 @@ async def test_skips_already_applied_migrations():
 
 @pytest.mark.asyncio
 async def test_records_failure_and_reraises():
-    bad = _StubMigration("20260101_000001_bad", fail=True)
+    bad = _StubMigration("000_bad", fail=True)
     service = MigrationService(_registry(bad))
     db = _build_mock_db(applied_docs=[])
 
@@ -145,7 +143,7 @@ async def test_records_failure_and_reraises():
 
 @pytest.mark.asyncio
 async def test_failed_migration_is_retried_on_next_boot():
-    flaky = _StubMigration("20260101_000001_flaky", fail=True)
+    flaky = _StubMigration("000_flaky", fail=True)
     service = MigrationService(_registry(flaky))
 
     # First boot: fails, recorded as "failed"
@@ -163,9 +161,9 @@ async def test_failed_migration_is_retried_on_next_boot():
 
 @pytest.mark.asyncio
 async def test_no_pending_migrations_returns_zero():
-    a = _StubMigration("20260101_000001_a")
+    a = _StubMigration("000_a")
     service = MigrationService(_registry(a))
-    db = _build_mock_db(applied_docs=[{"_id": "a", "migration_id": "20260101_000001_a"}])
+    db = _build_mock_db(applied_docs=[{"_id": "a", "migration_id": "000_a"}])
 
     summary = await service.run_pending(db)
 
@@ -175,7 +173,7 @@ async def test_no_pending_migrations_returns_zero():
 
 @pytest.mark.asyncio
 async def test_lock_held_skips_without_running():
-    a = _StubMigration("20260101_000001_a")
+    a = _StubMigration("000_a")
     service = MigrationService(_registry(a))
     db = _build_mock_db(applied_docs=[])
     # Pre-occupy the lock: insert_one raises DuplicateKeyError
@@ -189,7 +187,7 @@ async def test_lock_held_skips_without_running():
 
 @pytest.mark.asyncio
 async def test_lock_released_after_success():
-    a = _StubMigration("20260101_000001_a")
+    a = _StubMigration("000_a")
     service = MigrationService(_registry(a))
     db = _build_mock_db(applied_docs=[])
 
@@ -200,7 +198,7 @@ async def test_lock_released_after_success():
 
 @pytest.mark.asyncio
 async def test_lock_released_after_failure():
-    bad = _StubMigration("20260101_000001_bad", fail=True)
+    bad = _StubMigration("000_bad", fail=True)
     service = MigrationService(_registry(bad))
     db = _build_mock_db(applied_docs=[])
 
@@ -212,7 +210,7 @@ async def test_lock_released_after_failure():
 
 @pytest.mark.asyncio
 async def test_records_applied_with_detail_and_timing():
-    a = _StubMigration("20260101_000001_a")
+    a = _StubMigration("000_a")
     service = MigrationService(_registry(a))
     db = _build_mock_db(applied_docs=[])
 
@@ -221,7 +219,7 @@ async def test_records_applied_with_detail_and_timing():
     call = db[MIGRATIONS_COLLECTION].find_one_and_update.await_args
     fields = call.args[1]["$set"]
     assert fields["status"] == "applied"
-    assert fields["migration_id"] == "20260101_000001_a"
+    assert fields["migration_id"] == "000_a"
     assert fields["detail"] == {"ok": True}
     assert isinstance(fields["applied_at"], datetime)
     assert fields["applied_at"].tzinfo is UTC
@@ -231,13 +229,27 @@ async def test_records_applied_with_detail_and_timing():
 @pytest.mark.asyncio
 async def test_registry_orders_by_migration_id_lexicographically():
     reg = _registry(
-        _StubMigration("20260624_000002_late"),
-        _StubMigration("20260214_000001_early"),
-        _StubMigration("20260624_000001_mid"),
+        _StubMigration("002_late"),
+        _StubMigration("000_early"),
+        _StubMigration("001_mid"),
     )
     ids = [m.migration_id for m in reg.all()]
-    assert ids == [
-        "20260214_000001_early",
-        "20260624_000001_mid",
-        "20260624_000002_late",
-    ]
+    assert ids == ["000_early", "001_mid", "002_late"]
+
+
+def test_autodiscover_finds_numbered_migration_files():
+    """autodiscover scans the src.migrations package for NNN_*.py files."""
+    discovered = autodiscover()
+    ids = [m.migration_id for m in discovered]
+    assert "000_rename_companies_to_products" in ids
+    assert "001_fix_thin_evidence_products" in ids
+    assert "002_backfill_orphan_citations" in ids
+    assert "003_migrate_topic_stances" in ids
+    # Files without the NNN_ prefix (e.g. fix_product_names, base, registry) are excluded.
+    assert all(not mid.startswith("fix_") for mid in ids)
+
+
+def test_autodiscover_returns_migrations_in_filename_order():
+    discovered = autodiscover()
+    ids = [m.migration_id for m in discovered]
+    assert ids == sorted(ids)

--- a/packages/backend/tests/unit/migration_service_test.py
+++ b/packages/backend/tests/unit/migration_service_test.py
@@ -61,6 +61,7 @@ def _build_mock_db(applied_docs: list[dict] | None = None) -> MagicMock:
     # _migrations collection
     migrations_col = MagicMock()
     migrations_col.find_one_and_update = AsyncMock(return_value={"_id": "x"})
+    migrations_col.create_index = AsyncMock()
     # `find` must return a fresh async iterator each call — the service iterates
     # the applied-ids cursor more than once.
     migrations_col.find.side_effect = lambda *_a, **_kw: _AsyncIter(applied_docs or [])
@@ -70,6 +71,8 @@ def _build_mock_db(applied_docs: list[dict] | None = None) -> MagicMock:
     lock_col.insert_one = AsyncMock(return_value={"insertedId": "lock"})
     lock_col.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
     lock_col.delete_many = AsyncMock(return_value=MagicMock(deleted_count=0))
+    lock_col.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
+    lock_col.create_index = AsyncMock()
 
     def _getitem(name: str) -> MagicMock:
         if name == MIGRATIONS_COLLECTION:
@@ -194,6 +197,39 @@ async def test_lock_released_after_success():
     await service.run_pending(db)
 
     db[LOCK_COLLECTION].delete_one.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lock_release_only_deletes_own_lock():
+    """_release_lock filters by host so it never deletes another replica's lock."""
+    a = _StubMigration("000_a")
+    service = MigrationService(_registry(a))
+    db = _build_mock_db(applied_docs=[])
+
+    await service.run_pending(db)
+
+    delete_filter = db[LOCK_COLLECTION].delete_one.await_args.args[0]
+    assert delete_filter["_id"] == "migration-runner"
+    assert "host" in delete_filter  # scoped to this process, not unscoped
+
+
+@pytest.mark.asyncio
+async def test_lock_refreshed_before_each_migration():
+    """Each migration is preceded by a lock refresh so the TTL doesn't expire."""
+    a = _StubMigration("000_a")
+    b = _StubMigration("001_b")
+    c = _StubMigration("002_c")
+    service = MigrationService(_registry(a, b, c))
+    db = _build_mock_db(applied_docs=[])
+
+    await service.run_pending(db)
+
+    assert db[LOCK_COLLECTION].update_one.await_count == 3
+    for call in db[LOCK_COLLECTION].update_one.await_args_list:
+        update_filter = call.args[0]
+        assert update_filter["_id"] == "migration-runner"
+        assert "host" in update_filter
+        assert "locked_at" in call.args[1]["$set"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What this PR delivers

A versioned migration framework that automatically discovers and applies pending MongoDB data migrations when the FastAPI server starts — before index creation runs. Each migration is an idempotent class with a unique, lexicographically-sortable ID, tracked in a `_migrations` collection so it runs exactly once per environment. A TTL-backed lock document prevents two replicas from running migrations concurrently on Railway.

This replaces the previous workflow where every migration was a standalone script that had to be run manually against production after each deploy.

Three existing migration scripts are converted to the new framework and auto-registered: `companies → products` rename, thin-evidence crawl-config fixes, and orphan-citation backfill. The interactive `fix_product_names.py` script is intentionally left as a manual ops tool (it prompts for confirmation and targets a separate production URI).

## Why this matters

**For operators:** Migrations can no longer be forgotten. Every deploy that starts the API server automatically applies pending migrations in deterministic order. If a migration fails, the readiness probe stays 503 until the issue is resolved — the server won't serve traffic against a half-migrated database.

**For maintainers:** Eliminates ad-hoc migration scripts with inconsistent DB-connectivity patterns (some created their own Motor client, some used `db_session`). New migrations are a single class with a unique ID, a description, and an `upgrade(db)` method. The registry guarantees deterministic ordering.

## How startup behaviour changes

| Code path | Change |
|---|---|
| `_initialize_database()` in `main.py` | Now calls `MigrationService().run_pending(db)` **before** `ensure_all_indexes(db)`. Migrations that rename/create collections must run first so indexes build against the correct schema. |
| Index creation | No change to what indexes are created — just runs after migrations instead of first. |
| Readiness probe (`/health/ready`) | No change to the endpoint itself. If a migration fails, `_startup_failed` is set (existing behaviour) and readiness returns 503. |
| Replica concurrency | New: a `_migrations_lock` document with a 5-minute TTL prevents two replicas from running migrations simultaneously. If the lock is held, the second replica skips migrations (they'll already be applied by the first). |
| Re-runs of already-applied migrations | Skipped — `_migrations` records with `status="applied"` are excluded from the pending set. Failed migrations (status="failed") are retried on the next boot. |

## UX changes operators will notice

- Startup logs now include `[migration]` component lines: "Applying migration", "Migration applied" (with duration + detail), or "Migration failed".
- Two new collections appear in MongoDB: `_migrations` (one document per applied migration) and `_migrations_lock` (ephemeral lock document, TTL 5 minutes).
- On first deploy with this PR, the 3 converted migrations will run even if they were previously executed manually — there was no tracking collection before. All three are idempotent, so re-running is a no-op on already-migrated data.

## Migration — config changes required

No env var changes or operator actions required. The framework is self-provisioning: it creates its own tracking collection and index on first run.

| Old workflow | New workflow |
|---|---|
| `uv run python -m src.migrations.fix_thin_evidence_products` (manual, post-deploy) | Runs automatically on server startup. Still runnable manually via `python -m src.migrations.fix_thin_evidence_products` for ops. |
| `uv run python -m src.migrations.backfill_orphan_citations` (manual) | Same — auto-runs on startup, still runnable manually. |
| `uv run python -m src.migrations.migrate_companies_to_products` (manual) | Same. |

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| Migration function signature | `async def migrate_companies_to_products()` (creates own Motor client) | `async def migrate_companies_to_products(db: AgnosticDatabase)` (receives db from caller) |
| Migration function signature | `async def fix_thin_evidence_products()` (opens own `db_session`) | `async def fix_thin_evidence_products(db: AgnosticDatabase)` |
| Migration function signature | `async def backfill_orphan_citations() -> int` (opens own `db_session`) | `async def backfill_orphan_citations(db: AgnosticDatabase) -> dict[str, Any]` |
| New migration pattern | Standalone script with `if __name__ == "__main__"` block | Subclass of `Migration` with `migration_id`, `description`, `upgrade(db)`; registered in `src/migrations/__init__.py` |

## Tests

- 10 unit tests passing in `tests/unit/migration_service_test.py`.
- Canonical pin: `test_applies_all_pending_migrations_in_order` — locks in that all pending migrations run and receive the db handle.
- Regression pin: `test_failed_migration_is_retried_on_next_boot` — locks in that only `status="applied"` counts as done, so failed migrations are retried.
- Edge-case pin: `test_lock_held_skips_without_running` — locks in the replica-safety guarantee.

### Edge cases to verify in a staging session

1. **First deploy with existing data** — the 3 converted migrations re-run against already-migrated data. Expected: all complete as no-ops (0 documents modified, collections already renamed).
2. **Two replicas starting simultaneously** — the second replica should log "Migration lock held by another instance — skipping" and proceed to serve traffic normally.
3. **Migration that fails mid-way** — readiness should stay 503, the `_migrations` record should have `status="failed"`, and the next boot should retry it.
4. **Manual re-run of a converted script** — `uv run python -m src.migrations.fix_thin_evidence_products` should still work standalone (the `__main__` block opens its own `db_session`).

## Notes for reviewers

- Migrations run **before** `ensure_all_indexes` because the `companies → products` rename must happen before the products index is built. This ordering is load-bearing — do not reorder.
- The lock TTL is 5 minutes. If a migration takes longer than that, the lock could expire and a second replica could start running migrations concurrently. All registered migrations are currently sub-second, but if a future migration is long-running, increase `LOCK_TTL_SECONDS`.
- `fix_product_names.py` is intentionally NOT registered — it's an interactive script that prompts for confirmation and reads from `PRODUCTION_MONGO_URI` (a separate env var). Auto-running it on startup would be dangerous.
- `MigrationService.__init__` accepts an injectable `MigrationRegistry` for testability — the default is the module-level singleton populated by `src/migrations/__init__.py`.
