### PR TITLE
fix(railway): service-relative watchPatterns for CLI deploys

### DIFF
--- a/packages/backend/docs/RAILWAY.md
+++ b/packages/backend/docs/RAILWAY.md
@@ -42,7 +42,7 @@ Only one `railway.toml` can live at the service root (`packages/backend`). **Eve
 | Start command  | *(empty — image CMD binds `${PORT}` via shell)* |
 | Health check   | `/health`                                       |
 
-`railway.toml` sets `watchPatterns = ["packages/backend/**"]` so monorepo pushes only redeploy when backend files change.
+`railway.toml` sets `watchPatterns = ["**"]` relative to the service root (`packages/backend`) so pushes redeploy when backend files change. Do not use `packages/backend/**` here — that breaks local `railway up` deploys where the snapshot root is already `packages/backend`.
 
 ### 2. Worker service
 

--- a/packages/backend/railway.toml
+++ b/packages/backend/railway.toml
@@ -6,7 +6,7 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
-watchPatterns = ["packages/backend/**"]
+watchPatterns = ["**"]
 
 [deploy]
 # Do not set startCommand here — Railway passes it to uvicorn without shell

--- a/packages/frontend/railway.toml
+++ b/packages/frontend/railway.toml
@@ -1,7 +1,7 @@
 [build]
 builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
-watchPatterns = ["packages/frontend/**"]
+watchPatterns = ["**"]
 
 [deploy]
 healthcheckPath = "/"


### PR DESCRIPTION
## What this PR does

Fixes Railway build failures caused by `watchPatterns` referencing `packages/backend/**` and `packages/frontend/**` when the service root directory is already set to those paths.

Changes `watchPatterns` to `["**"]` in both service configs and documents the constraint in `docs/RAILWAY.md`.

## Why

Local `railway up` uploads a snapshot rooted at the service directory. With `watchPatterns = ["packages/backend/**"]`, the builder looks for `packages/backend` inside that snapshot and fails:

```
Build Failed: lstat .../snapshot-target-unpack/packages: no such file or directory
```

This caused crawler, API, and frontend to show **Failed** until redeploying from GitHub source.

## How deploy behaviour changes

| Deploy path | Before | After |
|---|---|---|
| GitHub push (root = `packages/backend`) | Usually worked | Works — watches all files under service root |
| Local `railway up` from `packages/backend` | **Build failed** | Works |
| Monorepo change outside service root | No redeploy | No redeploy (unchanged) |

## Tests

- No code changes — config + docs only
- Verified fix by redeploying crawler/api/frontend with `railway redeploy --from-source` after identifying root cause

### Edge cases to verify after merge

1. Push a change under `packages/backend/` — backend + worker services should redeploy
2. Push a change under `packages/frontend/` only — frontend redeploys, backend does not
3. `cd packages/backend && railway up --service crawler` — build succeeds (no `packages/` path error)

## Notes for reviewers

- GitHub Actions workflows still use `packages/backend/**` path filters — those are correct at repo root and unchanged
- Prefer `railway redeploy --from-source` over bare `railway redeploy` when recovering from failed CLI uploads