### PR TITLE
fix(backend): fix ops scripts prod DB and add job quiesce

### DIFF
--- a/packages/backend/scripts/README.md
+++ b/packages/backend/scripts/README.md
@@ -9,9 +9,10 @@ Run from `packages/backend` with `uv run python scripts/<name>.py`.
 | `pipeline_monitor.py` | **Primary monitor.** Modes: `regen` (5-min PIPELINE_UPDATE), `watch` (regen + auto requeue crawl), `down` (SERVICE_DOWN_ALERT), `status` (one-shot) |
 | `queue_status.py` | One-shot queue snapshot (same as `pipeline_monitor.py status`) |
 | `crawler_monitor.py` | Deep production watchdog: Railway logs, memory, auto-fix, redeploy |
-| `requeue_analysis.py` | Queue analysis-only jobs (`skip_crawl`) for products with stored docs |
+| `requeue_analysis.py` | Queue analysis-only jobs (`skip_crawl`); default: products **missing** overviews; `--stale-hours N` for regen |
 | `requeue_crawl.py` | Queue full crawls — **default: only products with zero policy docs** |
 | `cancel_wasteful_crawls.py` | Interrupt full crawls when docs already exist |
+| `quiesce_jobs.py` | Mark in-flight/interrupted/retryable-failed jobs non-retryable (stop worker auto-refill) |
 
 ### Typical production workflow
 
@@ -22,9 +23,13 @@ uv run python scripts/pipeline_monitor.py --production
 # One-shot queue check
 uv run python scripts/queue_status.py --production
 
-# After regen: queue analysis-only for all products with overviews
+# Queue analysis-only for products missing overviews (e.g. stripe)
 uv run python scripts/requeue_analysis.py --production --dry-run
-uv run python scripts/requeue_analysis.py --production
+uv run python scripts/requeue_analysis.py --production stripe
+
+# Stop all work and prevent worker sweeps from requeueing
+uv run python scripts/quiesce_jobs.py --production --dry-run
+uv run python scripts/quiesce_jobs.py --production
 
 # Only crawl products with no stored documents (e.g. openai)
 uv run python scripts/requeue_crawl.py --production --dry-run

--- a/packages/backend/scripts/cancel_wasteful_crawls.py
+++ b/packages/backend/scripts/cancel_wasteful_crawls.py
@@ -19,9 +19,8 @@ IN_FLIGHT = ("pending", "crawling", "synthesising", "generating_overview")
 
 
 async def main(*, dry_run: bool, use_production: bool) -> None:
-    from src.core.database import db_session
     from src.core.logging import get_logger, setup_logging
-    from src.ops.script_env import resolve_production
+    from src.ops.script_env import open_db, resolve_production
     from src.services.pipeline_eligibility import count_policy_documents, product_needs_full_crawl
     from src.services.service_factory import create_product_service
 
@@ -33,7 +32,8 @@ async def main(*, dry_run: bool, use_production: bool) -> None:
     logger = get_logger(__name__)
     product_svc = create_product_service()
 
