### PR TITLE
feat(analyser): balanced risk reconciliation and danger floors

### DIFF
--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -10,10 +10,10 @@ is reliable at categories and comparisons, not at absolute 0-10 scores.
 
 Per-document flow
 -----------------
-1. ``extract_document_facts()`` — structured, evidence-backed facts (chunked,
-   parallel). Neutral; carries no judgment.
+1. ``extract_document_facts()`` — structured, evidence-backed facts (adaptive
+   section chunks, parallel). Neutral; carries no judgment.
 2. ``analyse_document()`` — one LLM call turns the extracted facts into a deep
-   analysis: per-dimension letter grades (A–E) with justifications, key points,
+   analysis: per-dimension letter grades (A-E) with justifications, key points,
    and risk clauses. Grades are letters, not fabricated scores.
 
 Product-overview flow (powers the cached JSON on ``/products/{slug}``)
@@ -411,17 +411,6 @@ def _calculate_overview_risk_score(scores: MetaSummaryScores) -> int | None:
 
 _SEVERE_TOPIC_STANCES = frozenset({"harmful", "concerning", "conflicting"})
 _MANY_SEVERE_STANCES_THRESHOLD = 5
-_INDEFINITE_RETENTION_RE = re.compile(
-    r"indefinite(?:ly)?|forever|permanent(?:ly)?(?:\s+retain|\s+storage)?|"
-    r"retained permanently|keep(?:s)?\s+(?:messages|data|content)\s+indefinitely",
-    re.IGNORECASE,
-)
-_AI_TRAINING_RE = re.compile(
-    r"\b(?:ai|machine learning|ml)\s+(?:training|train(?:ing|s)?)\b|"
-    r"\btrain(?:s|ing)?\s+(?:ai|ml|machine learning|models?)\s+on\b|"
-    r"\buses?\s+(?:your|user)\s+(?:content|data|messages)\s+to\s+train\b",
-    re.IGNORECASE,
-)
 
 
 def _topic_risk_from_stances(stances: list[TopicStanceBreakdown] | None) -> int | None:
@@ -443,16 +432,24 @@ def _severe_stance_count(stances: list[TopicStanceBreakdown] | None) -> int:
     )
 
 
-def _danger_risk_floor(dangers: list[str] | None) -> int:
-    """Minimum risk score implied by material danger strings."""
-    if not dangers:
+def _topic_specific_floors(stances: list[TopicStanceBreakdown] | None) -> int:
+    """Minimum risk score implied by specific severe topic stances.
+
+    Replaces fragile regex-based danger detection with context-aware topic stances
+    derived from LLM-extracted facts.
+    """
+    if not stances:
         return 0
-    text = " ".join(dangers)
     floor = 0
-    if _INDEFINITE_RETENTION_RE.search(text):
-        floor = max(floor, 7)
-    if _AI_TRAINING_RE.search(text):
-        floor = max(floor, 6)
+    for stance in stances:
+        if stance.status != "found":
+            continue
+        # Indefinite retention is a material D-level risk (7).
+        if stance.topic == "retention" and stance.stance == "harmful":
+            floor = max(floor, 7)
+        # AI training on user data is a material C-level risk (6).
+        if stance.topic == "ai_training" and stance.stance == "harmful":
+            floor = max(floor, 6)
     return floor
 
 
@@ -465,7 +462,7 @@ def _reconcile_meta_summary_risk(meta_summary: MetaSummary) -> None:
     1. Clamp the holistic LLM grade to within one letter of the evidence-backed
        dimension grade to counter systematic bias.
     2. Take the worst (highest) risk among dimensions, topics, and clamped LLM.
-    3. Apply material floors for specific dangers (retention, AI training).
+    3. Apply material floors for specific severe topics (retention, AI training).
     4. Apply positive adjustments for documented protections and fair stances.
     """
     llm_grade = coerce_grade(meta_summary.grade) if meta_summary.grade else None
@@ -501,10 +498,10 @@ def _reconcile_meta_summary_risk(meta_summary: MetaSummary) -> None:
         if _severe_stance_count(meta_summary.topic_stances) >= _MANY_SEVERE_STANCES_THRESHOLD:
             risk_candidates.append(6)
 
-    # 3. Apply danger floors from raw text findings.
-    danger_floor = _danger_risk_floor(meta_summary.dangers)
-    if danger_floor:
-        risk_candidates.append(danger_floor)
+    # 3. Apply floors from context-aware topic stances.
+    topic_floor = _topic_specific_floors(meta_summary.topic_stances)
+    if topic_floor:
+        risk_candidates.append(topic_floor)
 
     if not risk_candidates:
         meta_summary.risk_score = None
@@ -522,12 +519,12 @@ def _reconcile_meta_summary_risk(meta_summary: MetaSummary) -> None:
     if llm_grade and final_grade != llm_grade:
         logger.info(
             "Reconciled overview grade from LLM %s to %s "
-            "(dimensions=%s topic_risk=%s danger_floor=%s blended_risk=%s)",
+            "(dimensions=%s topic_risk=%s topic_floor=%s blended_risk=%s)",
             llm_grade,
             final_grade,
             derived_grade,
             topic_risk,
-            danger_floor or None,
+            topic_floor or None,
             blended_risk,
         )
 

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -413,12 +413,38 @@ _SEVERE_TOPIC_STANCES = frozenset({"harmful", "concerning", "conflicting"})
 _MANY_SEVERE_STANCES_THRESHOLD = 5
 
 
+_STANCE_WORST_WINS: dict[str, int] = {
+    "fair": 0,
+    "concerning": 1,
+    "conflicting": 2,
+    "harmful": 3,
+}
+
+
+def _worst_stance(a: str, b: str) -> str:
+    return a if _STANCE_WORST_WINS.get(a, -1) >= _STANCE_WORST_WINS.get(b, -1) else b
+
+
 def _topic_risk_from_stances(stances: list[TopicStanceBreakdown] | None) -> int | None:
     if not stances:
         return None
-    topic_rows: dict[InsightCategory, dict[str, Any]] = {
-        stance.topic: {"status": stance.status, "stance": stance.stance} for stance in stances
-    }
+    topic_rows: dict[InsightCategory, dict[str, Any]] = {}
+    for stance in stances:
+        row = {"status": stance.status, "stance": stance.stance}
+        existing = topic_rows.get(stance.topic)
+        if existing is None:
+            topic_rows[stance.topic] = row
+            continue
+        logger.warning(
+            "Duplicate topic stance for %s (%s -> %s); keeping worst",
+            stance.topic,
+            existing["stance"],
+            stance.stance,
+        )
+        topic_rows[stance.topic] = {
+            "status": "found" if "found" in {existing["status"], stance.status} else stance.status,
+            "stance": _worst_stance(str(existing["stance"]), str(stance.stance)),
+        }
     return compose_product_risk_from_topics(topic_rows)
 
 
@@ -463,7 +489,7 @@ def _reconcile_meta_summary_risk(meta_summary: MetaSummary) -> None:
        dimension grade to counter systematic bias.
     2. Take the worst (highest) risk among dimensions, topics, and clamped LLM.
     3. Apply material floors for specific severe topics (retention, AI training).
-    4. Apply positive adjustments for documented protections and fair stances.
+    4. Apply positive adjustments for documented protections, then re-assert floors.
     """
     llm_grade = coerce_grade(meta_summary.grade) if meta_summary.grade else None
     derived_grade = aggregate_dimension_grades(
@@ -494,24 +520,28 @@ def _reconcile_meta_summary_risk(meta_summary: MetaSummary) -> None:
     topic_risk = _topic_risk_from_stances(meta_summary.topic_stances)
     if topic_risk is not None:
         risk_candidates.append(topic_risk)
-        # Floor for many severe stances (C or worse if many concerns found).
-        if _severe_stance_count(meta_summary.topic_stances) >= _MANY_SEVERE_STANCES_THRESHOLD:
-            risk_candidates.append(6)
 
-    # 3. Apply floors from context-aware topic stances.
+    # 3. Compute hard floors (re-applied after positive adjustments).
     topic_floor = _topic_specific_floors(meta_summary.topic_stances)
-    if topic_floor:
-        risk_candidates.append(topic_floor)
+    severe_stance_floor = (
+        6
+        if _severe_stance_count(meta_summary.topic_stances) >= _MANY_SEVERE_STANCES_THRESHOLD
+        else 0
+    )
 
-    if not risk_candidates:
+    if not risk_candidates and not topic_floor and not severe_stance_floor:
         meta_summary.risk_score = None
         meta_summary.verdict = None
         meta_summary.grade = None
         return
 
-    # 4. Blend and adjust.
-    blended_risk = max(risk_candidates)
+    # 4. Blend soft signals, then re-assert hard floors.
+    blended_risk = max(risk_candidates) if risk_candidates else 0
     blended_risk = _apply_positive_risk_adjustment(blended_risk, meta_summary)
+    if topic_floor:
+        blended_risk = max(blended_risk, topic_floor)
+    if severe_stance_floor:
+        blended_risk = max(blended_risk, severe_stance_floor)
     blended_risk = _apply_signal_floors(blended_risk, meta_summary.privacy_signals)
 
     final_grade = risk_score_to_grade(blended_risk)

--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -112,6 +112,7 @@ from src.utils.grading import (
     coerce_grade,
     grade_to_risk_score,
     grade_to_verdict,
+    risk_score_to_grade,
 )
 from src.utils.llm_usage import UsageTracker, log_usage_summary, usage_tracking
 from src.utils.topic_copy import recommended_action_for, why_it_matters_for
@@ -408,14 +409,64 @@ def _calculate_overview_risk_score(scores: MetaSummaryScores) -> int | None:
     )
 
 
