### PR TITLE
feat(pipeline): prioritize analysis-only jobs and add requeue_crawl script

### DIFF
--- a/packages/backend/scripts/requeue_crawl.py
+++ b/packages/backend/scripts/requeue_crawl.py
@@ -1,0 +1,130 @@
+"""Queue full crawl+analysis pipeline jobs (runs after analysis-only backlog).
+
+Creates pending pipeline jobs with skip_crawl=False and force_reanalyze=True.
+Skips products that already have an active job (including analysis-only requeues).
+
+Run after analysis-only jobs complete, or alongside them — the worker claims
+skip_crawl jobs first, so full crawls wait until the analysis backlog drains.
+
+Usage:
+    uv run python scripts/requeue_crawl.py --production --dry-run
+    uv run python scripts/requeue_crawl.py --production
+    uv run python scripts/requeue_crawl.py --production tiktok
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def _resolve_production(use_production: bool) -> None:
+    if not use_production:
+        return
+    prod_uri = os.getenv("PRODUCTION_MONGO_URI")
+    if not prod_uri:
+        print("ERROR: PRODUCTION_MONGO_URI not set")
+        sys.exit(1)
+    os.environ["MONGO_URI"] = prod_uri
+
+
+def _job_url(product) -> str:
+    if product.crawl_base_urls:
+        return product.crawl_base_urls[0]
+    if product.domains:
+        return f"https://{product.domains[0]}"
+    return f"https://clausea.co/products/{product.slug}"
+
+
+async def main(
+    slugs: list[str] | None,
+    *,
+    dry_run: bool,
+    use_production: bool,
+) -> None:
+    _resolve_production(use_production)
+    if use_production:
+        print("Using PRODUCTION_MONGO_URI")
+
+    from src.core.database import db_session
+    from src.core.logging import setup_logging
+    from src.models.pipeline_job import PipelineJob
+    from src.repositories.pipeline_repository import PipelineRepository
+    from src.services.service_factory import create_product_service
+
+    setup_logging()
+    product_svc = create_product_service()
+    pipeline_repo = PipelineRepository()
+
+    async with db_session() as db:
+        if slugs:
+            target_slugs = slugs
+        else:
+            rows = await db.products.find({}, {"slug": 1}).to_list(length=None)
+            target_slugs = sorted(row["slug"] for row in rows if row.get("slug"))
+
+        queued = 0
+        skipped_active = 0
+        skipped_analysis_pending = 0
+        skipped_missing = 0
+
+        print(f"Evaluating {len(target_slugs)} product(s)...")
+        for slug in target_slugs:
+            product = await product_svc.get_product_by_slug(db, slug)
+            if not product:
+                skipped_missing += 1
+                print(f"  [missing] {slug}")
+                continue
+
+            active = await pipeline_repo.find_active_by_product_slug(db, slug)
+            if active:
+                if active.skip_crawl and active.status == "pending":
+                    skipped_analysis_pending += 1
+                    print(f"  [analysis] {slug} (job {active.id} — waiting for analysis-only)")
+                else:
+                    skipped_active += 1
+                    print(f"  [active]  {slug} (job {active.id}, status={active.status})")
+                continue
+
+            if dry_run:
+                print(f"  [dry-run] {slug}")
+                queued += 1
+                continue
+
+            job = PipelineJob(
+                product_slug=slug,
+                product_id=product.id,
+                product_name=product.name,
+                url=_job_url(product),
+                skip_crawl=False,
+                force_reanalyze=True,
+            )
+            stored_job, created = await pipeline_repo.find_or_create_active(db, job)
+            if created:
+                queued += 1
+                print(f"  [queued]  {slug} job={stored_job.id}")
+            else:
+                skipped_active += 1
+                print(f"  [active]  {slug} (job {stored_job.id}, status={stored_job.status})")
+
+        print()
+        print(
+            f"Done: queued={queued}, skipped_active={skipped_active}, "
+            f"skipped_analysis_pending={skipped_analysis_pending}, "
+            f"skipped_missing={skipped_missing}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Queue full crawl+analysis pipeline jobs")
+    parser.add_argument("slugs", nargs="*", help="Product slugs (default: all products)")
+    parser.add_argument("--dry-run", action="store_true", help="List targets without enqueueing")
+    parser.add_argument("--production", action="store_true", help="Use PRODUCTION_MONGO_URI")
+    args = parser.parse_args()
+    asyncio.run(main(args.slugs or None, dry_run=args.dry_run, use_production=args.production))

--- a/packages/backend/src/repositories/pipeline_repository.py
+++ b/packages/backend/src/repositories/pipeline_repository.py
@@ -208,6 +208,10 @@ class PipelineRepository(BaseRepository):
         Flips status pending -> crawling in one step so two workers (or concurrent claim
         loops) never pick up the same job. Returns the claimed job, or None if none pending.
 
+        Jobs with ``skip_crawl=True`` (analysis-only requeues) are claimed before full
+        crawl+analysis jobs so stored documents can be re-analyzed without waiting behind
+        a long crawl backlog.
+
         Before claiming, checks the domain circuit breaker: if the job's accumulated hard
         failure count (bot detection, 403s, persistent access blocks) has reached
         DOMAIN_CIRCUIT_BREAKER_THRESHOLD, the job is marked as failed with
@@ -217,9 +221,10 @@ class PipelineRepository(BaseRepository):
         # Peek at the next candidate without claiming, so we can check the circuit
         # breaker first.  Uses the same sort as the eventual claim so we always inspect
         # the job that *would* be claimed.
+        # Analysis-only jobs (skip_crawl) drain before full crawl+analysis backlogs.
         candidate: dict[str, Any] | None = await db[self.COLLECTION].find_one(
             {"status": "pending"},
-            sort=[("created_at", 1)],
+            sort=[("skip_crawl", -1), ("created_at", 1)],
         )
         if not candidate:
             return None

--- a/packages/backend/tests/unit/pipeline_domain_circuit_breaker_test.py
+++ b/packages/backend/tests/unit/pipeline_domain_circuit_breaker_test.py
@@ -232,6 +232,35 @@ async def test_claim_returns_none_when_no_pending_jobs(monkeypatch: pytest.Monke
     collection.update_one.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_claim_prefers_skip_crawl_pending_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr, "DOMAIN_CIRCUIT_BREAKER_THRESHOLD", 5)
+
+    pending = {
+        "id": "job-analysis",
+        "product_slug": "tiktok",
+        "product_name": "TikTok",
+        "url": "https://tiktok.com",
+        "skip_crawl": True,
+        "accumulated_hard_failure_count": 0,
+        "status": "pending",
+        "created_at": "2024-01-02T00:00:00",
+    }
+    claimed = {**pending, "status": "crawling", "attempts": 1}
+
+    db = _make_db_for_claim(pending_doc=pending, find_and_update_result=claimed)
+    collection = db[PipelineRepository.COLLECTION]
+
+    job = await PipelineRepository().claim_next_pending_job(db)
+
+    assert job is not None
+    assert job.skip_crawl is True
+    collection.find_one.assert_awaited_once_with(
+        {"status": "pending"},
+        sort=[("skip_crawl", -1), ("created_at", 1)],
+    )
+
+
 # ---------------------------------------------------------------------------
 # requeue_failed_jobs: hard failure accumulation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this PR does

Pipeline workers now **claim analysis-only jobs (`skip_crawl=True`) before full crawl+analysis backlogs**, so document re-analysis and overview regen is not blocked behind long-running crawls.

Adds `scripts/requeue_crawl.py` to bulk-enqueue **full crawl+analysis** jobs for products that do not already have an active job (including those waiting on an analysis-only requeue).

## Why

After #199 we queued ~100 analysis-only regen jobs, but workers were saturated by legacy full-crawl jobs. Without claim priority, pending full crawls could still win the queue on `created_at` alone. This makes the intended two-phase rollout explicit in worker behaviour:

1. Drain analysis-only backlog first
2. Then process full crawl jobs (via `requeue_crawl.py`)

## How pipeline behaviour changes

| Path | Change |
|---|---|
| `claim_next_pending_job` | Sorts pending jobs by `skip_crawl` descending, then `created_at` ascending |
| Normal full-crawl jobs | Unchanged once claimed — still crawl → synthesise → overview |
| Analysis-only jobs (`skip_crawl=True`) | Claimed before any pending full-crawl job, regardless of age |
| `requeue_crawl.py` | Queues `skip_crawl=False` jobs; skips products with any active job; labels analysis-only blockers explicitly |

## Tests

- `test_claim_prefers_skip_crawl_pending_jobs` — asserts claim query uses `[("skip_crawl", -1), ("created_at", 1)]`
- Full `pipeline_domain_circuit_breaker_test.py` suite passes (24 tests)

### Edge cases to verify after merge

1. Deploy **crawler** worker, then confirm pending `skip_crawl=True` jobs move to `synthesising` while full-crawl jobs remain pending
2. `uv run python scripts/requeue_crawl.py --production --dry-run` — products with active analysis-only jobs show `[analysis]`, not `[queued]`
3. After analysis-only backlog drains, run `requeue_crawl.py --production` again to queue full crawls for the remaining catalog
4. Product with concurrent active job — `find_or_create_active` skips without `DuplicateKeyError`

## Usage

```bash
cd packages/backend

# Queue full crawl+analysis (skips products blocked by analysis-only jobs)
uv run python scripts/requeue_crawl.py --production --dry-run
uv run python scripts/requeue_crawl.py --production
```