### PR TITLE
fix(products): stop preview metering 500s and clarify error states

### DIFF
--- a/packages/backend/src/core/tier_deps.py
+++ b/packages/backend/src/core/tier_deps.py
@@ -10,6 +10,7 @@ from motor.core import AgnosticDatabase
 
 from src.core.database import get_db
 from src.core.jwt import clerk_auth_service
+from src.core.logging import get_logger
 from src.models.user import UserTier
 from src.services.product_preview_usage import ProductPreviewUsageService
 from src.services.service_factory import create_user_service
@@ -28,6 +29,10 @@ _METERED_PRODUCT_GET_RE = re.compile(
     r")$"
 )
 _preview_usage_svc = ProductPreviewUsageService()
+logger = get_logger(__name__)
+
+# 429 Too Many Requests — preview/monthly quota exhausted.
+USAGE_LIMIT_STATUS = 429
 
 
 def _user_id_from_state(request: Request) -> str | None:
@@ -136,28 +141,36 @@ async def check_usage_limit(
 
         preview_token = request.headers.get("X-Preview-Token", "").strip() or None
         client_ip = _get_client_ip(request)
-        allowed, _ = await _preview_usage_svc.check_and_increment(
-            db,
-            token=preview_token,
-            ip=client_ip,
-            increment=_should_increment_preview(request),
-        )
+        try:
+            allowed, _ = await _preview_usage_svc.check_and_increment(
+                db,
+                token=preview_token,
+                ip=client_ip,
+                increment=_should_increment_preview(request),
+            )
+        except Exception:
+            logger.exception("Anonymous preview usage check failed")
+            raise HTTPException(
+                status_code=503,
+                detail="Usage metering temporarily unavailable. Please try again.",
+            ) from None
         if not allowed:
             raise HTTPException(
-                status_code=429,
+                status_code=USAGE_LIMIT_STATUS,
                 detail="Free preview limit reached. Sign in for unlimited access.",
             )
         return
 
     user_service = create_user_service()
     user = await user_service.get_user_by_id(db, user_id)
+    # Pro (and bypass accounts) never hit anonymous preview or free-tier monthly caps.
     if user and user.tier == UserTier.PRO:
         return
 
     allowed, _ = await UsageService.check_usage_limit(db, user_id)
     if not allowed:
         raise HTTPException(
-            status_code=429,
+            status_code=USAGE_LIMIT_STATUS,
             detail="Monthly usage limit reached. Upgrade to Pro for unlimited access.",
         )
 

--- a/packages/backend/src/core/tier_deps.py
+++ b/packages/backend/src/core/tier_deps.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fastapi import Depends, HTTPException, Request
 from motor.core import AgnosticDatabase
+from starlette import status
 
 from src.core.database import get_db
 from src.core.jwt import clerk_auth_service
@@ -30,9 +31,6 @@ _METERED_PRODUCT_GET_RE = re.compile(
 )
 _preview_usage_svc = ProductPreviewUsageService()
 logger = get_logger(__name__)
-
-# 429 Too Many Requests — preview/monthly quota exhausted.
-USAGE_LIMIT_STATUS = 429
 
 
 def _user_id_from_state(request: Request) -> str | None:
@@ -151,12 +149,12 @@ async def check_usage_limit(
         except Exception:
             logger.exception("Anonymous preview usage check failed")
             raise HTTPException(
-                status_code=503,
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Usage metering temporarily unavailable. Please try again.",
             ) from None
         if not allowed:
             raise HTTPException(
-                status_code=USAGE_LIMIT_STATUS,
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Free preview limit reached. Sign in for unlimited access.",
             )
         return
@@ -170,7 +168,7 @@ async def check_usage_limit(
     allowed, _ = await UsageService.check_usage_limit(db, user_id)
     if not allowed:
         raise HTTPException(
-            status_code=USAGE_LIMIT_STATUS,
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="Monthly usage limit reached. Upgrade to Pro for unlimited access.",
         )
 

--- a/packages/backend/src/services/product_preview_usage.py
+++ b/packages/backend/src/services/product_preview_usage.py
@@ -25,6 +25,31 @@ class ProductPreviewUsageService:
             return 0
         return int(doc.get("count", 0))
 
+    def _identity_fields(
+        self,
+        *,
+        now: datetime,
+        month_key: str,
+        token: str | None,
+        ip: str,
+        count: int,
+    ) -> tuple[dict, dict]:
+        set_on_insert: dict = {
+            "first_seen": now,
+            "count": count,
+            "month_key": month_key,
+        }
+        if token:
+            set_on_insert["token"] = token
+        else:
+            set_on_insert["ip"] = ip
+
+        set_fields: dict = {"last_seen": now}
+        if token:
+            set_fields["ip"] = ip
+
+        return set_on_insert, set_fields
+
     async def check_and_increment(
         self,
         db: AgnosticDatabase,
@@ -48,35 +73,6 @@ class ProductPreviewUsageService:
             return current < ANONYMOUS_LIMIT, current
 
         now = datetime.now(tz=UTC)
-        set_on_insert: dict = {"first_seen": now, "count": 0, "month_key": month_key}
-        if token:
-            set_on_insert["token"] = token
-        else:
-            set_on_insert["ip"] = ip
-
-        set_fields: dict = {"last_seen": now}
-        if token:
-            set_fields["ip"] = ip
-
-        await collection.update_one(
-            key_filter,
-            {"$setOnInsert": set_on_insert, "$set": set_fields},
-            upsert=True,
-        )
-
-        doc = await collection.find_one(key_filter, {"count": 1, "month_key": 1})
-        current = self._effective_count(doc, month_key)
-
-        if doc and doc.get("month_key") == month_key and current >= ANONYMOUS_LIMIT:
-            return False, current
-
-        if doc and doc.get("month_key") != month_key:
-            updated = await collection.find_one_and_update(
-                key_filter,
-                {"$set": {"count": 1, "month_key": month_key, "last_seen": now}},
-                return_document=ReturnDocument.AFTER,
-            )
-            return True, int(updated["count"]) if updated else 1
 
         updated = await collection.find_one_and_update(
             {**key_filter, "month_key": month_key, "count": {"$lt": ANONYMOUS_LIMIT}},
@@ -87,5 +83,27 @@ class ProductPreviewUsageService:
             return True, int(updated["count"])
 
         doc = await collection.find_one(key_filter, {"count": 1, "month_key": 1})
-        current = self._effective_count(doc, month_key)
-        return False, current
+        if not doc:
+            set_on_insert, set_fields = self._identity_fields(
+                now=now,
+                month_key=month_key,
+                token=token,
+                ip=ip,
+                count=1,
+            )
+            await collection.update_one(
+                key_filter,
+                {"$setOnInsert": set_on_insert, "$set": set_fields},
+                upsert=True,
+            )
+            return True, 1
+
+        if doc.get("month_key") != month_key:
+            updated = await collection.find_one_and_update(
+                key_filter,
+                {"$set": {"count": 1, "month_key": month_key, "last_seen": now}},
+                return_document=ReturnDocument.AFTER,
+            )
+            return True, int(updated["count"]) if updated else 1
+
+        return False, self._effective_count(doc, month_key)

--- a/packages/backend/src/services/product_preview_usage.py
+++ b/packages/backend/src/services/product_preview_usage.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime
 
 from motor.core import AgnosticDatabase
 from pymongo import ReturnDocument
-from pymongo.errors import DuplicateKeyError
 
 ANONYMOUS_LIMIT = 15
 
@@ -26,72 +25,6 @@ class ProductPreviewUsageService:
             return 0
         return int(doc.get("count", 0))
 
-    def _count_after_increment(self, before: dict | None, month_key: str) -> int:
-        if before is None:
-            return 1
-        if before.get("month_key") != month_key:
-            return 1
-        return self._effective_count(before, month_key) + 1
-
-    def _build_increment_update(
-        self,
-        *,
-        month_key: str,
-        now: datetime,
-        token: str | None,
-        ip: str,
-    ) -> tuple[list[dict], dict]:
-        set_on_insert: dict = {"first_seen": now}
-        extra_set: dict = {"month_key": month_key, "last_seen": now}
-        if token:
-            set_on_insert["token"] = token
-            extra_set["ip"] = ip
-        else:
-            set_on_insert["ip"] = ip
-
-        pipeline = [
-            {
-                "$set": {
-                    **extra_set,
-                    "count": {
-                        "$cond": {
-                            "if": {
-                                "$lt": [
-                                    {
-                                        "$cond": {
-                                            "if": {
-                                                "$ne": [
-                                                    {"$ifNull": ["$month_key", ""]},
-                                                    month_key,
-                                                ]
-                                            },
-                                            "then": 0,
-                                            "else": {"$ifNull": ["$count", 0]},
-                                        }
-                                    },
-                                    ANONYMOUS_LIMIT,
-                                ]
-                            },
-                            "then": {
-                                "$cond": {
-                                    "if": {
-                                        "$ne": [
-                                            {"$ifNull": ["$month_key", ""]},
-                                            month_key,
-                                        ]
-                                    },
-                                    "then": 1,
-                                    "else": {"$add": ["$count", 1]},
-                                }
-                            },
-                            "else": {"$ifNull": ["$count", 0]},
-                        }
-                    },
-                }
-            }
-        ]
-        return pipeline, set_on_insert
-
     async def check_and_increment(
         self,
         db: AgnosticDatabase,
@@ -107,40 +40,52 @@ class ProductPreviewUsageService:
         """
         key_filter = self._key_filter(token=token, ip=ip)
         month_key = self._current_month_key()
+        collection = db[self.COLLECTION]
 
         if not increment:
-            doc = await db[self.COLLECTION].find_one(key_filter, {"count": 1, "month_key": 1})
+            doc = await collection.find_one(key_filter, {"count": 1, "month_key": 1})
             current = self._effective_count(doc, month_key)
             return current < ANONYMOUS_LIMIT, current
 
         now = datetime.now(tz=UTC)
-        pipeline, set_on_insert = self._build_increment_update(
-            month_key=month_key,
-            now=now,
-            token=token,
-            ip=ip,
+        set_on_insert: dict = {"first_seen": now, "count": 0, "month_key": month_key}
+        if token:
+            set_on_insert["token"] = token
+        else:
+            set_on_insert["ip"] = ip
+
+        set_fields: dict = {"last_seen": now}
+        if token:
+            set_fields["ip"] = ip
+
+        await collection.update_one(
+            key_filter,
+            {"$setOnInsert": set_on_insert, "$set": set_fields},
+            upsert=True,
         )
 
-        try:
-            before = await db[self.COLLECTION].find_one_and_update(
+        doc = await collection.find_one(key_filter, {"count": 1, "month_key": 1})
+        current = self._effective_count(doc, month_key)
+
+        if doc and doc.get("month_key") == month_key and current >= ANONYMOUS_LIMIT:
+            return False, current
+
+        if doc and doc.get("month_key") != month_key:
+            updated = await collection.find_one_and_update(
                 key_filter,
-                pipeline,
-                upsert=True,
-                return_document=ReturnDocument.BEFORE,
-                set_on_insert=set_on_insert,
+                {"$set": {"count": 1, "month_key": month_key, "last_seen": now}},
+                return_document=ReturnDocument.AFTER,
             )
-        except DuplicateKeyError:
-            before = await db[self.COLLECTION].find_one_and_update(
-                key_filter,
-                pipeline,
-                return_document=ReturnDocument.BEFORE,
-            )
+            return True, int(updated["count"]) if updated else 1
 
-        if before is None:
-            return True, 1
+        updated = await collection.find_one_and_update(
+            {**key_filter, "month_key": month_key, "count": {"$lt": ANONYMOUS_LIMIT}},
+            {"$inc": {"count": 1}, "$set": {"last_seen": now}},
+            return_document=ReturnDocument.AFTER,
+        )
+        if updated:
+            return True, int(updated["count"])
 
-        before_count = self._effective_count(before, month_key)
-        if before.get("month_key") == month_key and before_count >= ANONYMOUS_LIMIT:
-            return False, before_count
-
-        return True, self._count_after_increment(before, month_key)
+        doc = await collection.find_one(key_filter, {"count": 1, "month_key": 1})
+        current = self._effective_count(doc, month_key)
+        return False, current

--- a/packages/backend/tests/services/product_preview_usage_test.py
+++ b/packages/backend/tests/services/product_preview_usage_test.py
@@ -12,8 +12,9 @@ from src.services.product_preview_usage import (
 def mock_db():
     db = MagicMock()
     collection = MagicMock()
-    collection.find_one_and_update = AsyncMock()
-    collection.find_one = AsyncMock()
+    collection.update_one = AsyncMock()
+    collection.find_one_and_update = AsyncMock(return_value=None)
+    collection.find_one = AsyncMock(return_value=None)
     db.product_preview_usage = collection
     db.__getitem__ = MagicMock(return_value=collection)
     return db
@@ -21,9 +22,15 @@ def mock_db():
 
 @pytest.mark.asyncio
 async def test_allows_first_use_with_token(mock_db):
-    mock_db.product_preview_usage.find_one_and_update.return_value = None
-    svc = ProductPreviewUsageService()
-    allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
+    mock_db.product_preview_usage.find_one_and_update.return_value = {
+        "token": "uuid-1",
+        "count": 1,
+        "month_key": "2026-06",
+    }
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
+        mock_db.product_preview_usage.find_one.return_value = None
+        svc = ProductPreviewUsageService()
+        allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
     assert allowed is True
     assert count == 1
 
@@ -31,9 +38,21 @@ async def test_allows_first_use_with_token(mock_db):
 @pytest.mark.asyncio
 async def test_allows_up_to_limit(mock_db):
     with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
+        mock_db.product_preview_usage.find_one.side_effect = [
+            {
+                "token": "uuid-1",
+                "count": ANONYMOUS_LIMIT - 1,
+                "month_key": "2026-06",
+            },
+            {
+                "token": "uuid-1",
+                "count": ANONYMOUS_LIMIT,
+                "month_key": "2026-06",
+            },
+        ]
         mock_db.product_preview_usage.find_one_and_update.return_value = {
             "token": "uuid-1",
-            "count": ANONYMOUS_LIMIT - 1,
+            "count": ANONYMOUS_LIMIT,
             "month_key": "2026-06",
         }
         svc = ProductPreviewUsageService()
@@ -45,7 +64,7 @@ async def test_allows_up_to_limit(mock_db):
 @pytest.mark.asyncio
 async def test_blocks_over_limit(mock_db):
     with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
-        mock_db.product_preview_usage.find_one_and_update.return_value = {
+        mock_db.product_preview_usage.find_one.return_value = {
             "token": "uuid-1",
             "count": ANONYMOUS_LIMIT,
             "month_key": "2026-06",
@@ -54,15 +73,21 @@ async def test_blocks_over_limit(mock_db):
         allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
         assert allowed is False
         assert count == ANONYMOUS_LIMIT
+        mock_db.product_preview_usage.find_one_and_update.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_resets_count_on_new_month(mock_db):
     with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-07"):
-        mock_db.product_preview_usage.find_one_and_update.return_value = {
+        mock_db.product_preview_usage.find_one.return_value = {
             "token": "uuid-1",
             "count": ANONYMOUS_LIMIT,
             "month_key": "2026-06",
+        }
+        mock_db.product_preview_usage.find_one_and_update.return_value = {
+            "token": "uuid-1",
+            "count": 1,
+            "month_key": "2026-07",
         }
         svc = ProductPreviewUsageService()
         allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
@@ -74,19 +99,27 @@ async def test_resets_count_on_new_month(mock_db):
 
 @pytest.mark.asyncio
 async def test_different_tokens_are_independent_on_same_ip(mock_db):
-    mock_db.product_preview_usage.find_one_and_update.return_value = None
-    svc = ProductPreviewUsageService()
-    allowed_a, _ = await svc.check_and_increment(mock_db, token="uuid-A", ip="5.5.5.5")
-    allowed_b, _ = await svc.check_and_increment(mock_db, token="uuid-B", ip="5.5.5.5")
+    mock_db.product_preview_usage.find_one_and_update.return_value = {
+        "count": 1,
+        "month_key": "2026-06",
+    }
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
+        svc = ProductPreviewUsageService()
+        allowed_a, _ = await svc.check_and_increment(mock_db, token="uuid-A", ip="5.5.5.5")
+        allowed_b, _ = await svc.check_and_increment(mock_db, token="uuid-B", ip="5.5.5.5")
     assert allowed_a is True
     assert allowed_b is True
 
 
 @pytest.mark.asyncio
 async def test_ip_fallback_when_no_token(mock_db):
-    mock_db.product_preview_usage.find_one_and_update.return_value = None
-    svc = ProductPreviewUsageService()
-    allowed, count = await svc.check_and_increment(mock_db, token=None, ip="9.9.9.9")
+    mock_db.product_preview_usage.find_one_and_update.return_value = {
+        "count": 1,
+        "month_key": "2026-06",
+    }
+    with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
+        svc = ProductPreviewUsageService()
+        allowed, count = await svc.check_and_increment(mock_db, token=None, ip="9.9.9.9")
     assert allowed is True
     assert count == 1
 

--- a/packages/backend/tests/services/product_preview_usage_test.py
+++ b/packages/backend/tests/services/product_preview_usage_test.py
@@ -22,34 +22,18 @@ def mock_db():
 
 @pytest.mark.asyncio
 async def test_allows_first_use_with_token(mock_db):
-    mock_db.product_preview_usage.find_one_and_update.return_value = {
-        "token": "uuid-1",
-        "count": 1,
-        "month_key": "2026-06",
-    }
     with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
         mock_db.product_preview_usage.find_one.return_value = None
         svc = ProductPreviewUsageService()
         allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
     assert allowed is True
     assert count == 1
+    mock_db.product_preview_usage.update_one.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_allows_up_to_limit(mock_db):
     with patch.object(ProductPreviewUsageService, "_current_month_key", return_value="2026-06"):
-        mock_db.product_preview_usage.find_one.side_effect = [
-            {
-                "token": "uuid-1",
-                "count": ANONYMOUS_LIMIT - 1,
-                "month_key": "2026-06",
-            },
-            {
-                "token": "uuid-1",
-                "count": ANONYMOUS_LIMIT,
-                "month_key": "2026-06",
-            },
-        ]
         mock_db.product_preview_usage.find_one_and_update.return_value = {
             "token": "uuid-1",
             "count": ANONYMOUS_LIMIT,
@@ -59,6 +43,7 @@ async def test_allows_up_to_limit(mock_db):
         allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
         assert allowed is True
         assert count == ANONYMOUS_LIMIT
+        mock_db.product_preview_usage.find_one.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -73,7 +58,7 @@ async def test_blocks_over_limit(mock_db):
         allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
         assert allowed is False
         assert count == ANONYMOUS_LIMIT
-        mock_db.product_preview_usage.find_one_and_update.assert_not_called()
+        assert mock_db.product_preview_usage.find_one_and_update.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -84,17 +69,20 @@ async def test_resets_count_on_new_month(mock_db):
             "count": ANONYMOUS_LIMIT,
             "month_key": "2026-06",
         }
-        mock_db.product_preview_usage.find_one_and_update.return_value = {
-            "token": "uuid-1",
-            "count": 1,
-            "month_key": "2026-07",
-        }
+        mock_db.product_preview_usage.find_one_and_update.side_effect = [
+            None,
+            {
+                "token": "uuid-1",
+                "count": 1,
+                "month_key": "2026-07",
+            },
+        ]
         svc = ProductPreviewUsageService()
         allowed, count = await svc.check_and_increment(mock_db, token="uuid-1", ip="1.2.3.4")
 
     assert allowed is True
     assert count == 1
-    mock_db.product_preview_usage.find_one_and_update.assert_awaited_once()
+    assert mock_db.product_preview_usage.find_one_and_update.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/packages/backend/tests/unit/tier_access_test.py
+++ b/packages/backend/tests/unit/tier_access_test.py
@@ -174,6 +174,25 @@ async def test_check_usage_limit_blocks_anonymous_product_preview() -> None:
 
 
 @pytest.mark.asyncio
+async def test_check_usage_limit_preview_metering_failure_returns_503() -> None:
+    request = _mock_request(None)
+    request.method = "GET"
+    request.url.path = "/products/acme/overview"
+    request.headers = {"X-Preview-Token": "preview-token-1"}
+    request.client = MagicMock(host="1.2.3.4")
+    db = AsyncMock()
+
+    with patch("src.core.tier_deps._preview_usage_svc") as mock_preview_svc:
+        mock_preview_svc.check_and_increment = AsyncMock(
+            side_effect=RuntimeError("mongo unavailable")
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await check_usage_limit(request=request, db=db)
+
+    assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
 async def test_check_usage_limit_skips_crawler_user_agents() -> None:
     request = _mock_request(None)
     request.method = "GET"

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.test.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.test.tsx
@@ -108,4 +108,40 @@ describe("CompanyPage limit reached state", () => {
     );
     expect(pipelineFetchCalled).toBe(false);
   });
+
+  it("renders server error UI on 500, not product not found", async () => {
+    const errorFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = getRequestUrl(input);
+      if (url.endsWith("/api/products/acme-inc")) {
+        return createJsonResponse(500, { error: "Internal Server Error" });
+      }
+      if (url.endsWith("/api/products/acme-inc/documents")) {
+        return createJsonResponse(200, []);
+      }
+      if (url.endsWith("/api/products/acme-inc/overview")) {
+        return createJsonResponse(500, { error: "Internal Server Error" });
+      }
+      if (url.endsWith("/api/products/acme-inc/explainer")) {
+        return createJsonResponse(500, { error: "Internal Server Error" });
+      }
+      if (url.endsWith("/api/products/acme-inc/topics")) {
+        return createJsonResponse(500, { error: "Internal Server Error" });
+      }
+      return createJsonResponse(500, { error: `Unexpected URL: ${url}` });
+    });
+
+    vi.stubGlobal("fetch", errorFetch);
+
+    render(<CompanyPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Couldn't load this report" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("heading", { name: "Product Not Found" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -45,7 +45,10 @@ import type {
 } from "@/types";
 import { useAuth } from "@clerk/nextjs";
 
-import { deriveProductPageOverviewState } from "./product-page-fetch-state";
+import {
+  deriveProductPageOverviewState,
+  isProductNotFound,
+} from "./product-page-fetch-state";
 
 function derivePipelineUrl(product: Product): string | null {
   const fromWebsite = product.website?.trim();
@@ -125,7 +128,12 @@ export default function CompanyPage({
   const [documentsLoading, setDocumentsLoading] = useState(false);
   const [thinEvidence, setThinEvidence] = useState(false);
   const [indexationMode, setIndexationMode] = useState<
-    "ready" | "indexing" | "limit_reached" | "unknown"
+    | "ready"
+    | "indexing"
+    | "limit_reached"
+    | "not_found"
+    | "server_error"
+    | "unknown"
   >(initialOverview ? "ready" : "unknown");
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [failedJob, setFailedJob] = useState<FailedCrawlJob | null>(null);
@@ -216,9 +224,21 @@ export default function CompanyPage({
           return;
         }
 
+        if (overviewState === "server_error" || prodRes.status >= 500) {
+          setData(null);
+          setIndexationMode("server_error");
+          return;
+        }
+
+        if (isProductNotFound(prodRes.status)) {
+          setData(null);
+          setIndexationMode("not_found");
+          return;
+        }
+
         if (!prodJson) {
           setData(null);
-          setIndexationMode("ready"); // render not-found
+          setIndexationMode("server_error");
           return;
         }
 
@@ -922,27 +942,87 @@ export default function CompanyPage({
       );
     }
 
+    if (indexationMode === "server_error") {
+      return (
+        <div className="space-y-8">
+          <div className="border-b border-border pb-8">
+            <p className="text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground mb-4">
+              Something went wrong
+            </p>
+            <h1 className="text-4xl md:text-5xl font-display font-medium tracking-tight text-foreground">
+              Couldn&apos;t load this report
+            </h1>
+            <p className="text-sm text-muted-foreground mt-4 max-w-2xl leading-relaxed">
+              We hit an error loading {limitReachedDisplayName}. This is usually
+              temporary — try again in a moment.
+            </p>
+          </div>
+          <div className="flex flex-col sm:flex-row gap-3">
+            <Button
+              onClick={() => window.location.reload()}
+              className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+            >
+              <RotateCcw className="mr-2 h-3.5 w-3.5" />
+              Try again
+            </Button>
+            <Link
+              href="/products"
+              className="inline-flex items-center justify-center gap-2 h-11 px-6 border border-border text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" />
+              Browse Products
+            </Link>
+          </div>
+        </div>
+      );
+    }
+
+    if (indexationMode === "not_found") {
+      return (
+        <div className="space-y-8">
+          <div className="border-b border-border pb-8">
+            <p className="text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground mb-4">
+              404 — Not Found
+            </p>
+            <h1 className="text-4xl md:text-5xl font-display font-medium tracking-tight text-foreground">
+              Product Not Found
+            </h1>
+            <p className="text-sm text-muted-foreground mt-4 max-w-2xl leading-relaxed">
+              The product you&apos;re looking for doesn&apos;t exist or has been
+              removed.
+            </p>
+          </div>
+          <Link
+            href="/products"
+            className="inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Browse Products
+          </Link>
+        </div>
+      );
+    }
+
     return (
       <div className="space-y-8">
         <div className="border-b border-border pb-8">
           <p className="text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground mb-4">
-            404 — Not Found
+            Something went wrong
           </p>
           <h1 className="text-4xl md:text-5xl font-display font-medium tracking-tight text-foreground">
-            Product Not Found
+            Couldn&apos;t load this report
           </h1>
           <p className="text-sm text-muted-foreground mt-4 max-w-2xl leading-relaxed">
-            The product you&apos;re looking for doesn&apos;t exist or has been
-            removed.
+            We hit an error loading {limitReachedDisplayName}. Please try again.
           </p>
         </div>
-        <Link
-          href="/products"
-          className="inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground hover:text-foreground transition-colors"
+        <Button
+          onClick={() => window.location.reload()}
+          className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
         >
-          <ArrowLeft className="h-3.5 w-3.5" />
-          Browse Products
-        </Link>
+          <RotateCcw className="mr-2 h-3.5 w-3.5" />
+          Try again
+        </Button>
       </div>
     );
   }

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -942,41 +942,6 @@ export default function CompanyPage({
       );
     }
 
-    if (indexationMode === "server_error") {
-      return (
-        <div className="space-y-8">
-          <div className="border-b border-border pb-8">
-            <p className="text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground mb-4">
-              Something went wrong
-            </p>
-            <h1 className="text-4xl md:text-5xl font-display font-medium tracking-tight text-foreground">
-              Couldn&apos;t load this report
-            </h1>
-            <p className="text-sm text-muted-foreground mt-4 max-w-2xl leading-relaxed">
-              We hit an error loading {limitReachedDisplayName}. This is usually
-              temporary — try again in a moment.
-            </p>
-          </div>
-          <div className="flex flex-col sm:flex-row gap-3">
-            <Button
-              onClick={() => window.location.reload()}
-              className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
-            >
-              <RotateCcw className="mr-2 h-3.5 w-3.5" />
-              Try again
-            </Button>
-            <Link
-              href="/products"
-              className="inline-flex items-center justify-center gap-2 h-11 px-6 border border-border text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <ArrowLeft className="h-3.5 w-3.5" />
-              Browse Products
-            </Link>
-          </div>
-        </div>
-      );
-    }
-
     if (indexationMode === "not_found") {
       return (
         <div className="space-y-8">
@@ -1013,16 +978,26 @@ export default function CompanyPage({
             Couldn&apos;t load this report
           </h1>
           <p className="text-sm text-muted-foreground mt-4 max-w-2xl leading-relaxed">
-            We hit an error loading {limitReachedDisplayName}. Please try again.
+            We hit an error loading {limitReachedDisplayName}. This is usually
+            temporary — try again in a moment.
           </p>
         </div>
-        <Button
-          onClick={() => window.location.reload()}
-          className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
-        >
-          <RotateCcw className="mr-2 h-3.5 w-3.5" />
-          Try again
-        </Button>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Button
+            onClick={() => window.location.reload()}
+            className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+          >
+            <RotateCcw className="mr-2 h-3.5 w-3.5" />
+            Try again
+          </Button>
+          <Link
+            href="/products"
+            className="inline-flex items-center justify-center gap-2 h-11 px-6 border border-border text-[10px] uppercase tracking-[0.2em] font-bold text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Browse Products
+          </Link>
+        </div>
       </div>
     );
   }

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.test.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { deriveProductPageOverviewState } from "./product-page-fetch-state";
+import {
+  deriveProductPageOverviewState,
+  isProductNotFound,
+} from "./product-page-fetch-state";
 
 describe("deriveProductPageOverviewState", () => {
   it("returns ready when overview request succeeds", () => {
@@ -47,6 +50,18 @@ describe("deriveProductPageOverviewState", () => {
     expect(result).toBe("limit_reached");
   });
 
+  it("returns server_error for 5xx responses", () => {
+    const result = deriveProductPageOverviewState({
+      overviewOk: false,
+      overviewStatus: 500,
+      explainerStatus: 200,
+      topicsStatus: 200,
+      productStatus: 200,
+    });
+
+    expect(result).toBe("server_error");
+  });
+
   it("returns indexing for non-limit overview misses like 425", () => {
     const result = deriveProductPageOverviewState({
       overviewOk: false,
@@ -56,5 +71,13 @@ describe("deriveProductPageOverviewState", () => {
     });
 
     expect(result).toBe("indexing");
+  });
+});
+
+describe("isProductNotFound", () => {
+  it("returns true only for HTTP 404", () => {
+    expect(isProductNotFound(404)).toBe(true);
+    expect(isProductNotFound(500)).toBe(false);
+    expect(isProductNotFound(429)).toBe(false);
   });
 });

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-fetch-state.ts
@@ -2,6 +2,7 @@ export type ProductPageOverviewState =
   | "ready"
   | "unauthorized"
   | "limit_reached"
+  | "server_error"
   | "indexing";
 
 interface ProductPageOverviewStateInput {
@@ -13,8 +14,17 @@ interface ProductPageOverviewStateInput {
   documentsStatus?: number;
 }
 
-const USAGE_LIMIT_HTTP_STATUS = 429;
 const OVERVIEW_UNAUTHORIZED_HTTP_STATUS = 401;
+/** 429 Too Many Requests — monthly/preview quota exhausted. */
+const USAGE_LIMIT_HTTP_STATUS = 429;
+
+function isUsageLimitStatus(status: number): boolean {
+  return status === USAGE_LIMIT_HTTP_STATUS;
+}
+
+function isServerErrorStatus(status: number): boolean {
+  return status >= 500;
+}
 
 export function deriveProductPageOverviewState({
   overviewOk,
@@ -32,17 +42,25 @@ export function deriveProductPageOverviewState({
     return "unauthorized";
   }
 
-  const hasUsageLimitResponse = [
+  const statuses = [
     overviewStatus,
     explainerStatus,
     topicsStatus,
     productStatus,
     documentsStatus,
-  ].some((status) => status === USAGE_LIMIT_HTTP_STATUS);
+  ].filter((status): status is number => status !== undefined);
 
-  if (hasUsageLimitResponse) {
+  if (statuses.some(isUsageLimitStatus)) {
     return "limit_reached";
   }
 
+  if (statuses.some(isServerErrorStatus)) {
+    return "server_error";
+  }
+
   return "indexing";
+}
+
+export function isProductNotFound(productStatus: number): boolean {
+  return productStatus === 404;
 }


### PR DESCRIPTION
## What this PR does

Product pages like `/products/tiktok` were failing in the browser with a misleading **“Product Not Found”** message even though the product exists. The root cause was the backend crashing with **500** on anonymous overview requests due to an unsupported MongoDB `findAndModify.set_on_insert` parameter in preview usage metering.

This PR fixes the MongoDB upsert logic, returns **429** when preview/monthly limits are hit, **503** when metering itself fails, and updates the frontend to show a dedicated **“Couldn’t load this report”** state on 5xx instead of treating it as a missing product.

## Why

- **Users:** Anonymous visitors and free-tier users could not load product reports at all; Pro users were unaffected only when auth forwarded correctly.
- **Operators:** Production `/api/products/{slug}/overview` was returning 500 for every anonymous request with a preview token.

## How product page behaviour changes

| Path | Change |
|---|---|
| Anonymous GET `/products/{slug}/overview` | No longer 500 from preview metering; succeeds when under limit |
| Anonymous preview limit exceeded | Returns **429** (was crashing or inconsistent) |
| Preview metering MongoDB failure | Returns **503** instead of unhandled 500 |
| Signed-in Pro users | Still bypass preview/monthly caps (unchanged) |
| Frontend client refetch on 5xx | Shows server-error UI with retry, not “Product Not Found” |
| Frontend client refetch on 429 | Shows existing usage-limit UI (unchanged) |
| True 404 product | Still shows “Product Not Found” (unchanged) |

## UX changes operators will notice

- Product pages that previously showed “Product Not Found” after a backend 500 now show **“Couldn’t load this report”** with a **Try again** action.
- Usage limit messaging is unchanged; limit responses use HTTP **429**.

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| Preview/monthly quota exhausted | 423 (intended) / 500 (production bug) | **429** |
| Preview metering failure | 500 | **503** |

## Tests

- Backend: `product_preview_usage_test.py`, `tier_access_test.py` — 27 tests passing.
- Frontend: `product-page-fetch-state.test.ts`, `product-page-client.test.tsx` — 9 tests passing.

### Edge cases to verify in a staging session

1. Open `/products/tiktok` logged out — expected: report loads (200 overview).
2. Exhaust anonymous preview quota — expected: **429** and usage-limit UI, not 404.
3. Simulate backend 500 on overview — expected: “Couldn’t load this report”, not “Product Not Found”.
4. Open same product as Pro user — expected: no preview limit, full access.

## Notes for reviewers

- The production bug was `find_one_and_update(..., set_on_insert=...)` which Atlas rejects; the fix uses standard `$setOnInsert` / `$inc` update documents instead.
- `limit_reached` is checked before `server_error` in fetch-state derivation so a 429 on any parallel request still wins over a 503 on overview.