### PR TITLE
fix(llm): remove broken reasoning default and relax circuit breaker

### DIFF
--- a/packages/backend/src/analyser.py
+++ b/packages/backend/src/analyser.py
@@ -1800,7 +1800,7 @@ async def generate_product_consumer_explainer(
                     response_format={"type": "json_object"},
                     temperature=0,
                     heartbeat_callback=heartbeat_callback,
-                    circuit_key=product_circuit_key(product_slug),
+                    circuit_key=product_circuit_key(product_slug, "consumer_explainer"),
                 )
             logger.info(
                 "generate_product_consumer_explainer %s used model %s", product_slug, response.model
@@ -1929,7 +1929,7 @@ async def generate_product_compliance(
                     model_priority=_OVERVIEW_PRIORITY,
                     response_format={"type": "json_object"},
                     temperature=0,
-                    circuit_key=product_circuit_key(product_slug),
+                    circuit_key=product_circuit_key(product_slug, "compliance"),
                 )
             logger.info(
                 "generate_product_compliance %s used model %s", product_slug, response.model
@@ -2275,7 +2275,7 @@ Per-document analyses and extractions:
                         response_format={"type": "json_object"},
                         temperature=0,
                         heartbeat_callback=on_progress,
-                        circuit_key=product_circuit_key(product_slug),
+                        circuit_key=product_circuit_key(product_slug, "overview"),
                     )
                 )
 
@@ -2794,7 +2794,7 @@ Per-document analyses and extractions:
                 ],
                 model_priority=_OVERVIEW_PRIORITY,
                 response_format={"type": "json_object"},
-                circuit_key=product_circuit_key(product_slug),
+                circuit_key=product_circuit_key(product_slug, "deep_analysis"),
             )
 
         choice = response.choices[0]

--- a/packages/backend/src/core/config.py
+++ b/packages/backend/src/core/config.py
@@ -16,6 +16,28 @@ def _env_bool(name: str, default: bool) -> bool:
     return raw.strip().lower() in ("1", "true", "yes", "on")
 
 
+def _env_positive_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _env_positive_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
 _DISCOVERY_PAGE_CAP = 1000
 _DISCOVERY_DEPTH_CAP = 3
 
@@ -196,6 +218,19 @@ class CrawlerConfig:
         )
 
 
+class LlmConfig:
+    """LLM client settings (env-tunable)."""
+
+    def __init__(self) -> None:
+        # Off by default — pipeline jobs already retry; a low threshold blocks whole
+        # products after a few LLM errors (e.g. during redeploys or bulk regen).
+        self.circuit_breaker_enabled: bool = _env_bool("LLM_CIRCUIT_BREAKER_ENABLED", False)
+        self.circuit_breaker_threshold: int = _env_positive_int("LLM_CIRCUIT_BREAKER_THRESHOLD", 15)
+        self.circuit_breaker_reset_seconds: float = _env_positive_float(
+            "LLM_CIRCUIT_BREAKER_RESET_SECONDS", 60.0
+        )
+
+
 class Config:
     """Application configuration with nested configuration objects"""
 
@@ -208,6 +243,7 @@ class Config:
         self.tracking = TrackingConfig()
         self.paddle = PaddleConfig()
         self.crawler = CrawlerConfig()
+        self.llm = LlmConfig()
 
         logger.info(f"Tracking enabled: {self.tracking.tracking_enabled}")
 

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -28,8 +28,40 @@ class AllModelsFailedError(Exception):
     """Raised when every model in the priority list failed for one completion request."""
 
 