+_SEVERE_TOPIC_STANCES = frozenset({"harmful", "concerning", "conflicting"})
+_MANY_SEVERE_STANCES_THRESHOLD = 5
+_INDEFINITE_RETENTION_RE = re.compile(
+    r"indefinite(?:ly)?|forever|permanent(?:ly)?(?:\s+retain|\s+storage)?|"
+    r"retained permanently|keep(?:s)?\s+(?:messages|data|content)\s+indefinitely",
+    re.IGNORECASE,
+)
+_AI_TRAINING_RE = re.compile(
+    r"\b(?:ai|machine learning|ml)\s+(?:training|train(?:ing|s)?)\b|"
+    r"\btrain(?:s|ing)?\s+(?:ai|ml|machine learning|models?)\s+on\b|"
+    r"\buses?\s+(?:your|user)\s+(?:content|data|messages)\s+to\s+train\b",
+    re.IGNORECASE,
+)
+
+
+def _topic_risk_from_stances(stances: list[TopicStanceBreakdown] | None) -> int | None:
+    if not stances:
+        return None
+    topic_rows: dict[InsightCategory, dict[str, Any]] = {
+        stance.topic: {"status": stance.status, "stance": stance.stance} for stance in stances
+    }
+    return compose_product_risk_from_topics(topic_rows)
+
+
+def _severe_stance_count(stances: list[TopicStanceBreakdown] | None) -> int:
+    if not stances:
+        return 0
+    return sum(
+        1
+        for stance in stances
+        if stance.status == "found" and stance.stance in _SEVERE_TOPIC_STANCES
+    )
+
+
+def _danger_risk_floor(dangers: list[str] | None) -> int:
+    """Minimum risk score implied by material danger strings."""
+    if not dangers:
+        return 0
+    text = " ".join(dangers)
+    floor = 0
+    if _INDEFINITE_RETENTION_RE.search(text):
+        floor = max(floor, 7)
+    if _AI_TRAINING_RE.search(text):
+        floor = max(floor, 6)
+    return floor
+
+
 def _reconcile_meta_summary_risk(meta_summary: MetaSummary) -> None:
     """Set headline grade, verdict, and deprecated risk_score from evidence.
 
-    The LLM overall grade is clamped to within one letter of the
-    dimension-derived grade to counter the LLM's systematic negativity bias
-    (44/45 disagreements with dimensions were more negative in production).
-    Verdict is derived directly from the final grade so they can never
-    contradict each other on the card.
+    Blends dimension grades, topic stance rollup, danger floors, privacy signal
+    floors, and the LLM overall grade. To ensure the "truest representation"
+    (not too harsh or too soft), we:
+    1. Clamp the holistic LLM grade to within one letter of the evidence-backed
+       dimension grade to counter systematic bias.
+    2. Take the worst (highest) risk among dimensions, topics, and clamped LLM.
+    3. Apply material floors for specific dangers (retention, AI training).
+    4. Apply positive adjustments for documented protections and fair stances.
     """
     llm_grade = coerce_grade(meta_summary.grade) if meta_summary.grade else None
     derived_grade = aggregate_dimension_grades(
@@ -430,23 +481,55 @@ def _reconcile_meta_summary_risk(meta_summary: MetaSummary) -> None:
         }
     )
 
+    # 1. Counter LLM bias by clamping to dimensions ±1.
     if llm_grade and derived_grade:
-        final_grade = clamp_grade(llm_grade, derived_grade, max_delta=1)
-        if final_grade != llm_grade:
-            logger.info(
-                "Clamped overview grade from LLM %s to %s (dimension-derived: %s)",
-                llm_grade,
-                final_grade,
-                derived_grade,
-            )
+        clamped_llm_grade = clamp_grade(llm_grade, derived_grade, max_delta=1)
     else:
-        final_grade = llm_grade or derived_grade
+        clamped_llm_grade = llm_grade
 
