### PR TITLE
feat(pipeline): analysis-only requeue without recrawl

### DIFF
--- a/packages/backend/scripts/requeue_analysis.py
+++ b/packages/backend/scripts/requeue_analysis.py
@@ -1,0 +1,136 @@
+"""Queue analysis-only pipeline jobs (synthesis + overview, no recrawl).
+
+Creates pending pipeline jobs with skip_crawl=True and force_reanalyze=True so
+production workers re-run document analysis and overview generation on stored
+policy documents without hitting the crawler.
+
+Usage:
+    # Dry run — list eligible products:
+    uv run python scripts/requeue_analysis.py --production --dry-run
+
+    # Requeue all products with an existing overview:
+    uv run python scripts/requeue_analysis.py --production
+
+    # Requeue specific slugs:
+    uv run python scripts/requeue_analysis.py --production tiktok capcut
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def _resolve_production(use_production: bool) -> None:
+    if not use_production:
+        return
+    prod_uri = os.getenv("PRODUCTION_MONGO_URI")
+    if not prod_uri:
+        print("ERROR: PRODUCTION_MONGO_URI not set")
+        sys.exit(1)
+    os.environ["MONGO_URI"] = prod_uri
+
+
+def _job_url(product) -> str:
+    if product.crawl_base_urls:
+        return product.crawl_base_urls[0]
+    if product.domains:
+        return f"https://{product.domains[0]}"
+    return f"https://clausea.co/products/{product.slug}"
+
+
+async def main(
+    slugs: list[str] | None,
+    *,
+    dry_run: bool,
+    use_production: bool,
+) -> None:
+    _resolve_production(use_production)
+    if use_production:
+        print("Using PRODUCTION_MONGO_URI")
+
+    from src.core.database import db_session
+    from src.core.logging import setup_logging
+    from src.models.pipeline_job import PipelineJob
+    from src.repositories.pipeline_repository import PipelineRepository
+    from src.services.service_factory import create_document_service, create_product_service
+
+    setup_logging()
+    product_svc = create_product_service()
+    doc_svc = create_document_service()
+    pipeline_repo = PipelineRepository()
+
+    async with db_session() as db:
+        if slugs:
+            target_slugs = slugs
+        else:
+            cursor = db.product_intelligence.find(
+                {"overview": {"$exists": True, "$ne": None}},
+                {"product_slug": 1},
+            )
+            rows = await cursor.to_list(length=None)
+            target_slugs = sorted(row["product_slug"] for row in rows if row.get("product_slug"))
+
+        queued = 0
+        skipped_active = 0
+        skipped_no_docs = 0
+        skipped_missing = 0
+
+        print(f"Evaluating {len(target_slugs)} product(s)...")
+        for slug in target_slugs:
+            product = await product_svc.get_product_by_slug(db, slug)
+            if not product:
+                skipped_missing += 1
+                print(f"  [missing] {slug}")
+                continue
+
+            active = await pipeline_repo.find_active_by_product_slug(db, slug)
+            if active:
+                skipped_active += 1
+                print(f"  [active]  {slug} (job {active.id}, status={active.status})")
+                continue
+
+            docs = await doc_svc.get_product_documents_by_slug(db, slug)
+            policy_docs = [d for d in docs if d.doc_type != "other"]
+            if not policy_docs:
+                skipped_no_docs += 1
+                print(f"  [no-docs] {slug}")
+                continue
+
+            if dry_run:
+                print(f"  [dry-run] {slug} ({len(policy_docs)} docs)")
+                queued += 1
+                continue
+
+            job = PipelineJob(
+                product_slug=slug,
+                product_id=product.id,
+                product_name=product.name,
+                url=_job_url(product),
+                skip_crawl=True,
+                force_reanalyze=True,
+            )
+            await pipeline_repo.create(db, job)
+            queued += 1
+            print(f"  [queued]  {slug} job={job.id} docs={len(policy_docs)}")
+
+        print()
+        print(
+            f"Done: queued={queued}, skipped_active={skipped_active}, "
+            f"skipped_no_docs={skipped_no_docs}, skipped_missing={skipped_missing}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Queue analysis-only pipeline jobs")
+    parser.add_argument("slugs", nargs="*", help="Product slugs (default: all with overviews)")
+    parser.add_argument("--dry-run", action="store_true", help="List targets without enqueueing")
+    parser.add_argument("--production", action="store_true", help="Use PRODUCTION_MONGO_URI")
+    args = parser.parse_args()
+    asyncio.run(main(args.slugs or None, dry_run=args.dry_run, use_production=args.production))

--- a/packages/backend/src/models/pipeline_job.py
+++ b/packages/backend/src/models/pipeline_job.py
@@ -256,5 +256,9 @@ class PipelineJob(BaseModel):
     # LLM analysis on every document even if findings already exist in the DB.
     force_reanalyze: bool = False
 
+    # When True, skip the crawl phase and re-run synthesis + overview on existing
+    # stored documents (analysis-only requeue).
+    skip_crawl: bool = False
+
     # Number of documents whose analysis was reused from a prior run (skipped LLM).
     analyses_skipped: int = 0

--- a/packages/backend/src/services/pipeline_service.py
+++ b/packages/backend/src/services/pipeline_service.py
@@ -415,117 +415,7 @@ class PipelineService:
                             job.product_slug,
                         )
 
-                    # === Step 1: Crawl ===
-                    job.status = "crawling"
-                    await self._update_step(
-                        db, job, "crawling", "running", "Discovering policy documents..."
-                    )
-
-                    # Track progress tasks to ensure they are all processed before switching phases.
-                    # This prevents a race condition where a late 'Discovery' update overwrites
-                    # the subsequent 'synthesising' job status in MongoDB.
-                    crawl_tasks: list[asyncio.Task] = []
-
-                    # Create progress callback for crawl phase.
-                    #
-                    # `current` is pages successfully fetched; `total` is the discovered
-                    # frontier. We deliberately do NOT emit a percentage or "X remaining"
-                    # for crawling: the frontier is a moving target (it grows as links are
-                    # found) and is inflated by speculative policy-URL probes that mostly
-                    # 404, so any ratio is fiction. Report an honest count and let the UI
-                    # render this step as indeterminate. (The synthesising step, which has a
-                    # real fixed total, keeps its genuine percentage.)
-                    async def _on_crawl_progress(_phase: str, current: int, _total: int) -> None:
-                        pages = "page" if current == 1 else "pages"
-                        # We wrap this in a task so the crawler doesn't block on DB I/O,
-                        # but we keep track of it to await it before phase transitions.
-                        task = asyncio.create_task(
-                            self._update_step_progress(
-                                db,
-                                job,
-                                "crawling",
-                                message=f"Discovering documents — {current} {pages} read so far",
-                            )
-                        )
-                        crawl_tasks.append(task)
-
-                    pipeline = PolicyDocumentPipeline(
-                        progress_callback=_on_crawl_progress, job_id=job.id
-                    )
-                    stats = await pipeline.run([product])
-
-                    # Drain pending progress tasks before finalizing the crawl step
-                    if crawl_tasks:
-                        await asyncio.gather(*crawl_tasks, return_exceptions=True)
-
-                    # Update the product display name when the crawler found a better one in
-                    # page metadata (e.g. og:site_name "OpenAI" vs domain-derived "Openai").
-                    # Only auto-derived placeholder names are eligible for improvement;
-                    # manually curated ("manual") or already-extracted names are frozen so a
-                    # later crawl can never degrade a good name into a section title like
-                    # "Help Center".
-                    brand_name: str | None = getattr(stats, "brand_name", None)
-                    if _should_override_product_name(product.name, product.name_source, brand_name):
-                        assert brand_name is not None  # guaranteed by _should_override_product_name
-                        try:
-                            product_svc_upd = create_product_service()
-                            await product_svc_upd.update_product_name(
-                                db,
-                                product.id,
-                                brand_name,
-                                name_source=NAME_SOURCE_AUTO_EXTRACTED,
-                            )
-                            logger.info(
-                                "Product name updated: '%s' → '%s' (%s)",
-                                product.name,
-                                brand_name,
-                                job.product_slug,
-                            )
-                            product.name = brand_name
-                            product.name_source = NAME_SOURCE_AUTO_EXTRACTED
-                            job.product_name = brand_name
-                            await self._pipeline_repo.update_fields(
-                                db, job.id, {"product_name": brand_name}
-                            )
-                        except Exception as name_exc:
-                            logger.warning(
-                                "Brand name update failed for %s: %s",
-                                job.product_slug,
-                                name_exc,
-                            )
-
-                    job.documents_found = stats.total_documents_found
-                    job.documents_stored = stats.policy_documents_stored
-
-                    # Reset attempt-local crawl diagnostics so a retry cannot inherit
-                    # stale errors/skips from a previous failed attempt.
-                    job.crawl_errors = []
-                    job.crawl_skip_reasons = []
-
-                    # Persist per-URL crawl failures on the job
-                    if stats.crawl_errors:
-                        job.crawl_errors = [CrawlError(**err) for err in stats.crawl_errors]
-
-                    # Persist silent skips (fetched OK but rejected by a filter)
-                    if stats.crawl_skip_reasons:
-                        job.crawl_skip_reasons = [
-                            CrawlSkip(**skip) for skip in stats.crawl_skip_reasons
-                        ]
-
-                    await self._update_step(
-                        db,
-                        job,
-                        "crawling",
-                        "completed",
-                        f"Found {stats.policy_documents_stored} policy documents",
-                    )
-
-                    if stats.policy_documents_stored == 0:
-                        # Crawl stored nothing new. Before giving up, check if the
-                        # product already has documents from a previous run. If yes,
-                        # those docs are valid input for synthesis — deduplicated
-                        # re-crawls (same content hash) legitimately store 0 new docs
-                        # but must not skip the overview step.
+                    if job.skip_crawl:
                         doc_svc_check = create_document_service()
                         existing_docs = await doc_svc_check.get_product_documents_by_slug(
                             db, job.product_slug
@@ -533,98 +423,296 @@ class PipelineService:
                         existing_policy_docs = [
                             doc for doc in existing_docs if doc.doc_type != "other"
                         ]
-                        if existing_policy_docs:
-                            logger.info(
-                                "Crawl stored 0 new docs but %d existing docs found for %s "
-                                "— proceeding to synthesis",
-                                len(existing_policy_docs),
-                                job.product_slug,
-                            )
-                            job.documents_stored = len(existing_policy_docs)
-                        else:
-                            job.status = "no_documents"
-
-                        # Classify the terminal outcome from the crawl's error signals.
-                        # Priority order: robots_blocked > site_unavailable > access_denied
-                        # > no_policy_found (pages fetched, none matched) > fallback errors.
-                        _robots_errs = [
-                            e for e in job.crawl_errors if e.error_type == "robots_txt_blocked"
-                        ]
-                        _non_robots_errs = [
-                            e for e in job.crawl_errors if e.error_type != "robots_txt_blocked"
-                        ]
-                        _conn_errs = [
-                            e
-                            for e in _non_robots_errs
-                            if e.error_type in ("network_error", "timeout")
-                        ]
-                        _hard_errs = [
-                            e
-                            for e in _non_robots_errs
-                            if is_hard_crawl_error(e.error_type, e.status_code, e.error_message)
-                        ]
-
-                        if _robots_errs and not _non_robots_errs:
-                            # All attempted URLs were blocked by robots.txt — deterministic,
-                            # targeted outcome surfaced to the user with dedicated copy.
-                            job.status = "robots_blocked"
-                            job.error = PipelineErrorCode.crawl_robots_blocked
+                        if not existing_policy_docs:
+                            job.status = "failed"
+                            job.error = PipelineErrorCode.no_documents_found
                             job.error_detail = (
-                                "This site blocks automated access via robots.txt. "
-                                "We were unable to crawl any policy documents."
+                                "Analysis-only requeue skipped crawl but no stored "
+                                "policy documents were found."
                             )
-                        elif job.status == "no_documents":
-                            # Only apply specific new statuses when there are no existing
-                            # docs (job.status was set to "no_documents" in the else branch
-                            # above). For jobs with existing docs we leave the status
-                            # unchanged so the partial-block signal is informational only.
-                            if (
-                                _non_robots_errs
-                                and _conn_errs
-                                and len(_conn_errs) == len(_non_robots_errs)
-                            ):
-                                # All failures are connection-level (DNS, SSL, timeout, refused)
-                                # and there are no robots-txt blocks — site is unreachable.
-                                job.status = "site_unavailable"
-                                job.error = PipelineErrorCode.site_unavailable
+                            job.completed_at = datetime.now()
+                            await self._update_step(
+                                db,
+                                job,
+                                "crawling",
+                                "failed",
+                                "Skipped crawl — no existing documents",
+                            )
+                            await self._update_step(
+                                db,
+                                job,
+                                "synthesising",
+                                "failed",
+                                "Skipped — no documents to analyze",
+                            )
+                            await self._update_step(
+                                db,
+                                job,
+                                "generating_overview",
+                                "failed",
+                                "Skipped — no documents to analyze",
+                            )
+                            await self._pipeline_repo.update(db, job)
+                            return
+
+                        job.documents_stored = len(existing_policy_docs)
+                        job.documents_found = len(existing_policy_docs)
+                        job.crawl_errors = []
+                        job.crawl_skip_reasons = []
+                        await self._update_step(
+                            db,
+                            job,
+                            "crawling",
+                            "completed",
+                            f"Skipped crawl — reusing {len(existing_policy_docs)} existing document(s)",
+                        )
+                        await self._pipeline_repo.update_fields(
+                            db,
+                            job.id,
+                            {
+                                "documents_stored": job.documents_stored,
+                                "documents_found": job.documents_found,
+                                "crawl_errors": [],
+                                "crawl_skip_reasons": [],
+                            },
+                        )
+                    else:
+                        # === Step 1: Crawl ===
+                        job.status = "crawling"
+                        await self._update_step(
+                            db, job, "crawling", "running", "Discovering policy documents..."
+                        )
+
+                        # Track progress tasks to ensure they are all processed before switching phases.
+                        # This prevents a race condition where a late 'Discovery' update overwrites
+                        # the subsequent 'synthesising' job status in MongoDB.
+                        crawl_tasks: list[asyncio.Task] = []
+
+                        # Create progress callback for crawl phase.
+                        #
+                        # `current` is pages successfully fetched; `total` is the discovered
+                        # frontier. We deliberately do NOT emit a percentage or "X remaining"
+                        # for crawling: the frontier is a moving target (it grows as links are
+                        # found) and is inflated by speculative policy-URL probes that mostly
+                        # 404, so any ratio is fiction. Report an honest count and let the UI
+                        # render this step as indeterminate. (The synthesising step, which has a
+                        # real fixed total, keeps its genuine percentage.)
+                        async def _on_crawl_progress(
+                            _phase: str, current: int, _total: int
+                        ) -> None:
+                            pages = "page" if current == 1 else "pages"
+                            # We wrap this in a task so the crawler doesn't block on DB I/O,
+                            # but we keep track of it to await it before phase transitions.
+                            task = asyncio.create_task(
+                                self._update_step_progress(
+                                    db,
+                                    job,
+                                    "crawling",
+                                    message=f"Discovering documents — {current} {pages} read so far",
+                                )
+                            )
+                            crawl_tasks.append(task)
+
+                        pipeline = PolicyDocumentPipeline(
+                            progress_callback=_on_crawl_progress, job_id=job.id
+                        )
+                        stats = await pipeline.run([product])
+
+                        # Drain pending progress tasks before finalizing the crawl step
+                        if crawl_tasks:
+                            await asyncio.gather(*crawl_tasks, return_exceptions=True)
+
+                        # Update the product display name when the crawler found a better one in
+                        # page metadata (e.g. og:site_name "OpenAI" vs domain-derived "Openai").
+                        # Only auto-derived placeholder names are eligible for improvement;
+                        # manually curated ("manual") or already-extracted names are frozen so a
+                        # later crawl can never degrade a good name into a section title like
+                        # "Help Center".
+                        brand_name: str | None = getattr(stats, "brand_name", None)
+                        if _should_override_product_name(
+                            product.name, product.name_source, brand_name
+                        ):
+                            assert (
+                                brand_name is not None
+                            )  # guaranteed by _should_override_product_name
+                            try:
+                                product_svc_upd = create_product_service()
+                                await product_svc_upd.update_product_name(
+                                    db,
+                                    product.id,
+                                    brand_name,
+                                    name_source=NAME_SOURCE_AUTO_EXTRACTED,
+                                )
+                                logger.info(
+                                    "Product name updated: '%s' → '%s' (%s)",
+                                    product.name,
+                                    brand_name,
+                                    job.product_slug,
+                                )
+                                product.name = brand_name
+                                product.name_source = NAME_SOURCE_AUTO_EXTRACTED
+                                job.product_name = brand_name
+                                await self._pipeline_repo.update_fields(
+                                    db, job.id, {"product_name": brand_name}
+                                )
+                            except Exception as name_exc:
+                                logger.warning(
+                                    "Brand name update failed for %s: %s",
+                                    job.product_slug,
+                                    name_exc,
+                                )
+
+                        job.documents_found = stats.total_documents_found
+                        job.documents_stored = stats.policy_documents_stored
+
+                        # Reset attempt-local crawl diagnostics so a retry cannot inherit
+                        # stale errors/skips from a previous failed attempt.
+                        job.crawl_errors = []
+                        job.crawl_skip_reasons = []
+
+                        # Persist per-URL crawl failures on the job
+                        if stats.crawl_errors:
+                            job.crawl_errors = [CrawlError(**err) for err in stats.crawl_errors]
+
+                        # Persist silent skips (fetched OK but rejected by a filter)
+                        if stats.crawl_skip_reasons:
+                            job.crawl_skip_reasons = [
+                                CrawlSkip(**skip) for skip in stats.crawl_skip_reasons
+                            ]
+
+                        await self._update_step(
+                            db,
+                            job,
+                            "crawling",
+                            "completed",
+                            f"Found {stats.policy_documents_stored} policy documents",
+                        )
+
+                        if stats.policy_documents_stored == 0:
+                            # Crawl stored nothing new. Before giving up, check if the
+                            # product already has documents from a previous run. If yes,
+                            # those docs are valid input for synthesis — deduplicated
+                            # re-crawls (same content hash) legitimately store 0 new docs
+                            # but must not skip the overview step.
+                            doc_svc_check = create_document_service()
+                            existing_docs = await doc_svc_check.get_product_documents_by_slug(
+                                db, job.product_slug
+                            )
+                            existing_policy_docs = [
+                                doc for doc in existing_docs if doc.doc_type != "other"
+                            ]
+                            if existing_policy_docs:
+                                logger.info(
+                                    "Crawl stored 0 new docs but %d existing docs found for %s "
+                                    "— proceeding to synthesis",
+                                    len(existing_policy_docs),
+                                    job.product_slug,
+                                )
+                                job.documents_stored = len(existing_policy_docs)
+                            else:
+                                job.status = "no_documents"
+
+                            # Classify the terminal outcome from the crawl's error signals.
+                            # Priority order: robots_blocked > site_unavailable > access_denied
+                            # > no_policy_found (pages fetched, none matched) > fallback errors.
+                            _robots_errs = [
+                                e for e in job.crawl_errors if e.error_type == "robots_txt_blocked"
+                            ]
+                            _non_robots_errs = [
+                                e for e in job.crawl_errors if e.error_type != "robots_txt_blocked"
+                            ]
+                            _conn_errs = [
+                                e
+                                for e in _non_robots_errs
+                                if e.error_type in ("network_error", "timeout")
+                            ]
+                            _hard_errs = [
+                                e
+                                for e in _non_robots_errs
+                                if is_hard_crawl_error(e.error_type, e.status_code, e.error_message)
+                            ]
+
+                            if _robots_errs and not _non_robots_errs:
+                                # All attempted URLs were blocked by robots.txt — deterministic,
+                                # targeted outcome surfaced to the user with dedicated copy.
+                                job.status = "robots_blocked"
+                                job.error = PipelineErrorCode.crawl_robots_blocked
                                 job.error_detail = (
-                                    f"Could not connect to {len(_non_robots_errs)} seed URL(s). "
-                                    "The site may be temporarily down, the domain may have changed, "
-                                    "or a network-level block is in place."
+                                    "This site blocks automated access via robots.txt. "
+                                    "We were unable to crawl any policy documents."
                                 )
-                            elif (
-                                _non_robots_errs
-                                and _hard_errs
-                                and len(_hard_errs) == len(_non_robots_errs)
-                            ):
-                                # All failures are hard HTTP/anti-bot blocks (403/401/429/451 or
-                                # Cloudflare/CAPTCHA) — the site is actively denying access.
-                                job.status = "access_denied"
-                                job.error = PipelineErrorCode.access_denied
-                                job.error_detail = (
-                                    f"Access was denied for {len(_non_robots_errs)} URL(s). "
-                                    "The site is blocking automated access with anti-bot protection, "
-                                    "Cloudflare, or consistent 4xx responses."
-                                )
-                            elif job.crawl_skip_reasons:
-                                # Pages were fetched OK but none passed the policy classifier —
-                                # the site is accessible but has no detectable policy documents.
-                                counts: dict[str, int] = {}
-                                for skip in job.crawl_skip_reasons:
-                                    counts[skip.reason] = counts.get(skip.reason, 0) + 1
-                                breakdown = ", ".join(
-                                    f"{n}× {reason}"
-                                    for reason, n in sorted(counts.items(), key=lambda kv: -kv[1])
-                                )
-                                job.status = "no_policy_found"
-                                job.error = PipelineErrorCode.no_policy_found
-                                job.error_detail = (
-                                    f"{len(job.crawl_skip_reasons)} page(s) fetched but all "
-                                    f"rejected by content filters ({breakdown}). "
-                                    "See crawl_skip_reasons for the per-URL detail."
-                                )
+                            elif job.status == "no_documents":
+                                # Only apply specific new statuses when there are no existing
+                                # docs (job.status was set to "no_documents" in the else branch
+                                # above). For jobs with existing docs we leave the status
+                                # unchanged so the partial-block signal is informational only.
+                                if (
+                                    _non_robots_errs
+                                    and _conn_errs
+                                    and len(_conn_errs) == len(_non_robots_errs)
+                                ):
+                                    # All failures are connection-level (DNS, SSL, timeout, refused)
+                                    # and there are no robots-txt blocks — site is unreachable.
+                                    job.status = "site_unavailable"
+                                    job.error = PipelineErrorCode.site_unavailable
+                                    job.error_detail = (
+                                        f"Could not connect to {len(_non_robots_errs)} seed URL(s). "
+                                        "The site may be temporarily down, the domain may have changed, "
+                                        "or a network-level block is in place."
+                                    )
+                                elif (
+                                    _non_robots_errs
+                                    and _hard_errs
+                                    and len(_hard_errs) == len(_non_robots_errs)
+                                ):
+                                    # All failures are hard HTTP/anti-bot blocks (403/401/429/451 or
+                                    # Cloudflare/CAPTCHA) — the site is actively denying access.
+                                    job.status = "access_denied"
+                                    job.error = PipelineErrorCode.access_denied
+                                    job.error_detail = (
+                                        f"Access was denied for {len(_non_robots_errs)} URL(s). "
+                                        "The site is blocking automated access with anti-bot protection, "
+                                        "Cloudflare, or consistent 4xx responses."
+                                    )
+                                elif job.crawl_skip_reasons:
+                                    # Pages were fetched OK but none passed the policy classifier —
+                                    # the site is accessible but has no detectable policy documents.
+                                    counts: dict[str, int] = {}
+                                    for skip in job.crawl_skip_reasons:
+                                        counts[skip.reason] = counts.get(skip.reason, 0) + 1
+                                    breakdown = ", ".join(
+                                        f"{n}× {reason}"
+                                        for reason, n in sorted(
+                                            counts.items(), key=lambda kv: -kv[1]
+                                        )
+                                    )
+                                    job.status = "no_policy_found"
+                                    job.error = PipelineErrorCode.no_policy_found
+                                    job.error_detail = (
+                                        f"{len(job.crawl_skip_reasons)} page(s) fetched but all "
+                                        f"rejected by content filters ({breakdown}). "
+                                        "See crawl_skip_reasons for the per-URL detail."
+                                    )
+                                elif _robots_errs:
+                                    # Partial robots block mixed with other errors.
+                                    job.error = PipelineErrorCode.crawl_robots_blocked
+                                    job.error_detail = (
+                                        f"Some pages were blocked by robots.txt ({len(_robots_errs)} "
+                                        f"of {len(job.crawl_errors)} failed URLs). "
+                                        "No policy documents could be found."
+                                    )
+                                elif job.crawl_errors:
+                                    job.error = PipelineErrorCode.crawl_failed
+                                    job.error_detail = (
+                                        f"Crawling failed for {len(job.crawl_errors)} URL(s). "
+                                        "No policy documents could be found."
+                                    )
+                                else:
+                                    job.error = PipelineErrorCode.no_documents_found
+                                    job.error_detail = "No policy documents found on this site"
                             elif _robots_errs:
-                                # Partial robots block mixed with other errors.
+                                # Partial robots block on a job that had existing docs —
+                                # informational only, status remains unchanged.
                                 job.error = PipelineErrorCode.crawl_robots_blocked
                                 job.error_detail = (
                                     f"Some pages were blocked by robots.txt ({len(_robots_errs)} "
@@ -640,98 +728,81 @@ class PipelineService:
                             else:
                                 job.error = PipelineErrorCode.no_documents_found
                                 job.error_detail = "No policy documents found on this site"
-                        elif _robots_errs:
-                            # Partial robots block on a job that had existing docs —
-                            # informational only, status remains unchanged.
-                            job.error = PipelineErrorCode.crawl_robots_blocked
-                            job.error_detail = (
-                                f"Some pages were blocked by robots.txt ({len(_robots_errs)} "
-                                f"of {len(job.crawl_errors)} failed URLs). "
-                                "No policy documents could be found."
-                            )
-                        elif job.crawl_errors:
-                            job.error = PipelineErrorCode.crawl_failed
-                            job.error_detail = (
-                                f"Crawling failed for {len(job.crawl_errors)} URL(s). "
-                                "No policy documents could be found."
-                            )
-                        else:
-                            job.error = PipelineErrorCode.no_documents_found
-                            job.error_detail = "No policy documents found on this site"
 
-                        job.completed_at = datetime.now()
-                        await self._update_step(
-                            db,
-                            job,
-                            "synthesising",
-                            "failed",
-                            "Skipped - no documents to analyze",
-                        )
-                        await self._update_step(
-                            db,
-                            job,
-                            "generating_overview",
-                            "failed",
-                            "Skipped - no documents to analyze",
-                        )
-                        await self._pipeline_repo.update(db, job)
+                            job.completed_at = datetime.now()
+                            await self._update_step(
+                                db,
+                                job,
+                                "synthesising",
+                                "failed",
+                                "Skipped - no documents to analyze",
+                            )
+                            await self._update_step(
+                                db,
+                                job,
+                                "generating_overview",
+                                "failed",
+                                "Skipped - no documents to analyze",
+                            )
+                            await self._pipeline_repo.update(db, job)
 
-                        # Remove the product record when the crawl found nothing at all.
-                        # A product with no documents is invisible to users (no analysis,
-                        # no overview) and reappearing in the product list is confusing.
-                        # The pipeline job is kept as a failure record; the product is
-                        # re-created automatically if the user retries the URL later.
-                        if job.status in (
-                            "no_documents",
-                            "robots_blocked",
-                            "access_denied",
-                            "no_policy_found",
-                            "site_unavailable",
-                        ):
+                            # Remove the product record when the crawl found nothing at all.
+                            # A product with no documents is invisible to users (no analysis,
+                            # no overview) and reappearing in the product list is confusing.
+                            # The pipeline job is kept as a failure record; the product is
+                            # re-created automatically if the user retries the URL later.
+                            if job.status in (
+                                "no_documents",
+                                "robots_blocked",
+                                "access_denied",
+                                "no_policy_found",
+                                "site_unavailable",
+                            ):
+                                try:
+                                    doc_count = await db.documents.count_documents(
+                                        {"product_id": product.id}
+                                    )
+                                    if doc_count == 0:
+                                        await db.products.delete_one({"id": product.id})
+                                        logger.info(
+                                            "Removed empty product %s (no policy documents found)",
+                                            job.product_slug,
+                                        )
+                                    else:
+                                        logger.info(
+                                            "Kept product %s despite no_documents — %d existing document(s) present",
+                                            job.product_slug,
+                                            doc_count,
+                                        )
+                                except Exception as del_exc:  # noqa: BLE001
+                                    logger.warning(
+                                        "Failed to remove empty product %s: %s",
+                                        job.product_slug,
+                                        del_exc,
+                                    )
+
+                            # Alert the admin so a human can check whether this is a
+                            # crawler coverage gap or the site genuinely has no policy
+                            # documents. Best-effort — never fail the job on email error.
                             try:
-                                doc_count = await db.documents.count_documents(
-                                    {"product_id": product.id}
+                                from src.services.email_service import get_email_service
+
+                                await get_email_service().send_no_documents_alert(
+                                    product_name=product.name,
+                                    product_slug=job.product_slug,
+                                    url=job.url,
+                                    reason=job.error_detail
+                                    or "No policy documents found on this site",
+                                    crawl_error_count=len(job.crawl_errors),
+                                    skip_count=len(job.crawl_skip_reasons),
                                 )
-                                if doc_count == 0:
-                                    await db.products.delete_one({"id": product.id})
-                                    logger.info(
-                                        "Removed empty product %s (no policy documents found)",
-                                        job.product_slug,
-                                    )
-                                else:
-                                    logger.info(
-                                        "Kept product %s despite no_documents — %d existing document(s) present",
-                                        job.product_slug,
-                                        doc_count,
-                                    )
-                            except Exception as del_exc:  # noqa: BLE001
+                            except Exception as alert_exc:  # noqa: BLE001
                                 logger.warning(
-                                    "Failed to remove empty product %s: %s",
-                                    job.product_slug,
-                                    del_exc,
+                                    "no-documents admin alert failed",
+                                    product_slug=job.product_slug,
+                                    error=str(alert_exc),
                                 )
-
-                        # Alert the admin so a human can check whether this is a
-                        # crawler coverage gap or the site genuinely has no policy
-                        # documents. Best-effort — never fail the job on email error.
-                        try:
-                            from src.services.email_service import get_email_service
-
-                            await get_email_service().send_no_documents_alert(
-                                product_name=product.name,
-                                product_slug=job.product_slug,
-                                url=job.url,
-                                reason=job.error_detail or "No policy documents found on this site",
-                                crawl_error_count=len(job.crawl_errors),
-                                skip_count=len(job.crawl_skip_reasons),
-                            )
-                        except Exception as alert_exc:  # noqa: BLE001
-                            logger.warning(
-                                "no-documents admin alert failed",
-                                product_slug=job.product_slug,
-                                error=str(alert_exc),
-                            )
-                        return
+                            return
 
                     # === Step 2: Summarize ===
                     job.status = "synthesising"

--- a/packages/backend/tests/unit/pipeline_service_test.py
+++ b/packages/backend/tests/unit/pipeline_service_test.py
@@ -194,6 +194,77 @@ async def test_run_pipeline_zero_documents_marks_no_documents_not_failed(mock_db
 
 
 @pytest.mark.asyncio
+async def test_run_pipeline_skip_crawl_never_runs_crawler(mock_db):
+    """Analysis-only jobs reuse stored documents and must not invoke the crawler."""
+    job = PipelineJob(
+        id="job-skip-crawl",
+        product_slug="test-product",
+        product_name="Test Product",
+        url="https://test.com",
+        status="pending",
+        skip_crawl=True,
+        force_reanalyze=True,
+    )
+
+    repo = MagicMock(spec=PipelineRepository)
+    repo.find_by_id = AsyncMock(return_value=job)
+    repo.update = AsyncMock()
+    repo.update_fields = AsyncMock()
+    service = PipelineService(pipeline_repo=repo)
+
+    product = SimpleNamespace(
+        id="test-product-id", slug="test-product", name="Test Product", name_source=None
+    )
+    product_svc = MagicMock()
+    product_svc.get_product_by_slug = AsyncMock(return_value=product)
+    product_svc.get_product_overview_data = AsyncMock(return_value={"overview": {"summary": "ok"}})
+    product_svc.save_product_explainer = AsyncMock(return_value=True)
+    product_svc.save_product_compliance = AsyncMock(return_value=True)
+
+    existing_doc = SimpleNamespace(id="doc-1", doc_type="privacy_policy", analysis=object())
+    doc_svc = MagicMock()
+    doc_svc.get_product_documents_by_slug = AsyncMock(return_value=[existing_doc])
+
+    fake_pipeline = MagicMock()
+    fake_pipeline.run = AsyncMock()
+
+    analyse_mock = AsyncMock(
+        return_value=AnalysisResult(documents=[existing_doc], analyses_skipped=0)  # ty: ignore[invalid-argument-type]
+    )
+    overview_mock = AsyncMock(return_value=SimpleNamespace(grade="C"))
+
+    @asynccontextmanager
+    async def fake_db_session():
+        yield mock_db
+
+    with (
+        patch("src.services.pipeline_service.db_session", fake_db_session),
+        patch("src.services.pipeline_service.create_product_service", return_value=product_svc),
+        patch("src.services.pipeline_service.create_document_service", return_value=doc_svc),
+        patch("src.services.pipeline_service.PolicyDocumentPipeline", return_value=fake_pipeline),
+        patch("src.services.pipeline_service.analyse_product_documents", analyse_mock),
+        patch("src.services.pipeline_service.generate_product_overview", overview_mock),
+        patch(
+            "src.services.pipeline_service.generate_product_consumer_explainer",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "src.services.pipeline_service.generate_product_compliance",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await service.run_pipeline("job-skip-crawl")
+
+    fake_pipeline.run.assert_not_called()
+    assert job.documents_stored == 1
+    assert job.steps[0].status == "completed"
+    assert "Skipped crawl" in (job.steps[0].message or "")
+    analyse_mock.assert_awaited_once()
+    assert analyse_mock.await_args.kwargs.get("force_reanalyze") is True
+    assert job.status == "completed"
+
+
+@pytest.mark.asyncio
 async def test_run_pipeline_all_documents_fail_analysis_is_truthful(mock_db):
     """Crawl succeeds but every document fails analysis.
 