-    async with db_session() as db:
+    client, db = open_db(prefer_production=use_production)
+    try:
         jobs = await db.pipeline_jobs.find(
             {
                 "active": True,
@@ -80,6 +80,8 @@ async def main(*, dry_run: bool, use_production: bool) -> None:
             print(f"  [cancel]  {slug} status={job['status']} docs={doc_count} job={job['id']}")
 
         print(f"\nDone: cancelled={cancelled}, kept={kept}")
+    finally:
+        client.close()
 
 
 if __name__ == "__main__":

--- a/packages/backend/scripts/quiesce_jobs.py
+++ b/packages/backend/scripts/quiesce_jobs.py
@@ -1,0 +1,132 @@
+"""Mark pipeline jobs non-retryable so worker sweeps stop refilling the queue.
+
+Sets active/in-flight/interrupted jobs to failed with auto_retry_disabled, and
+disables auto-retry on all other failed jobs the worker would otherwise revive.
+
+Usage:
+    uv run python scripts/quiesce_jobs.py --production --dry-run
+    uv run python scripts/quiesce_jobs.py --production
+    uv run python scripts/quiesce_jobs.py --production --keep-slugs stripe
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import UTC, datetime
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+IN_FLIGHT = ("pending", "crawling", "synthesising", "generating_overview", "interrupted")
+REASON = "manual_ops_quiesce"
+
+
+async def main(*, dry_run: bool, use_production: bool, keep_slugs: set[str]) -> None:
+    from src.ops.script_env import open_db, resolve_production
+
+    resolve_production(use_production=use_production)
+    if use_production:
+        print("Using PRODUCTION_MONGO_URI")
+
+    client, db = open_db(prefer_production=use_production)
+    try:
+        now = datetime.now(UTC).replace(tzinfo=None)
+
+        in_flight_query = {
+            "$or": [
+                {"active": True},
+                {"status": {"$in": list(IN_FLIGHT)}},
+            ]
+        }
+        if keep_slugs:
+            in_flight_query = {
+                "$and": [
+                    in_flight_query,
+                    {"product_slug": {"$nin": sorted(keep_slugs)}},
+                ]
+            }
+
+        in_flight = await db.pipeline_jobs.count_documents(in_flight_query)
+        retryable_failed = await db.pipeline_jobs.count_documents(
+            {"status": "failed", "auto_retry_disabled": {"$ne": True}}
+        )
+        interrupted = await db.pipeline_jobs.count_documents({"status": "interrupted"})
+        print(
+            f"Would quiesce in_flight={in_flight} retryable_failed={retryable_failed} "
+            f"interrupted={interrupted} keep={sorted(keep_slugs) or 'none'}"
+        )
+
+        if dry_run:
+            sample = (
+                await db.pipeline_jobs.find(
+                    in_flight_query, {"product_slug": 1, "status": 1, "active": 1}
+                )
+                .limit(15)
+                .to_list(15)
+            )
+            for j in sample:
+                print(
+                    f"  [dry-run] {j['product_slug']} status={j['status']} active={j.get('active')}"
+                )
+            return
+
+        r1 = await db.pipeline_jobs.update_many(
+            in_flight_query,
+            {
+                "$set": {
+                    "status": "failed",
+                    "active": False,
+                    "error": "interrupted",
+                    "error_detail": "Quiesced by ops — do not auto-retry",
+                    "auto_retry_disabled": True,
+                    "auto_retry_disabled_reason": REASON,
+                    "updated_at": now,
+                    "completed_at": now,
+                }
+            },
+        )
+        r2 = await db.pipeline_jobs.update_many(
+            {"status": "failed", "auto_retry_disabled": {"$ne": True}},
+            {
+                "$set": {
+                    "auto_retry_disabled": True,
+                    "auto_retry_disabled_reason": REASON,
+                    "updated_at": now,
+                }
+            },
+        )
+        active_left = await db.pipeline_jobs.count_documents({"active": True})
+        interrupted_left = await db.pipeline_jobs.count_documents({"status": "interrupted"})
+        retryable_left = await db.pipeline_jobs.count_documents(
+            {"status": "failed", "auto_retry_disabled": {"$ne": True}}
+        )
+        print(
+            f"Done: quiesced_in_flight={r1.modified_count} "
+            f"disabled_failed_retry={r2.modified_count} "
+            f"active_left={active_left} interrupted_left={interrupted_left} "
+            f"retryable_failed_left={retryable_left}"
+        )
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Quiesce pipeline jobs (no worker auto-retry)")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--production", action="store_true")
+    parser.add_argument(
+        "--keep-slugs",
+        nargs="*",
+        default=[],
+        help="Do not quiesce active/in-flight jobs for these slugs",
+    )
+    args = parser.parse_args()
+    asyncio.run(
+        main(
+            dry_run=args.dry_run,
+            use_production=args.production,
+            keep_slugs=set(args.keep_slugs),
+        )
+    )

--- a/packages/backend/scripts/requeue_analysis.py
+++ b/packages/backend/scripts/requeue_analysis.py
@@ -10,10 +10,45 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from datetime import UTC, datetime, timedelta
 
 from dotenv import load_dotenv
 
 load_dotenv()
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        ts = value
+    elif isinstance(value, str):
+        try:
+            ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if ts.tzinfo is not None:
+        ts = ts.replace(tzinfo=None)
+    return ts
+
+
+async def _stale_overview_slugs(db, *, stale_hours: int) -> list[str]:
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=stale_hours)
+    slugs: list[str] = []
+    async for row in db.product_intelligence.find(
+        {"overview": {"$exists": True, "$ne": None}},
+        {"product_slug": 1, "overview_generated_at": 1, "updated_at": 1},
+    ):
+        slug = row.get("product_slug")
+        if not slug:
+            continue
+        ts = _parse_ts(row.get("overview_generated_at") or row.get("updated_at"))
+        if ts is None or ts >= cutoff:
+            continue
+        slugs.append(slug)
+    return sorted(slugs)
 
 
 async def main(
@@ -21,13 +56,13 @@ async def main(
     *,
     dry_run: bool,
     use_production: bool,
+    stale_hours: int | None,
 ) -> None:
-    from src.core.database import db_session
     from src.core.logging import get_logger, setup_logging
     from src.models.pipeline_job import PipelineJob
-    from src.ops.script_env import job_url, resolve_production
+    from src.ops.script_env import job_url, open_db, resolve_production
     from src.repositories.pipeline_repository import PipelineRepository
-    from src.services.pipeline_eligibility import count_policy_documents
+    from src.services.pipeline_eligibility import count_policy_documents, has_overview
     from src.services.service_factory import create_product_service
 
     resolve_production(use_production=use_production)
@@ -39,16 +74,20 @@ async def main(
     product_svc = create_product_service()
     pipeline_repo = PipelineRepository()
 
-    async with db_session() as db:
+    client, db = open_db(prefer_production=use_production)
+    try:
         if slugs:
             target_slugs = slugs
+        elif stale_hours is not None:
+            target_slugs = await _stale_overview_slugs(db, stale_hours=stale_hours)
+            print(f"Stale overview cutoff: {stale_hours}h ({len(target_slugs)} product(s))")
         else:
-            cursor = db.product_intelligence.find(
-                {"overview": {"$exists": True, "$ne": None}},
-                {"product_slug": 1},
-            )
-            rows = await cursor.to_list(length=None)
-            target_slugs = sorted(row["product_slug"] for row in rows if row.get("product_slug"))
+            missing: list[str] = []
+            async for row in db.products.find({}, {"slug": 1}):
+                slug = row.get("slug")
+                if slug and not await has_overview(db, slug):
+                    missing.append(slug)
+            target_slugs = sorted(missing)
 
         queued = skipped_active = skipped_no_docs = skipped_missing = 0
         print(f"Evaluating {len(target_slugs)} product(s)...")
@@ -93,12 +132,27 @@ async def main(
             f"\nDone: queued={queued}, skipped_active={skipped_active}, "
             f"skipped_no_docs={skipped_no_docs}, skipped_missing={skipped_missing}"
         )
+    finally:
+        client.close()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Queue analysis-only pipeline jobs")
-    parser.add_argument("slugs", nargs="*", help="Product slugs (default: all with overviews)")
+    parser.add_argument("slugs", nargs="*", help="Product slugs (default: all missing overviews)")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--production", action="store_true")
+    parser.add_argument(
+        "--stale-hours",
+        type=int,
+        metavar="N",
+        help="Queue products whose overview is older than N hours",
+    )
     args = parser.parse_args()
-    asyncio.run(main(args.slugs or None, dry_run=args.dry_run, use_production=args.production))
+    asyncio.run(
+        main(
+            args.slugs or None,
+            dry_run=args.dry_run,
+            use_production=args.production,
+            stale_hours=args.stale_hours,
+        )
+    )


### PR DESCRIPTION
## What this PR does

Follow-up to #209: fixes production ops scripts that still used `db_session()` (which reads the Mongo URI cached at import time, so `--production` silently hit local DB). Adds `quiesce_jobs.py` to stop the worker from auto-refilling the queue after manual ops stops.

## Why

During production recovery we cancelled 73 jobs on **local** Mongo before discovering the bug. `cancel_wasteful_crawls.py` and `requeue_analysis.py` from #209 were affected. Worker `_sweep_stale` also kept requeueing interrupted/failed jobs until we bulk-quiesced them.

## Changes made

| File | Change |
|------|--------|
| `cancel_wasteful_crawls.py` | `db_session()` → `open_db(prefer_production=...)` |
| `requeue_analysis.py` | Same DB fix; default targets products **missing** overviews (not all with overviews); adds `--stale-hours N` |
| `quiesce_jobs.py` | New: mark in-flight/interrupted/retryable-failed jobs as `failed` + `auto_retry_disabled` |
| `scripts/README.md` | Document new script and corrected `requeue_analysis` default |

## How to test

- [ ] `uv run python scripts/cancel_wasteful_crawls.py --production --dry-run` — should print `Using PRODUCTION_MONGO_URI` and query prod job counts (not local)
- [ ] `uv run python scripts/requeue_analysis.py --production --dry-run` — default lists only products missing overviews
- [ ] `uv run python scripts/requeue_analysis.py --production --stale-hours 48 --dry-run` — lists products with stale overviews
- [ ] `uv run python scripts/quiesce_jobs.py --production --dry-run` — reports counts without modifying; run without `--dry-run` only on a test/staging DB if available
- [ ] After deploy, worker sweep should not revive jobs quiesced with `auto_retry_disabled: true`