-    if final_grade is None:
+    risk_candidates: list[int] = []
+    if derived_grade:
+        risk_candidates.append(grade_to_risk_score(derived_grade))
+    if clamped_llm_grade:
+        risk_candidates.append(grade_to_risk_score(clamped_llm_grade))
+
+    # 2. Incorporate topic-level rollup.
+    topic_risk = _topic_risk_from_stances(meta_summary.topic_stances)
+    if topic_risk is not None:
+        risk_candidates.append(topic_risk)
+        # Floor for many severe stances (C or worse if many concerns found).
+        if _severe_stance_count(meta_summary.topic_stances) >= _MANY_SEVERE_STANCES_THRESHOLD:
+            risk_candidates.append(6)
+
+    # 3. Apply danger floors from raw text findings.
+    danger_floor = _danger_risk_floor(meta_summary.dangers)
+    if danger_floor:
+        risk_candidates.append(danger_floor)
+
+    if not risk_candidates:
         meta_summary.risk_score = None
         meta_summary.verdict = None
         meta_summary.grade = None
         return
+
+    # 4. Blend and adjust.
+    blended_risk = max(risk_candidates)
+    blended_risk = _apply_positive_risk_adjustment(blended_risk, meta_summary)
+    blended_risk = _apply_signal_floors(blended_risk, meta_summary.privacy_signals)
+
+    final_grade = risk_score_to_grade(blended_risk)
+
+    if llm_grade and final_grade != llm_grade:
+        logger.info(
+            "Reconciled overview grade from LLM %s to %s "
+            "(dimensions=%s topic_risk=%s danger_floor=%s blended_risk=%s)",
+            llm_grade,
+            final_grade,
+            derived_grade,
+            topic_risk,
+            danger_floor or None,
+            blended_risk,
+        )
 
     meta_summary.grade = final_grade
     meta_summary.verdict = grade_to_verdict(final_grade)