### PR DESCRIPTION
## What this PR does

Adds a way to re-run **document analysis and overview generation** on products that already have crawled policy documents, **without hitting the crawler again**. Pipeline jobs can set `skip_crawl=True` (with `force_reanalyze=True`) so workers reuse stored docs, mark the crawl step complete, and go straight to synthesising + overview.

Includes `scripts/requeue_analysis.py` to bulk-enqueue these jobs against production or local MongoDB.

## Why

After overview/stance pipeline changes (e.g. #197), we need to regenerate analyses on existing products. Full pipeline re-runs waste crawler capacity and can re-hit anti-bot walls. Analysis-only requeue is faster, cheaper, and safer for already-indexed products.

## How pipeline behaviour changes

| Path | Change |
|---|---|
| Normal pipeline job (`skip_crawl=False`) | No change — crawl → synthesise → overview |
| Analysis-only job (`skip_crawl=True`) | Skips `PolicyDocumentPipeline`; counts existing non-`other` docs; runs synthesise + overview with `force_reanalyze=True` |
| Job with `skip_crawl=True` but no stored docs | Fails early with `no_documents_found` — does not crawl |

## Tests

- `test_run_pipeline_skip_crawl_never_runs_crawler` — asserts crawler is never invoked, crawl step completes with skip message, and analysis runs with `force_reanalyze=True`
- Existing `pipeline_service_test.py` suite passes (10 tests)

### Edge cases to verify in staging

1. `uv run python scripts/requeue_analysis.py --dry-run tiktok` — lists doc count, no enqueue
2. Enqueue one slug, watch worker logs — crawl step should complete instantly with "Skipped crawl — reusing N existing document(s)"
3. Product with zero policy docs — job should fail without crawling
4. Product with an active pipeline job — script should skip (no duplicate active jobs)

## Usage after merge

Deploy the **crawler** worker service, then:

```bash
cd packages/backend
uv run python scripts/requeue_analysis.py --production --dry-run
uv run python scripts/requeue_analysis.py --production
# or specific slugs:
uv run python scripts/requeue_analysis.py --production tiktok capcut
```