-CIRCUIT_BREAKER_THRESHOLD: int = 3
-CIRCUIT_RESET_SECONDS: float = 300.0
+def _read_bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _read_positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _read_positive_float_env(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+# Off by default — pipeline jobs already retry; a low threshold blocks whole products
+# after a few LLM errors (e.g. during redeploys or bulk regen).
+LLM_CIRCUIT_BREAKER_ENABLED: bool = _read_bool_env("LLM_CIRCUIT_BREAKER_ENABLED", False)
+CIRCUIT_BREAKER_THRESHOLD: int = _read_positive_int_env("LLM_CIRCUIT_BREAKER_THRESHOLD", 15)
+CIRCUIT_RESET_SECONDS: float = _read_positive_float_env("LLM_CIRCUIT_BREAKER_RESET_SECONDS", 60.0)
 
 
 class CircuitBreaker:
@@ -87,15 +119,17 @@ class CircuitBreaker:
 _circuit_breakers: dict[str, CircuitBreaker] = {}
 
 
-def product_circuit_key(product_slug: str) -> str:
-    """Scope circuit-breaker state to one product (bulk pipeline jobs must not share one breaker)."""
-    return f"product:{product_slug}"
+def product_circuit_key(product_slug: str, operation: str = "default") -> str:
+    """Scope circuit-breaker state to one product operation (overview, consolidation, etc.)."""
+    slug = product_slug.strip() or "unknown"
+    op = operation.strip() or "default"
+    return f"product:{slug}:{op}"
 
 
 def document_circuit_key(document: Any) -> str:
-    """Circuit key for a policy document row (prefers slug in metadata, else product_id)."""
+    """Circuit key scoped to a single document — not the whole product."""
     if document is None:
-        return product_circuit_key("unknown")
+        return product_circuit_key("unknown", "document")
     if isinstance(document, dict):
         meta = document.get("metadata") or {}
         product_id = document.get("product_id")
@@ -106,16 +140,44 @@ def document_circuit_key(document: Any) -> str:
         doc_id = getattr(document, "id", "unknown")
     slug = meta.get("product_slug") if isinstance(meta, dict) else None
     if isinstance(slug, str) and slug.strip():
-        return product_circuit_key(slug.strip())
-    if isinstance(product_id, str) and product_id.strip():
-        return product_circuit_key(product_id.strip())
-    return product_circuit_key(str(doc_id))
+        product_scope = slug.strip()
+    elif isinstance(product_id, str) and product_id.strip():
+        product_scope = product_id.strip()
+    else:
+        product_scope = "unknown"
+    return product_circuit_key(product_scope, f"doc:{doc_id}")
 
 
 def get_circuit_breaker(key: str) -> CircuitBreaker:
     if key not in _circuit_breakers:
         _circuit_breakers[key] = CircuitBreaker()
     return _circuit_breakers[key]
+
+
+def reset_circuit_breakers() -> None:
+    """Clear in-process breaker state (e.g. on worker boot after redeploy)."""
+    _circuit_breakers.clear()
+
+
+def _resolve_circuit_breaker(circuit_key: str | None) -> CircuitBreaker | None:
+    if not LLM_CIRCUIT_BREAKER_ENABLED or circuit_key is None:
+        return None
+    return get_circuit_breaker(circuit_key)
+
+
+def _failure_should_trip_breaker(exc: Exception | None) -> bool:
+    """Config/client errors won't heal by opening the circuit — don't count them."""
+    if exc is None:
+        return True
+    name = type(exc).__name__
+    if name in {"UnsupportedParamsError", "AuthenticationError", "NotFoundError"}:
+        return False
+    message = str(exc).lower()
+    if "reasoning_effort" in message or "does not support parameters" in message:
+        return False
+    if "api key" in message or "authentication" in message or "unauthorized" in message:
+        return False
+    return True
 
 
 class Model:
@@ -249,11 +311,9 @@ async def _completion_with_fallback_impl(
         logger.debug("Attempting completion with model: %s (%s)", model_name, model.model)
 
         call_kwargs = kwargs.copy()
-        # All OpenRouter models in MODEL_PRIORITY support reasoning; default medium
-        # when the caller does not specify an effort level.
-        effort = reasoning_effort or ("medium" if model_name.startswith("openrouter/") else None)
-        if effort and "reasoning_effort" not in call_kwargs:
-            call_kwargs["reasoning_effort"] = effort
+        if reasoning_effort and "reasoning_effort" not in call_kwargs:
+            call_kwargs["reasoning_effort"] = reasoning_effort
+        call_kwargs.setdefault("drop_params", True)
 
         try:
             start_time = time.time()
@@ -325,18 +385,18 @@ async def acompletion_with_fallback(
     output fails validation. Since the list runs cheapest-to-most-capable, a validation
     failure naturally escalates to a stronger model.
 
-    When ``circuit_key`` is set (e.g. :func:`product_circuit_key`), consecutive failures
-    for that scope open a breaker that blocks only the same key — not other products.
-    When ``circuit_key`` is omitted, no circuit breaker is applied.
+    When ``LLM_CIRCUIT_BREAKER_ENABLED`` is true and ``circuit_key`` is set, consecutive
+    transient failures for that scope can open a breaker for the same key only.
+    By default the breaker is disabled so pipeline retries are not short-circuited.
 
     Args:
         heartbeat_callback: Optional async no-arg callable fired before each model attempt
             and before each rate-limit backoff sleep, so the caller can bump a pipeline
             job heartbeat and avoid stall-guard kills during long fallback sequences.
         reasoning_effort: Optional reasoning effort level (e.g. "medium", "high").
-            Defaults to "medium" for OpenRouter models if not specified.
+            Only passed when explicitly set by the caller.
     """
-    cb = get_circuit_breaker(circuit_key) if circuit_key is not None else None
+    cb = _resolve_circuit_breaker(circuit_key)
 
     if cb is not None and not cb.allow_request():
         raise CircuitBreakerError("LLM service unavailable: too many consecutive failures")
@@ -355,8 +415,9 @@ async def acompletion_with_fallback(
             reasoning_effort=reasoning_effort,
             **kwargs,
         )
-    except AllModelsFailedError:
-        if cb is not None:
+    except AllModelsFailedError as exc:
+        cause = exc.__cause__ if isinstance(exc.__cause__, Exception) else None
+        if cb is not None and _failure_should_trip_breaker(cause):
             cb.record_failure()
             if not cb.allow_request():
                 raise CircuitBreakerError(

--- a/packages/backend/src/llm.py
+++ b/packages/backend/src/llm.py
@@ -8,6 +8,7 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+from src.core.config import config
 from src.core.logging import get_logger
 from src.utils.llm_usage import track_usage
 
@@ -28,49 +29,13 @@ class AllModelsFailedError(Exception):
     """Raised when every model in the priority list failed for one completion request."""
 
 
-def _read_bool_env(name: str, default: bool) -> bool:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _read_positive_int_env(name: str, default: int) -> int:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
-    return value if value > 0 else default
-
-
-def _read_positive_float_env(name: str, default: float) -> float:
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    try:
-        value = float(raw)
-    except ValueError:
-        return default
-    return value if value > 0 else default
-
-
-# Off by default — pipeline jobs already retry; a low threshold blocks whole products
-# after a few LLM errors (e.g. during redeploys or bulk regen).
-LLM_CIRCUIT_BREAKER_ENABLED: bool = _read_bool_env("LLM_CIRCUIT_BREAKER_ENABLED", False)
-CIRCUIT_BREAKER_THRESHOLD: int = _read_positive_int_env("LLM_CIRCUIT_BREAKER_THRESHOLD", 15)
-CIRCUIT_RESET_SECONDS: float = _read_positive_float_env("LLM_CIRCUIT_BREAKER_RESET_SECONDS", 60.0)
-
-
 class CircuitBreaker:
     """Per-key circuit breaker with time-based decay and half-open probe support.
 
     Tracks consecutive failures for a single scope (e.g. a product slug).  When the
-    failure count reaches ``CIRCUIT_BREAKER_THRESHOLD`` the circuit opens and rejects
-    all requests until ``CIRCUIT_RESET_SECONDS`` have elapsed, at which point it enters
-    a half-open state and allows exactly one probe.  A successful probe closes the
+    failure count reaches ``config.llm.circuit_breaker_threshold`` the circuit opens
+    and rejects all requests until ``config.llm.circuit_breaker_reset_seconds`` have
+    elapsed, at which point it enters a half-open state and allows exactly one probe.  A successful probe closes the
     circuit; a failed probe re-opens it.
     """
 
@@ -92,7 +57,7 @@ class CircuitBreaker:
         self._consecutive_failures += 1
         self._last_failure_time = time.monotonic()
         self._half_open = False
-        if self._consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD:
+        if self._consecutive_failures >= config.llm.circuit_breaker_threshold:
             self._is_open = True
 
     def record_success(self) -> None:
@@ -110,7 +75,7 @@ class CircuitBreaker:
         if self._half_open:
             return False
         now = time.monotonic()
-        if now - self._last_failure_time >= CIRCUIT_RESET_SECONDS:
+        if now - self._last_failure_time >= config.llm.circuit_breaker_reset_seconds:
             self._half_open = True
             return True
         return False
@@ -121,8 +86,8 @@ _circuit_breakers: dict[str, CircuitBreaker] = {}
 
 def product_circuit_key(product_slug: str, operation: str = "default") -> str:
     """Scope circuit-breaker state to one product operation (overview, consolidation, etc.)."""
-    slug = product_slug.strip() or "unknown"
-    op = operation.strip() or "default"
+    slug = str(product_slug or "").strip() or "unknown"
+    op = str(operation or "").strip() or "default"
     return f"product:{slug}:{op}"
 
 
@@ -160,17 +125,29 @@ def reset_circuit_breakers() -> None:
 
 
 def _resolve_circuit_breaker(circuit_key: str | None) -> CircuitBreaker | None:
-    if not LLM_CIRCUIT_BREAKER_ENABLED or circuit_key is None:
+    if not config.llm.circuit_breaker_enabled or circuit_key is None:
         return None
     return get_circuit_breaker(circuit_key)
+
+
+_NON_TRANSIENT_LLM_ERRORS = frozenset(
+    {
+        "UnsupportedParamsError",
+        "AuthenticationError",
+        "NotFoundError",
+        "BadRequestError",
+        "PermissionDeniedError",
+        "UnprocessableEntityError",
+        "InvalidRequestError",
+    }
+)
 
 
 def _failure_should_trip_breaker(exc: Exception | None) -> bool:
     """Config/client errors won't heal by opening the circuit — don't count them."""
     if exc is None:
         return True
-    name = type(exc).__name__
-    if name in {"UnsupportedParamsError", "AuthenticationError", "NotFoundError"}:
+    if type(exc).__name__ in _NON_TRANSIENT_LLM_ERRORS:
         return False
     message = str(exc).lower()
     if "reasoning_effort" in message or "does not support parameters" in message:
@@ -385,7 +362,7 @@ async def acompletion_with_fallback(
     output fails validation. Since the list runs cheapest-to-most-capable, a validation
     failure naturally escalates to a stronger model.
 
-    When ``LLM_CIRCUIT_BREAKER_ENABLED`` is true and ``circuit_key`` is set, consecutive
+    When ``config.llm.circuit_breaker_enabled`` is true and ``circuit_key`` is set,
     transient failures for that scope can open a breaker for the same key only.
     By default the breaker is disabled so pipeline retries are not short-circuited.
 

--- a/packages/backend/src/services/product_rollup_service.py
+++ b/packages/backend/src/services/product_rollup_service.py
@@ -765,7 +765,7 @@ class ProductRollupService:
         from src.services.topic_consolidation import consolidate_rollup_items
 
         rollup.items = await consolidate_rollup_items(
-            rollup.items, circuit_key=product_circuit_key(product_slug)
+            rollup.items, circuit_key=product_circuit_key(product_slug, "consolidation")
         )
         source_hashes = await self._intelligence_service.compute_source_hashes(db, product_id)
         await self._intelligence_service.save_rollup(

--- a/packages/backend/tests/unit/llm_circuit_breaker_test.py
+++ b/packages/backend/tests/unit/llm_circuit_breaker_test.py
@@ -8,10 +8,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from src import llm as llm_module
+from src.core.config import config
 from src.llm import (
-    CIRCUIT_BREAKER_THRESHOLD,
-    CIRCUIT_RESET_SECONDS,
     AllModelsFailedError,
     CircuitBreaker,
     CircuitBreakerError,
@@ -26,7 +24,7 @@ from src.llm import (
 @pytest.fixture(autouse=True)
 def _reset_breakers(monkeypatch: pytest.MonkeyPatch) -> None:
     reset_circuit_breakers()
-    monkeypatch.setattr(llm_module, "LLM_CIRCUIT_BREAKER_ENABLED", True)
+    monkeypatch.setattr(config.llm, "circuit_breaker_enabled", True)
 
 
 def test_reset_half_open_allows_subsequent_probe() -> None:
@@ -44,11 +42,11 @@ def test_reset_half_open_allows_subsequent_probe() -> None:
 async def test_cancelled_probe_resets_half_open() -> None:
     cb = get_circuit_breaker("cancel-probe-test")
     cb.record_success()
-    for _ in range(CIRCUIT_BREAKER_THRESHOLD):
+    for _ in range(config.llm.circuit_breaker_threshold):
         cb.record_failure()
     assert cb.is_open is True
 
-    cb._last_failure_time = time.monotonic() - CIRCUIT_RESET_SECONDS - 1
+    cb._last_failure_time = time.monotonic() - config.llm.circuit_breaker_reset_seconds - 1
 
     with patch(
         "src.llm._completion_with_fallback_impl", AsyncMock(side_effect=asyncio.CancelledError())
@@ -92,14 +90,14 @@ def test_document_circuit_key_scopes_per_document() -> None:
 
 @pytest.mark.asyncio
 async def test_breaker_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(llm_module, "LLM_CIRCUIT_BREAKER_ENABLED", False)
+    monkeypatch.setattr(config.llm, "circuit_breaker_enabled", False)
     reset_circuit_breakers()
 
     with patch(
         "src.llm._completion_with_fallback_impl",
         AsyncMock(side_effect=AllModelsFailedError("all failed")),
     ):
-        for _ in range(CIRCUIT_BREAKER_THRESHOLD + 2):
+        for _ in range(config.llm.circuit_breaker_threshold + 2):
             with pytest.raises(AllModelsFailedError):
                 await acompletion_with_fallback(
                     messages=[{"role": "user", "content": "hi"}],
@@ -143,7 +141,7 @@ async def test_product_circuit_keys_are_isolated() -> None:
         "src.llm._completion_with_fallback_impl",
         AsyncMock(side_effect=AllModelsFailedError("all failed")),
     ):
-        for _ in range(CIRCUIT_BREAKER_THRESHOLD - 1):
+        for _ in range(config.llm.circuit_breaker_threshold - 1):
             with pytest.raises(AllModelsFailedError):
                 await acompletion_with_fallback(
                     messages=[{"role": "user", "content": "hi"}],

--- a/packages/backend/tests/unit/llm_circuit_breaker_test.py
+++ b/packages/backend/tests/unit/llm_circuit_breaker_test.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src import llm as llm_module
 from src.llm import (
     CIRCUIT_BREAKER_THRESHOLD,
     CIRCUIT_RESET_SECONDS,
@@ -18,7 +19,14 @@ from src.llm import (
     document_circuit_key,
     get_circuit_breaker,
     product_circuit_key,
+    reset_circuit_breakers,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_breakers(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_circuit_breakers()
+    monkeypatch.setattr(llm_module, "LLM_CIRCUIT_BREAKER_ENABLED", True)
 
 
 def test_reset_half_open_allows_subsequent_probe() -> None:
@@ -36,9 +44,8 @@ def test_reset_half_open_allows_subsequent_probe() -> None:
 async def test_cancelled_probe_resets_half_open() -> None:
     cb = get_circuit_breaker("cancel-probe-test")
     cb.record_success()
-    cb.record_failure()
-    cb.record_failure()
-    cb.record_failure()
+    for _ in range(CIRCUIT_BREAKER_THRESHOLD):
+        cb.record_failure()
     assert cb.is_open is True
 
     cb._last_failure_time = time.monotonic() - CIRCUIT_RESET_SECONDS - 1
@@ -73,36 +80,60 @@ async def test_all_models_failed_still_records_failure() -> None:
     assert cb.consecutive_failures == 1
 
 
-def test_document_circuit_key_handles_dict_and_none() -> None:
-    assert document_circuit_key(None) == product_circuit_key("unknown")
+def test_document_circuit_key_scopes_per_document() -> None:
+    assert document_circuit_key(None) == product_circuit_key("unknown", "document")
     assert document_circuit_key({"product_id": "pid-1", "id": "doc-1"}) == product_circuit_key(
-        "pid-1"
+        "pid-1", "doc:doc-1"
     )
     assert document_circuit_key(
-        {"metadata": {"product_slug": "discord"}, "product_id": "pid-1"}
-    ) == product_circuit_key("discord")
+        {"metadata": {"product_slug": "discord"}, "product_id": "pid-1", "id": "doc-9"}
+    ) == product_circuit_key("discord", "doc:doc-9")
 
 
 @pytest.mark.asyncio
-async def test_no_circuit_key_skips_breaker_on_all_models_failed() -> None:
-    """Without circuit_key, failures must not open a shared breaker for later calls."""
+async def test_breaker_disabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(llm_module, "LLM_CIRCUIT_BREAKER_ENABLED", False)
+    reset_circuit_breakers()
+
     with patch(
         "src.llm._completion_with_fallback_impl",
         AsyncMock(side_effect=AllModelsFailedError("all failed")),
     ):
-        with pytest.raises(AllModelsFailedError):
-            await acompletion_with_fallback(messages=[{"role": "user", "content": "hi"}])
+        for _ in range(CIRCUIT_BREAKER_THRESHOLD + 2):
+            with pytest.raises(AllModelsFailedError):
+                await acompletion_with_fallback(
+                    messages=[{"role": "user", "content": "hi"}],
+                    circuit_key=product_circuit_key("alpha", "overview"),
+                )
 
-        # Second call still attempts the LLM (not short-circuited).
+
+@pytest.mark.asyncio
+async def test_config_errors_do_not_trip_breaker() -> None:
+    cb = get_circuit_breaker("config-error-test")
+
+    class UnsupportedParamsError(Exception):
+        pass
+
+    err = AllModelsFailedError("all failed")
+    err.__cause__ = UnsupportedParamsError(
+        "openrouter does not support parameters: ['reasoning_effort']"
+    )
+
+    with patch("src.llm._completion_with_fallback_impl", AsyncMock(side_effect=err)):
         with pytest.raises(AllModelsFailedError):
-            await acompletion_with_fallback(messages=[{"role": "user", "content": "hi"}])
+            await acompletion_with_fallback(
+                messages=[{"role": "user", "content": "hi"}],
+                circuit_key="config-error-test",
+            )
+
+    assert cb.consecutive_failures == 0
 
 
 @pytest.mark.asyncio
 async def test_product_circuit_keys_are_isolated() -> None:
     """Failures for one product must not trip the breaker for another."""
-    product_a = product_circuit_key("alpha")
-    product_b = product_circuit_key("beta")
+    product_a = product_circuit_key("alpha", "overview")
+    product_b = product_circuit_key("beta", "overview")
     cb_a = get_circuit_breaker(product_a)
     cb_b = get_circuit_breaker(product_b)
     cb_a.record_success()

--- a/packages/backend/worker.py
+++ b/packages/backend/worker.py
@@ -20,6 +20,7 @@ from aiohttp import web
 
 from src.core.database import close_motor_client, db_session
 from src.core.logging import get_logger, setup_logging
+from src.llm import reset_circuit_breakers
 from src.repositories.monitoring_schedule_repository import MonitoringScheduleRepository
 from src.repositories.pipeline_repository import (
     ORPHANABLE_PIPELINE_STATUSES,
@@ -253,6 +254,7 @@ async def _run_worker_loop(
     last_sweep = loop.time()
     last_monitoring_sweep = loop.time()
 
+    reset_circuit_breakers()
     logger.info("Pipeline worker started (concurrency=%d, poll=%.1fs)", _CONCURRENCY, _POLL_SECONDS)
     running: dict[asyncio.Task[None], str] = {}
 


### PR DESCRIPTION
## What this PR delivers

Fixes the production regen outage where every OpenRouter model in the fallback chain failed before reaching the API, then our circuit breaker blocked the rest of each product's pipeline.

Removes the incorrect default `reasoning_effort=medium` on all OpenRouter calls (LiteLLM rejects it for owl-alpha, gemma, deepseek, gemini-flash-lite, etc.). Passes `drop_params=True` per completion so unsupported params are dropped instead of failing the whole chain.

Relaxes the LLM circuit breaker: **disabled by default**, higher threshold when enabled (15 vs 3), faster reset (60s vs 5m), per-operation keys (overview vs consolidation vs per-document), and config/client errors no longer trip the breaker.

## Why this matters

**For operators:** Bulk analysis-only regen was completing synthesis then failing every overview with `LLM service unavailable: too many consecutive failures`. Logs showed the real error was `UnsupportedParamsError: reasoning_effort` on all 5 models — not an OpenRouter outage. Redeploys and recrawls made this worse by burning retries and tripping per-product breakers after only 3 failures.

**For maintainers:** PR #207 scoped the breaker per product but still shared one key across document analysis, consolidation, and overview — so a few doc failures blocked overview generation entirely.

## How LLM behaviour changes

| Deployment | Change |
|---|---|
| Crawler worker (pipeline) | OpenRouter calls no longer get a default `reasoning_effort`; unsupported params dropped via `drop_params=True`. |
| Crawler worker (pipeline) | LLM circuit breaker **off by default** — failures propagate to job-level retry instead of short-circuiting. |
| Crawler worker (breaker enabled) | Threshold 15, reset 60s, keys scoped per operation (`overview`, `consolidation`, `doc:{id}`). |
| Crawler worker (boot) | In-process breaker state cleared on worker start. |
| API / other services | Same `llm.py` changes; no env migration required unless re-enabling breaker. |

## UX changes operators will notice

- Pipeline regen jobs should start completing overviews again after deploy (watch `regen_ok` climb).
- Fewer false `LLM service unavailable` errors when the underlying issue is a config/param mismatch.
- OpenRouter credit errors (402) may still surface per-model in logs — top up credits separately if needed.

## Migration — config changes required

| Old | New |
|---|---|
| (implicit) breaker always on at threshold 3 | Breaker **off** unless `LLM_CIRCUIT_BREAKER_ENABLED=true` |
| 300s reset | `LLM_CIRCUIT_BREAKER_RESET_SECONDS=60` (default) |
| threshold 3 | `LLM_CIRCUIT_BREAKER_THRESHOLD=15` (default when enabled) |

## Developer-visible API changes

| Surface | Old | New |
|---|---|---|
| `product_circuit_key(slug)` | `product:{slug}` | `product:{slug}:{operation}` (operation defaults to `"default"`) |
| `document_circuit_key(doc)` | Shared per product slug | `product:{slug}:doc:{doc_id}` |

## Tests

- 7 tests in `tests/unit/llm_circuit_breaker_test.py` passing.
- Covers: breaker disabled by default, per-product isolation, config errors don't trip breaker, per-document key scoping.

### Edge cases to verify in a staging session

1. Deploy to crawler, requeue one failed product (e.g. discord) — expected: overview completes, no `UnsupportedParamsError`.
2. Bulk regen 10+ products — expected: `regen_ok` increments; no fleet-wide `LLM service unavailable`.
3. Set `LLM_CIRCUIT_BREAKER_ENABLED=true`, force 15+ transient failures on one product — expected: only that product/operation key blocks; others unaffected.
4. Worker redeploy mid-job — expected: interrupted jobs requeued; breaker state fresh on boot.

## Notes for reviewers

- Root cause confirmed in production logs: `All 5 models failed... UnsupportedParamsError: reasoning_effort`.
- The old comment claiming all OpenRouter models support reasoning was wrong — removed with the default.
- `crawler_down_watch.py` intentionally excluded (ops tooling, separate PR if wanted).