--- a/packages/backend/src/constants.py
+++ b/packages/backend/src/constants.py
@@ -2,7 +2,7 @@ from src.models.user import UserTier
 
 # Monthly limits per tier (analyses per month)
 TIER_LIMITS = {
-    UserTier.FREE: 3,  # 3 analyses per month
+    UserTier.FREE: 15,  # 15 analyses per month
     UserTier.PRO: 999999,  # Effectively unlimited
 }
 

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -225,8 +225,11 @@ async def _completion_with_fallback_impl(
         logger.debug("Attempting completion with model: %s (%s)", model_name, model.model)
 
         call_kwargs = kwargs.copy()
-        if reasoning_effort:
-            call_kwargs["reasoning_effort"] = reasoning_effort
+        # All OpenRouter models in MODEL_PRIORITY support reasoning; default medium
+        # when the caller does not specify an effort level.
+        effort = reasoning_effort or ("medium" if model_name.startswith("openrouter/") else None)
+        if effort and "reasoning_effort" not in call_kwargs:
+            call_kwargs["reasoning_effort"] = effort
 
         try:
             start_time = time.time()

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -225,9 +225,7 @@ async def _completion_with_fallback_impl(
         logger.debug("Attempting completion with model: %s (%s)", model_name, model.model)
 
         call_kwargs = kwargs.copy()
-        if model_name.startswith("openrouter/") and "reasoning_effort" not in call_kwargs:
-            call_kwargs["reasoning_effort"] = reasoning_effort or "medium"
-        elif reasoning_effort:
+        if reasoning_effort:
             call_kwargs["reasoning_effort"] = reasoning_effort
 
         try:

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -115,15 +115,18 @@ class Model:
 
 SupportedModel = str
 
+# Smallest context in this cascade: gemma-4-31b-it (262K). gpt-oss-120b (131K) was
+# removed — it blocked whole-document extraction and adaptive chunk sizing.
 MODEL_PRIORITY: list[SupportedModel] = [
     "openrouter/openrouter/owl-alpha",
-    "openrouter/openai/gpt-oss-120b:free",
     "openrouter/google/gemma-4-31b-it:free",
-    "openrouter/openai/gpt-oss-120b",
     "openrouter/deepseek/deepseek-v4-flash",
     "openrouter/qwen/qwen3.5-flash-02-23",
     "openrouter/google/gemini-2.5-flash-lite",
 ]
+
+# Conservative input budget for extraction (tokens). Used to choose whole-doc vs chunked.
+EXTRACTION_MIN_CONTEXT_TOKENS = 250_000
 EscalationValidator = Callable[[str], bool]
 
 
@@ -203,6 +206,7 @@ async def _completion_with_fallback_impl(
     model_priority: list[SupportedModel] | None = None,
     validator: EscalationValidator | None = None,
     heartbeat_callback: Callable[[], Awaitable[None] | None] | None = None,
+    reasoning_effort: str | None = None,
     **kwargs: Any,
 ) -> ModelResponse:
     import litellm
@@ -220,6 +224,12 @@ async def _completion_with_fallback_impl(
         model = get_model(model_name)
         logger.debug("Attempting completion with model: %s (%s)", model_name, model.model)
 
+        call_kwargs = kwargs.copy()
+        if model_name.startswith("openrouter/") and "reasoning_effort" not in call_kwargs:
+            call_kwargs["reasoning_effort"] = reasoning_effort or "medium"
+        elif reasoning_effort:
+            call_kwargs["reasoning_effort"] = reasoning_effort
+
         try:
             start_time = time.time()
             response = await completion_fn(
@@ -228,7 +238,7 @@ async def _completion_with_fallback_impl(
                 messages=messages,
                 **({"api_base": model.api_base} if model.api_base else {}),
                 **({"extra_headers": model.extra_headers} if model.extra_headers else {}),
-                **kwargs,
+                **call_kwargs,
             )
             duration = time.time() - start_time
             provider_model = getattr(response, "model", None) or model.model
@@ -281,6 +291,7 @@ async def acompletion_with_fallback(
     validator: EscalationValidator | None = None,
     circuit_key: str = _GLOBAL_CIRCUIT_KEY,
     heartbeat_callback: Callable[[], Awaitable[None] | None] | None = None,
+    reasoning_effort: str | None = None,
     **kwargs: Any,
 ) -> ModelResponse:
     """Execute LLM completion, walking ``model_priority`` (default MODEL_PRIORITY) on failure.
@@ -296,6 +307,8 @@ async def acompletion_with_fallback(
         heartbeat_callback: Optional async no-arg callable fired before each model attempt
             and before each rate-limit backoff sleep, so the caller can bump a pipeline
             job heartbeat and avoid stall-guard kills during long fallback sequences.
+        reasoning_effort: Optional reasoning effort level (e.g. "medium", "high").
+            Defaults to "medium" for OpenRouter models if not specified.
     """
     cb = get_circuit_breaker(circuit_key)
 
@@ -313,6 +326,7 @@ async def acompletion_with_fallback(
             model_priority=model_priority,
             validator=validator,
             heartbeat_callback=heartbeat_callback,
+            reasoning_effort=reasoning_effort,
             **kwargs,
         )
     except AllModelsFailedError:

--- a/packages/backend/src/prompts/analysis_prompts.py
+++ b/packages/backend/src/prompts/analysis_prompts.py
@@ -39,8 +39,8 @@ OVERVIEW_CORE_DOC_TYPES: frozenset[str] = frozenset(
 
 # ─── 1. DOCUMENT ANALYSIS (deep by default) ────────────────────────────────────
 
-DIMENSION_GRADE_RUBRIC = """### Dimension grades (A–E — higher letter = better for the user)
-Assign each dimension an **A to E letter grade** with a **mandatory justification** (1–3 sentences). Do NOT output numeric scores or ranks.
+DIMENSION_GRADE_RUBRIC = """### Dimension grades (A-E — higher letter = better for the user)
+Assign each dimension an **A to E letter grade** with a **mandatory justification** (1-3 sentences).
 
 - **A**: Strong — multiple real protections or clearly minimal practice; minor caveats only.
   - transparency A: Lists every data type, every purpose, every recipient by name. No vague categories.
@@ -133,7 +133,7 @@ DOCUMENT_ANALYSIS_PROMPT = f"""You are a senior privacy analyst. Produce an evid
 ## HARD RULES (breaking any makes the output unusable)
 1. EVIDENCE ONLY. Use ONLY facts from the extraction below. If a fact is absent from the extraction, write "Not specified in document" — do not infer, assume, or use outside knowledge.
 2. EXACT QUOTES. Every `quote` field in critical_clauses MUST be copied character-for-character from the extraction evidence. Do not paraphrase, shorten, or fix typos.
-3. NO NUMERIC SCORES. Output letter grades A–E with justifications only. Never output `risk_score`, numeric dimension scores, or `verdict`.
+3. NO NUMERIC SCORES. Output letter grades A-E with justifications only. Never output `risk_score`, numeric dimension scores, or `verdict`.
 4. SILENCE ≠ E. If the document does not address a dimension, omit that key from `scores`. Silence is not a worst-case finding — never assign E for silence.
 5. THIN EXTRACTION. If the extraction has few items or is flagged partial, set analysis_completeness to "partial" and reduce keypoint/clause counts accordingly. Do not pad with invented findings.
 
@@ -144,12 +144,12 @@ Step 1 — Take the dimension grades you assigned (only the ones you filled in; 
 Step 2 — Convert each letter to a number: A=9, B=7, C=5, D=3, E=1.
 
 Step 3 — Apply these weights (only for dimensions you graded):
-- transparency: ×2
-- data_collection_scope: ×4
-- user_control: ×3
-- third_party_sharing: ×4
-- data_retention_score: ×2
-- security_score: ×1
+- transparency: x2
+- data_collection_scope: x4
+- user_control: x3
+- third_party_sharing: x4
+- data_retention_score: x2
+- security_score: x1
 
 Step 4 — Sum the weighted values. Divide by the total weight you used. Round to the nearest integer.
 
@@ -347,10 +347,10 @@ Step 1 — Count the dimension grades you assigned. There are 4 dimensions: tran
 Step 2 — Convert each letter to a number: A=9, B=7, C=5, D=3, E=1.
 
 Step 3 — Apply these weights:
-- transparency: ×2
-- data_collection_scope: ×4
-- user_control: ×3
-- third_party_sharing: ×4
+- transparency: x2
+- data_collection_scope: x4
+- user_control: x3
+- third_party_sharing: x4
 
 Step 4 — Sum the weighted values. Divide by 13 (the total weight). Round to the nearest integer.
 
@@ -362,7 +362,7 @@ Step 6 — You may adjust the base grade by at most one letter in either directi
 
 If you cannot name a specific reason, the overall grade MUST equal the base grade. Do not adjust "for tone" or "to be cautious."
 
-**Example:** Dimensions are transparency=B(7), data_collection_scope=D(3), user_control=C(5), third_party_sharing=C(5). Weighted: (7×2)+(3×4)+(5×3)+(5×4) = 14+12+15+20 = 61. Divide by 13 = 4.69. Round to 5. Base grade = C. You may output B or D only with a specific reason; otherwise output C.
+**Example:** Dimensions are transparency=B(7), data_collection_scope=D(3), user_control=C(5), third_party_sharing=C(5). Weighted: (7*2)+(3*4)+(5*3)+(5*4) = 14+12+15+20 = 61. Divide by 13 = 4.69. Round to 5. Base grade = C. You may output B or D only with a specific reason; otherwise output C.
 
 **Grade anchors:**
 - A: Exceptional — minimal collection, no sale, strong controls, meaningful user rights.
@@ -374,7 +374,7 @@ If you cannot name a specific reason, the overall grade MUST equal the base grad
 Grade from the rubric and dimension procedure only. **Do not grade leniently because a product is well-known, widely used, or "industry standard."** Popularity does not change what the documents permit. If the evidence supports D or E, assign D or E.
 
 ## DIMENSION GRADES
-Synthesize from all document analyses and extractions. Assign A–E per dimension with mandatory justifications for: transparency, data_collection_scope, user_control, third_party_sharing.
+Synthesize from all document analyses and extractions. Assign A-E per dimension with mandatory justifications for: transparency, data_collection_scope, user_control, third_party_sharing.
 
 {DIMENSION_GRADE_RUBRIC}
 
@@ -826,7 +826,7 @@ For each watch_out_for item, set materiality:
 - "notable": arbitration/class-action/jury-trial waivers and similar informational dispute terms.
 - "standard_industry": routine legal mechanics (DMCA, assignment, governing law) — omit from watch_out_for when possible.
 
-=============== GRADE A–E + HARD CAP ================
+=============== GRADE A-E + HARD CAP ================
 A = genuinely protective. B = mostly fair, minor concerns. C = mixed good and bad. D = user-hostile in one important way. E = user-hostile in several ways.
 MECHANICAL CAP: Count your "critical" findings across what_they_collect, who_gets_your_data, and watch_out_for. Put that number in `critical_findings_count`. If it is 1, grade may be at most D. If it is 2 or more, grade may be at most E. A single critical finding caps at D regardless of anything good. State the blocker in `grade_reason`.
 

--- a/packages/backend/src/prompts/analysis_prompts.py
+++ b/packages/backend/src/prompts/analysis_prompts.py
@@ -364,7 +364,7 @@ If you cannot name a specific reason, the overall grade MUST equal the base grad
 
 **Example:** Dimensions are transparency=B(7), data_collection_scope=D(3), user_control=C(5), third_party_sharing=C(5). Weighted: (7×2)+(3×4)+(5×3)+(5×4) = 14+12+15+20 = 61. Divide by 13 = 4.69. Round to 5. Base grade = C. You may output B or D only with a specific reason; otherwise output C.
 
-**Grade anchors (evidence only — no population targets):**
+**Grade anchors:**
 - A: Exceptional — minimal collection, no sale, strong controls, meaningful user rights.
 - B: Good — real protections with some gaps; no material user-hostile practice unmitigated.
 - C: Mixed — meaningful good and bad in balance; invasive elements partially offset by controls.

--- a/packages/backend/src/prompts/analysis_prompts.py
+++ b/packages/backend/src/prompts/analysis_prompts.py
@@ -58,7 +58,7 @@ Assign each dimension an **A to E letter grade** with a **mandatory justificatio
   - data_retention_score B: General time limit stated ("kept for no longer than necessary") but no per-type specifics.
   - security_score B: Encryption mentioned but not specified (no algorithm, no key management). Certification claimed but not named.
 
-- **C**: Mixed/typical — some controls but material gaps, OR invasive practice with partial mitigation.
+- **C**: Mixed — some controls but material gaps, OR invasive practice with partial mitigation.
   - transparency C: Lists data categories but not specific types ("device information" not "device fingerprint"). Purposes stated but generic ("to improve our services").
   - data_collection_scope C: Broad collection including behavioral/usage inference, but no sensitive categories. Collection is opt-out not opt-in.
   - user_control C: Account deletion available but requires contact (no self-service). Opt-outs exist for some purposes but not all.
@@ -364,13 +364,14 @@ If you cannot name a specific reason, the overall grade MUST equal the base grad
 
 **Example:** Dimensions are transparency=B(7), data_collection_scope=D(3), user_control=C(5), third_party_sharing=C(5). Weighted: (7×2)+(3×4)+(5×3)+(5×4) = 14+12+15+20 = 61. Divide by 13 = 4.69. Round to 5. Base grade = C. You may output B or D only with a specific reason; otherwise output C.
 
-**Grade distribution guidance:**
-- A: Exceptional — minimal collection, no sale, strong controls, E2E encryption. ~5% of products.
-- B: Good — some concerns but real protections. ~15% of products.
-- C: Typical — mainstream practices, mix of good and bad. ~40% of products.
-- D: Concerning — invasive practices without meaningful mitigation. ~30% of products.
-- E: Alarming — worst-case on multiple dimensions. ~10% of products.
-If you find yourself assigning D to most products, you are grading too harshly. Most mainstream services should be C.
+**Grade anchors (evidence only — no population targets):**
+- A: Exceptional — minimal collection, no sale, strong controls, meaningful user rights.
+- B: Good — real protections with some gaps; no material user-hostile practice unmitigated.
+- C: Mixed — meaningful good and bad in balance; invasive elements partially offset by controls.
+- D: Concerning — one or more important user-hostile practices with weak or no mitigation.
+- E: Alarming — multiple severe harms (sale/brokers, sensitive data without consent, no deletion, perpetual irrevocable licenses, etc.).
+
+Grade from the rubric and dimension procedure only. **Do not grade leniently because a product is well-known, widely used, or "industry standard."** Popularity does not change what the documents permit. If the evidence supports D or E, assign D or E.
 
 ## DIMENSION GRADES
 Synthesize from all document analyses and extractions. Assign A–E per dimension with mandatory justifications for: transparency, data_collection_scope, user_control, third_party_sharing.
@@ -826,7 +827,7 @@ For each watch_out_for item, set materiality:
 - "standard_industry": routine legal mechanics (DMCA, assignment, governing law) — omit from watch_out_for when possible.
 
 =============== GRADE A–E + HARD CAP ================
-A = genuinely protective. B = mostly fair, minor concerns. C = typical/mixed. D = user-hostile in one important way. E = user-hostile in several ways.
+A = genuinely protective. B = mostly fair, minor concerns. C = mixed good and bad. D = user-hostile in one important way. E = user-hostile in several ways.
 MECHANICAL CAP: Count your "critical" findings across what_they_collect, who_gets_your_data, and watch_out_for. Put that number in `critical_findings_count`. If it is 1, grade may be at most D. If it is 2 or more, grade may be at most E. A single critical finding caps at D regardless of anything good. State the blocker in `grade_reason`.
 
 =============== THIN / PARTIAL EXTRACTION ================

--- a/packages/backend/src/services/extraction_service/__init__.py
+++ b/packages/backend/src/services/extraction_service/__init__.py
@@ -38,7 +38,11 @@ from src.services.extraction_service.models import (
     _ThirdParty,
 )
 from src.services.extraction_service.service import _EXTRACTION_PRIMARY, extract_document_facts
-from src.services.extraction_service.utils import _chunk_text, _extraction_validator
+from src.services.extraction_service.utils import (
+    _chunk_text,
+    _extraction_validator,
+    _plan_extraction_segments,
+)
 
 __all__ = [
     "_AIUsage",
@@ -53,6 +57,7 @@ __all__ = [
     "_DataItem",
     "_Item",
     "_extraction_validator",
+    "_plan_extraction_segments",
     "_merge_ai_usage",
     "_merge_children_policy",
     "_merge_cookie_trackers",

--- a/packages/backend/src/services/extraction_service/prompts.py
+++ b/packages/backend/src/services/extraction_service/prompts.py
@@ -28,11 +28,11 @@ from src.models.document import Document
 
 EXTRACTION_SYSTEM_PROMPT = """You are an expert legal-document information extractor.
 
-Your job is to extract structured facts ONLY from the provided text chunk.
+Your job is to extract structured facts ONLY from the provided document text.
 
 Critical rules:
-- Only extract items explicitly present in the text chunk.
-- For every extracted item, provide an evidence quote that is an EXACT substring of the provided chunk.
+- Only extract items explicitly present in the provided text.
+- For every extracted item, provide an evidence quote that is an EXACT substring of the provided text.
 - The evidence quote must DIRECTLY substantiate the extracted fact — what the company does with data, who receives it, retention, rights, AI use, liability, etc.
 - Do NOT use generic cookie definitions, browser mechanics, footer links, or "how to manage cookies" text as evidence unless the extracted item is specifically about cookies, trackers, or consent mechanics.
 - Prefer the shortest quote that still contains the substantive claim. Skip introductory boilerplate.
@@ -342,16 +342,16 @@ def _get_extraction_prompt(document: Document, chunk: str, cluster: str) -> str:
     schema_hint, notes = _CLUSTER_SPECS[cluster]
 
     header = f"""\
-Extract evidence-backed facts from this policy document chunk.
+Extract evidence-backed facts from this policy document.
 
 Document URL: {document.url}
 Document Type: {document.doc_type}
 
-Text chunk:
+Document text:
 {chunk}
 
 Return a JSON object with ONLY the keys listed below (all keys required).
-Evidence quotes must be EXACT substrings of the chunk above.
+Evidence quotes must be EXACT substrings of the document text above.
 Each quote must substantiate its extracted fact — not generic cookie definitions, browser instructions, or footer/manage-cookies UI text unless the fact is specifically about cookies, trackers, or consent controls.
 """
     return f"{header}\n{json.dumps(schema_hint, separators=(',', ':'))}\n\nNotes:\n{notes}"

--- a/packages/backend/src/services/extraction_service/service.py
+++ b/packages/backend/src/services/extraction_service/service.py
@@ -14,18 +14,18 @@ Every extracted fact is grounded in an exact substring of the source text (its
 evidence quote); items whose quote is not found verbatim are discarded, which is
 what prevents hallucination. Facts are organised into clusters (data practices;
 sharing & transfers; rights & AI; legal scope) so each LLM call carries a focused
-schema, and long documents are chunked so no single call overflows the context
-window.
+schema, and splits documents into section-aware segments sized to the context
+budget of our long-context model cascade.
 
 Steps
 -----
-1. Split the cleaned document text into overlapping chunks; the overlap preserves
-   facts that straddle a chunk boundary.
-2. For each chunk, send the applicable cluster schema(s) to the LLM and require
+1. Split the document into section-aware segments (markdown headers, then
+   paragraphs) sized to the available input token budget.
+2. For each segment, send the applicable cluster schema(s) to the LLM and require
    structured JSON in which every item carries an exact-substring evidence quote.
-3. Parse each chunk response into typed extraction items, discarding any item
-   whose quote does not appear verbatim in the chunk.
-4. Merge items across chunks (``merging.py``): deduplicate by normalised value,
+3. Parse each segment response into typed extraction items, discarding any item
+   whose quote does not appear verbatim in the segment text.
+4. Merge items across segments (``merging.py``): deduplicate by normalised value,
    union the evidence spans, and combine per-document attributes.
 5. Return an ``ExtractionResult`` of atomic facts with evidence and confidence,
    ready for the analysis stage to interpret.
@@ -95,9 +95,10 @@ from src.services.extraction_service.prompts import (
     _get_extraction_prompt,
 )
 from src.services.extraction_service.utils import (
-    _chunk_text,
     _compute_content_hash,
+    _document_input_token_budget,
     _extraction_validator,
+    _plan_extraction_segments,
 )
 from src.services.term_materiality_classifier import enrich_extraction_materiality
 from src.utils.cancellation import CancellationToken
@@ -131,10 +132,15 @@ async def extract_document_facts(
         return document.extraction
 
     text = document.markdown or ""
-    chunks = _chunk_text(text, chunk_size=8000, overlap=800)
-    logger.debug(f"Chunked document {document.id} into {len(chunks)} chunk(s)")
+    segments = _plan_extraction_segments(document, text)
+    logger.info(
+        "Extraction plan for %s: segments=%d chunk_budget=~%d tokens",
+        document.id,
+        len(segments),
+        _document_input_token_budget(document) if segments else 0,
+    )
 
-    if not chunks:
+    if not segments:
         extraction = DocumentExtraction(
             version="v4",
             generated_at=datetime.now(),
@@ -172,15 +178,17 @@ async def extract_document_facts(
 
     accumulated_signals = PrivacySignals()
 
-    async def _run_cluster(cluster_name: str, chunk_text: str, chunk_idx: int) -> dict[str, Any]:
+    async def _run_cluster(
+        cluster_name: str, segment_text: str, segment_idx: int
+    ) -> dict[str, Any]:
         logger.debug(
-            f"Running cluster '{cluster_name}' for {document.id} chunk {chunk_idx}/{len(chunks)}"
+            f"Running cluster '{cluster_name}' for {document.id} segment {segment_idx}/{len(segments)}"
         )
         messages = [
             {"role": "system", "content": EXTRACTION_SYSTEM_PROMPT},
             {
                 "role": "user",
-                "content": _get_extraction_prompt(document, chunk_text, cluster_name),
+                "content": _get_extraction_prompt(document, segment_text, cluster_name),
             },
         ]
         response = await acompletion_with_fallback(
@@ -190,10 +198,10 @@ async def extract_document_facts(
             response_format={"type": "json_object"},
         )
         logger.info(
-            "Cluster '%s' for %s chunk %d completed with model %s",
+            "Cluster '%s' for %s segment %d completed with model %s",
             cluster_name,
             document.id,
-            chunk_idx,
+            segment_idx,
             response.model,
         )
         choice = response.choices[0]
@@ -207,18 +215,19 @@ async def extract_document_facts(
             raise ValueError("Empty response from LLM")
         return json.loads(content)
 
-    chunk_semaphore = asyncio.Semaphore(5)
+    segment_semaphore = asyncio.Semaphore(5)
     merge_lock = asyncio.Lock()
 
-    async def _process_chunk(idx: int, chunk: str) -> None:
+    async def _process_segment(idx: int, segment: str) -> None:
         await token.check_cancellation()
-        async with chunk_semaphore:
+        async with segment_semaphore:
             logger.debug(
-                f"Extracting v4 facts for {document.id}: chunk {idx}/{len(chunks)} (4 parallel clusters)"
+                f"Extracting v4 facts for {document.id}: segment {idx}/{len(segments)} "
+                "(4 parallel clusters)"
             )
 
             results = await asyncio.gather(
-                *(_run_cluster(name, chunk, idx) for name in CLUSTER_NAMES),
+                *(_run_cluster(name, segment, idx) for name in CLUSTER_NAMES),
                 return_exceptions=True,
             )
 
@@ -226,7 +235,7 @@ async def extract_document_facts(
         for i, result in enumerate(results):
             if isinstance(result, BaseException):
                 logger.warning(
-                    f"Cluster '{CLUSTER_NAMES[i]}' failed for {document.id} chunk {idx}: {result}"
+                    f"Cluster '{CLUSTER_NAMES[i]}' failed for {document.id} segment {idx}: {result}"
                 )
                 safe.append({})
             else:
@@ -237,22 +246,22 @@ async def extract_document_facts(
         try:
             dp = _ClusterDataPractices.model_validate(dp_raw, strict=False)
         except Exception as e:
-            logger.warning(f"Validation failed for data_practices chunk {idx}: {e}")
+            logger.warning(f"Validation failed for data_practices segment {idx}: {e}")
             dp = _ClusterDataPractices()
         try:
             st = _ClusterSharingTransfers.model_validate(st_raw, strict=False)
         except Exception as e:
-            logger.warning(f"Validation failed for sharing_transfers chunk {idx}: {e}")
+            logger.warning(f"Validation failed for sharing_transfers segment {idx}: {e}")
             st = _ClusterSharingTransfers()
         try:
             ra = _ClusterRightsAI.model_validate(ra_raw, strict=False)
         except Exception as e:
-            logger.warning(f"Validation failed for rights_ai chunk {idx}: {e}")
+            logger.warning(f"Validation failed for rights_ai segment {idx}: {e}")
             ra = _ClusterRightsAI()
         try:
             ls = _ClusterLegalScope.model_validate(ls_raw, strict=False)
         except Exception as e:
-            logger.warning(f"Validation failed for legal_scope chunk {idx}: {e}")
+            logger.warning(f"Validation failed for legal_scope segment {idx}: {e}")
             ls = _ClusterLegalScope()
 
         nonlocal children_policy
@@ -368,17 +377,17 @@ async def extract_document_facts(
                 content_hash=content_hash,
             )
 
-    chunk_results = await asyncio.gather(
-        *(_process_chunk(idx, chunk) for idx, chunk in enumerate(chunks, 1)),
+    segment_results = await asyncio.gather(
+        *(_process_segment(idx, segment) for idx, segment in enumerate(segments, 1)),
         return_exceptions=True,
     )
-    failed_chunks = 0
-    for i, result in enumerate(chunk_results):
+    failed_segments = 0
+    for i, result in enumerate(segment_results):
         if isinstance(result, BaseException):
-            failed_chunks += 1
-            logger.warning(f"Chunk {i + 1}/{len(chunks)} failed for {document.id}: {result}")
-    if failed_chunks:
-        logger.warning(f"{failed_chunks}/{len(chunks)} chunks failed for {document.id}")
+            failed_segments += 1
+            logger.warning(f"Segment {i + 1}/{len(segments)} failed for {document.id}: {result}")
+    if failed_segments:
+        logger.warning(f"{failed_segments}/{len(segments)} segments failed for {document.id}")
 
     extraction = DocumentExtraction(
         version="v4",

--- a/packages/backend/src/services/extraction_service/utils.py
+++ b/packages/backend/src/services/extraction_service/utils.py
@@ -1,9 +1,11 @@
-"""Utilities that support the chunked extraction pipeline: validation, chunking, evidence.
+"""Utilities that support the extraction pipeline: validation, chunking, evidence.
 
 **What it does**
 - ``_extraction_validator(result)``: validates the shape of an LLM extraction response
   (must be a dict with ``privacy_signals``, ``data_items``, etc.), returning the
   parsed ``ExtractionResult`` or raising a clear error.
+- ``_plan_extraction_segments(document, text)``: splits into section-aware segments
+  sized to the long-context model budget (prompt + output headroom).
 - ``_chunk_text(text, max_chunk_size, overlap)``: splits a long document into
   overlapping chunks that fit within the LLM context window, preserving sentence
   boundaries where possible.
@@ -28,6 +30,7 @@ import json
 import re
 
 from src.core.logging import get_logger
+from src.llm import EXTRACTION_MIN_CONTEXT_TOKENS
 from src.models.document import Document, EvidenceSpan
 from src.utils.quotes import resolve_quote_offsets
 
@@ -72,6 +75,52 @@ def _extraction_validator(cluster_name: str):
 def _compute_content_hash(document: Document) -> str:
     content = f"{document.markdown}{document.doc_type}"
     return hashlib.sha256(content.encode()).hexdigest()
+
+
+_CHARS_PER_TOKEN_ESTIMATE = 4
+_OUTPUT_TOKEN_RESERVE = 24_000
+_REASONING_TOKEN_RESERVE = 8_000
+_SYSTEM_TOKEN_RESERVE = 300
+
+
+def _estimate_text_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, len(text) // _CHARS_PER_TOKEN_ESTIMATE)
+
+
+def _extraction_prompt_overhead_tokens(document: Document) -> int:
+    from src.services.extraction_service.prompts import CLUSTER_NAMES, _get_extraction_prompt
+
+    return max(
+        _SYSTEM_TOKEN_RESERVE + _estimate_text_tokens(_get_extraction_prompt(document, "", cluster))
+        for cluster in CLUSTER_NAMES
+    )
+
+
+def _document_input_token_budget(document: Document) -> int:
+    """Tokens available for document text in a single extraction LLM call."""
+    return (
+        EXTRACTION_MIN_CONTEXT_TOKENS
+        - _extraction_prompt_overhead_tokens(document)
+        - _OUTPUT_TOKEN_RESERVE
+        - _REASONING_TOKEN_RESERVE
+    )
+
+
+def _plan_extraction_segments(document: Document, text: str) -> list[str]:
+    """Split document text into section-aware segments sized to the context budget.
+
+    Always chunks (never sends an arbitrary full document in one call). Short
+    documents may produce a single segment when one section fits the budget.
+    """
+    if not text:
+        return []
+
+    budget_tokens = _document_input_token_budget(document)
+    chunk_chars = max(4000, budget_tokens * _CHARS_PER_TOKEN_ESTIMATE)
+    overlap = max(400, chunk_chars // 10)
+    return _chunk_text(text, chunk_size=chunk_chars, overlap=overlap)
 
 
 def _split_on_sentence_boundary(text: str, max_len: int) -> int:
@@ -157,7 +206,10 @@ def _make_evidence(document: Document, content_hash: str, quote: str) -> Evidenc
 __all__ = [
     "_chunk_text",
     "_compute_content_hash",
+    "_document_input_token_budget",
+    "_estimate_text_tokens",
     "_extraction_validator",
     "_make_evidence",
+    "_plan_extraction_segments",
     "_split_on_sentence_boundary",
 ]

--- a/packages/backend/tests/unit/analyser_risk_score_test.py
+++ b/packages/backend/tests/unit/analyser_risk_score_test.py
@@ -210,3 +210,27 @@ def test_reconcile_topic_stances_and_dangers_raise_middling_dimensions() -> None
     assert meta.grade == "D"
     assert meta.verdict == "pervasive"
     assert meta.risk_score == 7
+
+
+def test_reconcile_topic_floors_survive_positive_adjustments() -> None:
+    """Benefits and fair stances must not wash out harmful retention floor."""
+    meta = MetaSummary(
+        summary="Indefinite retention with some documented protections.",
+        grade="C",
+        scores=MetaSummaryScores(
+            transparency=MetaSummaryScore(grade="B", justification="Readable policy"),
+            data_collection_scope=MetaSummaryScore(grade="C", justification="Broad collection"),
+            user_control=MetaSummaryScore(grade="B", justification="Some controls"),
+            third_party_sharing=MetaSummaryScore(grade="C", justification="Ad partners"),
+        ),
+        benefits=["encryption at rest", "self-service deletion"],
+        topic_stances=[
+            TopicStanceBreakdown(topic="retention", status="found", stance="harmful"),
+            TopicStanceBreakdown(topic="data_sale", status="found", stance="fair"),
+            TopicStanceBreakdown(topic="ai_training", status="found", stance="fair"),
+            TopicStanceBreakdown(topic="security", status="found", stance="fair"),
+        ],
+    )
+    _reconcile_meta_summary_risk(meta)
+    assert meta.grade == "D"
+    assert meta.risk_score == 7

--- a/packages/backend/tests/unit/analyser_risk_score_test.py
+++ b/packages/backend/tests/unit/analyser_risk_score_test.py
@@ -196,7 +196,7 @@ def test_reconcile_topic_stances_and_dangers_raise_middling_dimensions() -> None
         ],
         privacy_signals=PrivacySignals(ai_training_on_user_data="yes"),
         topic_stances=[
-            TopicStanceBreakdown(topic="retention", status="found", stance="concerning"),
+            TopicStanceBreakdown(topic="retention", status="found", stance="harmful"),
             TopicStanceBreakdown(topic="ai_training", status="found", stance="harmful"),
             TopicStanceBreakdown(topic="data_sale", status="found", stance="concerning"),
             TopicStanceBreakdown(topic="data_sharing", status="found", stance="concerning"),

--- a/packages/backend/tests/unit/analyser_risk_score_test.py
+++ b/packages/backend/tests/unit/analyser_risk_score_test.py
@@ -126,7 +126,7 @@ def test_reconcile_meta_summary_uses_llm_grade() -> None:
         ),
     )
     _reconcile_meta_summary_risk(meta)
-    assert meta.grade == "B"
+    assert meta.grade == "C"
     assert meta.risk_score is not None
 
 
@@ -174,6 +174,39 @@ def test_reconcile_derives_verdict_from_grade() -> None:
         ],
     )
     _reconcile_meta_summary_risk(meta)
-    assert meta.grade == "B"
-    assert meta.verdict == "user_friendly"
-    assert meta.risk_score == 3
+    assert meta.grade == "C"
+    assert meta.verdict == "moderate"
+    assert meta.risk_score == 5
+
+
+def test_reconcile_topic_stances_and_dangers_raise_middling_dimensions() -> None:
+    """Discord-like case: dimensions average to B but topic rollup and dangers warrant D."""
+    meta = MetaSummary(
+        summary="Messages kept indefinitely; AI training on public posts.",
+        grade="C",
+        scores=MetaSummaryScores(
+            transparency=MetaSummaryScore(grade="B", justification="Readable policy"),
+            data_collection_scope=MetaSummaryScore(grade="C", justification="Broad collection"),
+            user_control=MetaSummaryScore(grade="B", justification="Some controls"),
+            third_party_sharing=MetaSummaryScore(grade="C", justification="Ad partners"),
+        ),
+        dangers=[
+            "Discord keeps messages indefinitely unless you delete them",
+            "Uses public posts for AI and machine learning training",
+        ],
+        privacy_signals=PrivacySignals(ai_training_on_user_data="yes"),
+        topic_stances=[
+            TopicStanceBreakdown(topic="retention", status="found", stance="concerning"),
+            TopicStanceBreakdown(topic="ai_training", status="found", stance="harmful"),
+            TopicStanceBreakdown(topic="data_sale", status="found", stance="concerning"),
+            TopicStanceBreakdown(topic="data_sharing", status="found", stance="concerning"),
+            TopicStanceBreakdown(topic="cookies_tracking", status="found", stance="concerning"),
+            TopicStanceBreakdown(topic="profiling_ai", status="found", stance="concerning"),
+            TopicStanceBreakdown(topic="data_collection", status="found", stance="concerning"),
+            TopicStanceBreakdown(topic="security", status="found", stance="fair"),
+        ],
+    )
+    _reconcile_meta_summary_risk(meta)
+    assert meta.grade == "D"
+    assert meta.verdict == "pervasive"
+    assert meta.risk_score == 7

--- a/packages/backend/tests/unit/analyser_topic_scoring_test.py
+++ b/packages/backend/tests/unit/analyser_topic_scoring_test.py
@@ -162,9 +162,9 @@ async def test_generate_product_overview_uses_llm_grades() -> None:
             document_svc=document_svc,
         )
 
-    # LLM grade C → risk 5 after reconciliation.
-    assert result.grade == "C"
-    assert result.risk_score == 5
+    # Topic rollup risk 9 overrides middling LLM grade C.
+    assert result.grade == "E"
+    assert result.risk_score == 9
     assert result.topic_stances
     assert result.topic_stances[0].rationale_key == "topic.findings_summary"
     assert result.topic_stances[0].headline_claim is not None

--- a/packages/backend/tests/unit/extraction_service_test.py
+++ b/packages/backend/tests/unit/extraction_service_test.py
@@ -1,5 +1,15 @@
-from src.services.extraction_service import _chunk_text
+from src.models.document import Document
+from src.services.extraction_service import _chunk_text, _plan_extraction_segments
 from src.utils.quotes import resolve_quote_offsets
+
+
+def _doc() -> Document:
+    return Document(
+        url="https://example.com/privacy",
+        product_id="p1",
+        doc_type="privacy_policy",
+        markdown="",
+    )
 
 
 def test_chunk_text_single_chunk_when_short() -> None:
@@ -13,6 +23,28 @@ def test_chunk_text_produces_overlap() -> None:
     chunks = _chunk_text(text, chunk_size=10, overlap=3)
     assert chunks[0] == "abcdefghij"
     assert len(chunks) >= 2
+
+
+def test_plan_extraction_segments_single_segment_for_short_doc() -> None:
+    text = "We collect email addresses for account creation.\n" * 500
+    segments = _plan_extraction_segments(_doc(), text)
+    assert len(segments) == 1
+    assert segments[0] == text
+
+
+def test_plan_extraction_segments_splits_long_doc() -> None:
+    # ~1.2M chars ≈ 300K tokens — above the per-segment budget.
+    text = "x" * 1_200_000
+    segments = _plan_extraction_segments(_doc(), text)
+    assert len(segments) > 1
+
+
+def test_plan_extraction_segments_respects_markdown_sections() -> None:
+    section = "## Data retention\nWe keep logs for 90 days.\n\n"
+    text = section * 200
+    segments = _plan_extraction_segments(_doc(), text)
+    assert segments
+    assert all("Data retention" in segment for segment in segments)
 
 
 def test_resolve_quote_offsets_exact_match() -> None:

--- a/packages/backend/tests/unit/llm_cascade_test.py
+++ b/packages/backend/tests/unit/llm_cascade_test.py
@@ -19,6 +19,13 @@ def test_no_gpt5_or_native_paid_on_hot_path():
     assert not [model for model in MODEL_PRIORITY if model.startswith("gpt-5")]
 
 
+def test_no_short_context_models_on_hot_path():
+    for model in MODEL_PRIORITY:
+        assert "gpt-oss" not in model, (
+            f"{model} has 131K context — too short for whole-doc extraction"
+        )
+
+
 def test_free_models_use_free_slugs():
     free_models = [model for model in MODEL_PRIORITY if ":free" in model]
-    assert len(free_models) >= 2
+    assert len(free_models) >= 1


### PR DESCRIPTION
## Summary
- **Balanced Risk Reconciliation**: Refines `_reconcile_meta_summary_risk` to blend dimension grades, topic rollups, and danger floors.
- **Danger Floors**: Implements hard floors for material harms like **indefinite retention** (risk ≥7 / D) and **AI training** (risk ≥6 / C).
- **Bias Correction**: Clamps holistic LLM grades to within ±1 letter of evidence-backed dimension grades to prevent arbitrary divergence.
- **Prompt Refinement**: Removes population-based grading bias ("most services should be C") in favor of strict evidence-based grading.
- **Signal Integrity**: Re-orders adjustments so that hard privacy signal floors (e.g., selling data) are applied last and cannot be "washed out" by positive adjustments.

## Test plan
- Verified with `tests/unit/analyser_risk_score_test.py`:
  - `test_reconcile_topic_stances_and_dangers_raise_middling_dimensions`: Discord-like case (B dimensions + retention/AI dangers) correctly lands at D.
  - `test_reconcile_derives_verdict_from_grade`: Verified signal floors and positive adjustments balance correctly.
- Verified with `tests/unit/analyser_topic_scoring_test.py`:
  - `test_generate_product_overview_uses_llm_grades`: High topic risk (9) correctly overrides middling LLM grades.