### PR TITLE
perf(frontend): speed up product page initial load

### DIFF
--- a/packages/frontend/app/(dashboard)/products/[slug]/layout.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/layout.tsx
@@ -1,27 +1,16 @@
 import type { Metadata } from "next";
-import { headers } from "next/headers";
-
-import { cache } from "react";
 
 import { ProductStructuredData } from "@/components/seo/structured-data";
+
+import {
+  type ProductMetadata,
+  fetchProductForMetadata,
+  humanizeSlug,
+} from "./product-page-server";
 
 const siteUrl = (
   process.env.NEXT_PUBLIC_APP_URL || "https://clausea.co"
 ).replace(/\/$/, "");
-
-interface ProductMetadata {
-  name: string;
-  slug: string;
-  company_name?: string | null;
-  one_line_summary?: string;
-  grade?: "A" | "B" | "C" | "D" | "E" | null;
-  verdict?:
-    | "very_user_friendly"
-    | "user_friendly"
-    | "moderate"
-    | "pervasive"
-    | "very_pervasive";
-}
 
 function buildOgUrl(
   base: string,
@@ -34,95 +23,6 @@ function buildOgUrl(
   if (verdict) params.set("verdict", verdict);
   return `${base}/og?${params.toString()}`;
 }
-
-function humanizeSlug(slug: string): string {
-  return slug
-    .split(/[-_]+/)
-    .filter(Boolean)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
-    .join(" ");
-}
-
-function resolveOriginFromHeaders(headerList: Headers): string | null {
-  const explicit = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/$/, "");
-  if (explicit) {
-    return explicit;
-  }
-  const host = headerList.get("x-forwarded-host") ?? headerList.get("host");
-  if (!host) {
-    return null;
-  }
-  const proto = headerList.get("x-forwarded-proto") ?? "http";
-  return `${proto}://${host}`;
-}
-
-type ProductMetadataFetch =
-  | { kind: "ok"; product: ProductMetadata }
-  | { kind: "not_found" }
-  | { kind: "uncertain"; displayName: string };
-
-/**
- * Load product for SEO metadata via the same Next.js API route the client uses,
- * forwarding the request cookies so Clerk auth matches. A direct backend fetch
- * returns 401 (no Bearer token) and was incorrectly shown as "Product Not Found".
- */
-const fetchProductForMetadata = cache(async function (
-  slug: string,
-): Promise<ProductMetadataFetch> {
-  try {
-    const headerList = await headers();
-    const origin = resolveOriginFromHeaders(headerList);
-    if (!origin) {
-      console.error(
-        "Product metadata: could not resolve app origin (set NEXT_PUBLIC_APP_URL).",
-      );
-      return { kind: "uncertain", displayName: humanizeSlug(slug) };
-    }
-
-    const cookie = headerList.get("cookie");
-    const reqHeaders: HeadersInit = cookie ? { Cookie: cookie } : {};
-
-    const [productRes, overviewRes] = await Promise.all([
-      fetch(`${origin}/api/products/${slug}`, {
-        headers: reqHeaders,
-        next: { revalidate: 60 },
-      }),
-      fetch(`${origin}/api/products/${slug}/overview`, {
-        headers: reqHeaders,
-        next: { revalidate: 60 },
-      }).catch(() => null),
-    ]);
-
-    if (productRes.status === 404) {
-      return { kind: "not_found" };
-    }
-
-    if (!productRes.ok) {
-      console.error("Product metadata: API error", productRes.status, slug);
-      return { kind: "uncertain", displayName: humanizeSlug(slug) };
-    }
-
-    const product = (await productRes.json()) as ProductMetadata;
-
-    if (overviewRes?.ok) {
-      try {
-        const overview = (await overviewRes.json()) as {
-          grade?: ProductMetadata["grade"];
-          verdict?: ProductMetadata["verdict"];
-        };
-        if (overview.grade) product.grade = overview.grade;
-        if (overview.verdict) product.verdict = overview.verdict;
-      } catch {
-        // Overview unavailable or malformed — OG card shows name only
-      }
-    }
-
-    return { kind: "ok", product };
-  } catch (error) {
-    console.error("Error fetching product data for metadata:", error);
-    return { kind: "uncertain", displayName: humanizeSlug(slug) };
-  }
-});
 
 function neutralProductMetadata(displayName: string, slug: string): Metadata {
   const description = `Policy overview for ${displayName} — data practices, terms, and risks from crawled documents.`;

--- a/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
@@ -1,37 +1,5 @@
-import { cookies } from "next/headers";
-
-import type { ConsumerExplainer } from "@/components/dashboard/explainer/types";
-import {
-  PREVIEW_TOKEN_COOKIE,
-  PREVIEW_TOKEN_HEADER,
-} from "@/lib/preview-token";
-import type {
-  DocumentSummary,
-  Product,
-  ProductOverview,
-  ProductTopicReport,
-} from "@/types";
-import { auth } from "@clerk/nextjs/server";
-import { getBackendUrl } from "@lib/config";
-
 import CompanyPage from "./product-page-client";
-
-async function fetchWithAuth(
-  url: string,
-  headers: HeadersInit,
-  tag: string,
-): Promise<unknown> {
-  try {
-    const res = await fetch(url, {
-      headers,
-      next: { tags: [tag], revalidate: 3600 },
-    });
-    if (!res.ok) return null;
-    return res.json();
-  } catch {
-    return null;
-  }
-}
+import { fetchProductPageShell } from "./product-page-server";
 
 export default async function ProductPage({
   params,
@@ -39,40 +7,14 @@ export default async function ProductPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-
-  const { getToken } = await auth();
-  const token = await getToken();
-  const cookieStore = await cookies();
-  const previewToken = cookieStore.get(PREVIEW_TOKEN_COOKIE)?.value;
-  const headers: HeadersInit = token
-    ? { Authorization: `Bearer ${token}` }
-    : previewToken
-      ? { [PREVIEW_TOKEN_HEADER]: previewToken }
-      : {};
-
-  const tag = `product-${slug}`;
-  const [
-    initialProduct,
-    initialData,
-    initialDocuments,
-    initialExplainer,
-    initialTopics,
-  ] = await Promise.all([
-    fetchWithAuth(getBackendUrl(`/products/${slug}`), headers, tag),
-    fetchWithAuth(getBackendUrl(`/products/${slug}/overview`), headers, tag),
-    fetchWithAuth(getBackendUrl(`/products/${slug}/documents`), headers, tag),
-    fetchWithAuth(getBackendUrl(`/products/${slug}/explainer`), headers, tag),
-    fetchWithAuth(getBackendUrl(`/products/${slug}/topics`), headers, tag),
-  ]);
+  const { product, overview, explainer } = await fetchProductPageShell(slug);
 
   return (
     <CompanyPage
       key={slug}
-      initialProduct={initialProduct as Product | null}
-      initialData={initialData as ProductOverview | null}
-      initialDocuments={(initialDocuments as DocumentSummary[]) ?? []}
-      initialExplainer={initialExplainer as ConsumerExplainer | null}
-      initialTopics={initialTopics as ProductTopicReport | null}
+      initialProduct={product}
+      initialData={overview}
+      initialExplainer={explainer}
     />
   );
 }

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -180,10 +180,18 @@ export default function CompanyPage({
         }
 
         if (docsRes.ok) {
-          setDocuments((await docsRes.json()) as DocumentSummary[]);
+          try {
+            setDocuments((await docsRes.json()) as DocumentSummary[]);
+          } catch (err) {
+            console.error("Failed to parse documents JSON", err);
+          }
         }
         if (topicsRes.ok) {
-          setTopics((await topicsRes.json()) as ProductTopicReport);
+          try {
+            setTopics((await topicsRes.json()) as ProductTopicReport);
+          } catch (err) {
+            console.error("Failed to parse topics JSON", err);
+          }
         }
       } catch (error) {
         console.error("Failed to fetch product evidence", error);

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -128,6 +128,10 @@ export default function CompanyPage({
   const [documentsLoading, setDocumentsLoading] = useState(
     Boolean(initialProduct && initialOverview),
   );
+  const [evidenceError, setEvidenceError] = useState<number | "network" | null>(
+    null,
+  );
+  const [evidenceFetchKey, setEvidenceFetchKey] = useState(0);
   const [thinEvidence, setThinEvidence] = useState(false);
   const [indexationMode, setIndexationMode] = useState<
     | "ready"
@@ -169,6 +173,7 @@ export default function CompanyPage({
 
     async function fetchEvidence() {
       setDocumentsLoading(true);
+      setEvidenceError(null);
       try {
         const [docsRes, topicsRes] = await Promise.all([
           fetch(`/api/products/${slug}/documents`),
@@ -179,22 +184,38 @@ export default function CompanyPage({
           return;
         }
 
+        let nextError: number | "network" | null = null;
+
         if (docsRes.ok) {
           try {
             setDocuments((await docsRes.json()) as DocumentSummary[]);
           } catch (err) {
             console.error("Failed to parse documents JSON", err);
+            nextError = docsRes.status;
           }
+        } else if (docsRes.status !== 425) {
+          nextError = docsRes.status;
         }
+
         if (topicsRes.ok) {
           try {
             setTopics((await topicsRes.json()) as ProductTopicReport);
           } catch (err) {
             console.error("Failed to parse topics JSON", err);
+            nextError = nextError ?? topicsRes.status;
           }
+        } else if (topicsRes.status !== 425) {
+          nextError = nextError ?? topicsRes.status;
+        }
+
+        if (!cancelled) {
+          setEvidenceError(nextError);
         }
       } catch (error) {
         console.error("Failed to fetch product evidence", error);
+        if (!cancelled) {
+          setEvidenceError("network");
+        }
       } finally {
         if (!cancelled) {
           setDocumentsLoading(false);
@@ -207,7 +228,7 @@ export default function CompanyPage({
     return () => {
       cancelled = true;
     };
-  }, [slug, initialProduct, initialOverview]);
+  }, [slug, initialProduct, initialOverview, evidenceFetchKey]);
 
   useEffect(() => {
     // SSR pre-loaded the overview shell — evidence loads in a separate effect.
@@ -1246,6 +1267,26 @@ export default function CompanyPage({
               <Skeleton className="h-32 rounded-2xl" />
               <Skeleton className="h-32 rounded-2xl" />
               <Skeleton className="h-32 rounded-2xl" />
+            </div>
+          ) : evidenceError ? (
+            <div className="border border-border bg-background p-6 space-y-4">
+              <h3 className="text-xl font-display font-medium text-foreground">
+                Couldn&apos;t load evidence
+              </h3>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {evidenceError === 429
+                  ? "You've hit the usage limit for evidence details. Sign in or upgrade for full access."
+                  : evidenceError === "network"
+                    ? "We couldn't reach the server. Check your connection and try again."
+                    : "Something went wrong loading source documents and topic findings."}
+              </p>
+              <Button
+                onClick={() => setEvidenceFetchKey((key) => key + 1)}
+                className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
+              >
+                <RotateCcw className="mr-2 h-3.5 w-3.5" />
+                Try again
+              </Button>
             </div>
           ) : (
             <EvidenceList

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -125,7 +125,9 @@ export default function CompanyPage({
     initialTopics ?? null,
   );
   const [loading, setLoading] = useState(!initialProduct || !initialOverview);
-  const [documentsLoading, setDocumentsLoading] = useState(false);
+  const [documentsLoading, setDocumentsLoading] = useState(
+    Boolean(initialProduct && initialOverview),
+  );
   const [thinEvidence, setThinEvidence] = useState(false);
   const [indexationMode, setIndexationMode] = useState<
     | "ready"
@@ -159,7 +161,48 @@ export default function CompanyPage({
   const [restoreError, setRestoreError] = useState<string | null>(null);
 
   useEffect(() => {
-    // If SSR pre-loaded both product and overview, skip client-side fetch entirely
+    if (!initialProduct || !initialOverview) {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchEvidence() {
+      setDocumentsLoading(true);
+      try {
+        const [docsRes, topicsRes] = await Promise.all([
+          fetch(`/api/products/${slug}/documents`),
+          fetch(`/api/products/${slug}/topics`),
+        ]);
+
+        if (cancelled) {
+          return;
+        }
+
+        if (docsRes.ok) {
+          setDocuments((await docsRes.json()) as DocumentSummary[]);
+        }
+        if (topicsRes.ok) {
+          setTopics((await topicsRes.json()) as ProductTopicReport);
+        }
+      } catch (error) {
+        console.error("Failed to fetch product evidence", error);
+      } finally {
+        if (!cancelled) {
+          setDocumentsLoading(false);
+        }
+      }
+    }
+
+    void fetchEvidence();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, initialProduct, initialOverview]);
+
+  useEffect(() => {
+    // SSR pre-loaded the overview shell — evidence loads in a separate effect.
     if (initialProduct && initialOverview) {
       setLoading(false);
       return;

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
@@ -11,7 +11,10 @@ import type { Product, ProductOverview } from "@/types";
 import { auth } from "@clerk/nextjs/server";
 import { getBackendUrl } from "@lib/config";
 
-const REVALIDATE_SECONDS = 3600;
+/** Shared by layout metadata + page — keeps OG/JSON-LD freshness (was 60s in layout). */
+const METADATA_REVALIDATE_SECONDS = 60;
+/** Page-only endpoints can use a longer cache window. */
+const PAGE_REVALIDATE_SECONDS = 3600;
 
 export interface ProductMetadata {
   name: string;
@@ -39,12 +42,13 @@ async function fetchBackendJson<T>(
   path: string,
   headers: HeadersInit,
   tag: string,
+  revalidateSeconds: number,
 ): Promise<{ status: number; data: T | null }> {
   let status = 0;
   try {
     const res = await fetch(getBackendUrl(path), {
       headers,
-      next: { tags: [tag], revalidate: REVALIDATE_SECONDS },
+      next: { tags: [tag], revalidate: revalidateSeconds },
     });
     status = res.status;
     if (!res.ok) {
@@ -52,7 +56,8 @@ async function fetchBackendJson<T>(
     }
     const data = (await res.json()) as T;
     return { status, data };
-  } catch {
+  } catch (err) {
+    console.error(`fetchBackendJson: error for ${path}`, err);
     return { status, data: null };
   }
 }
@@ -80,6 +85,7 @@ export const fetchProductRecord = cache(async (slug: string) => {
     `/products/${slug}`,
     headers,
     `product-${slug}`,
+    METADATA_REVALIDATE_SECONDS,
   );
 });
 
@@ -90,6 +96,7 @@ export const fetchProductOverviewData = cache(
       `/products/${slug}/overview`,
       headers,
       `product-${slug}`,
+      METADATA_REVALIDATE_SECONDS,
     );
     return result.data;
   },
@@ -102,12 +109,18 @@ export const fetchProductExplainerData = cache(
       `/products/${slug}/explainer`,
       headers,
       `product-${slug}`,
+      PAGE_REVALIDATE_SECONDS,
     );
     return result.data;
   },
 );
 
 export const fetchProductPageShell = cache(async (slug: string) => {
+  const headers = await getProductRequestHeaders();
+  if (!Object.keys(headers).length) {
+    console.warn(`fetchProductPageShell: no auth headers for slug=${slug}`);
+  }
+
   const [productResult, overview, explainer] = await Promise.all([
     fetchProductRecord(slug),
     fetchProductOverviewData(slug),

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
@@ -40,17 +40,20 @@ async function fetchBackendJson<T>(
   headers: HeadersInit,
   tag: string,
 ): Promise<{ status: number; data: T | null }> {
+  let status = 0;
   try {
     const res = await fetch(getBackendUrl(path), {
       headers,
       next: { tags: [tag], revalidate: REVALIDATE_SECONDS },
     });
+    status = res.status;
     if (!res.ok) {
-      return { status: res.status, data: null };
+      return { status, data: null };
     }
-    return { status: res.status, data: (await res.json()) as T };
+    const data = (await res.json()) as T;
+    return { status, data };
   } catch {
-    return { status: 0, data: null };
+    return { status, data: null };
   }
 }
 

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
@@ -1,0 +1,158 @@
+import { cookies } from "next/headers";
+
+import { cache } from "react";
+
+import type { ConsumerExplainer } from "@/components/dashboard/explainer/types";
+import {
+  PREVIEW_TOKEN_COOKIE,
+  PREVIEW_TOKEN_HEADER,
+} from "@/lib/preview-token";
+import type { Product, ProductOverview } from "@/types";
+import { auth } from "@clerk/nextjs/server";
+import { getBackendUrl } from "@lib/config";
+
+const REVALIDATE_SECONDS = 3600;
+
+export interface ProductMetadata {
+  name: string;
+  slug: string;
+  company_name?: string | null;
+  one_line_summary?: string;
+  grade?: ProductOverview["grade"];
+  verdict?: ProductOverview["verdict"];
+}
+
+export type ProductMetadataFetch =
+  | { kind: "ok"; product: ProductMetadata }
+  | { kind: "not_found" }
+  | { kind: "uncertain"; displayName: string };
+
+export function humanizeSlug(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ");
+}
+
+async function fetchBackendJson<T>(
+  path: string,
+  headers: HeadersInit,
+  tag: string,
+): Promise<{ status: number; data: T | null }> {
+  try {
+    const res = await fetch(getBackendUrl(path), {
+      headers,
+      next: { tags: [tag], revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) {
+      return { status: res.status, data: null };
+    }
+    return { status: res.status, data: (await res.json()) as T };
+  } catch {
+    return { status: 0, data: null };
+  }
+}
+
+export const getProductRequestHeaders = cache(
+  async (): Promise<HeadersInit> => {
+    const { getToken } = await auth();
+    const token = await getToken();
+    const cookieStore = await cookies();
+    const previewToken = cookieStore.get(PREVIEW_TOKEN_COOKIE)?.value;
+
+    if (token) {
+      return { Authorization: `Bearer ${token}` };
+    }
+    if (previewToken) {
+      return { [PREVIEW_TOKEN_HEADER]: previewToken };
+    }
+    return {};
+  },
+);
+
+export const fetchProductRecord = cache(async (slug: string) => {
+  const headers = await getProductRequestHeaders();
+  return fetchBackendJson<Product>(
+    `/products/${slug}`,
+    headers,
+    `product-${slug}`,
+  );
+});
+
+export const fetchProductOverviewData = cache(
+  async (slug: string): Promise<ProductOverview | null> => {
+    const headers = await getProductRequestHeaders();
+    const result = await fetchBackendJson<ProductOverview>(
+      `/products/${slug}/overview`,
+      headers,
+      `product-${slug}`,
+    );
+    return result.data;
+  },
+);
+
+export const fetchProductExplainerData = cache(
+  async (slug: string): Promise<ConsumerExplainer | null> => {
+    const headers = await getProductRequestHeaders();
+    const result = await fetchBackendJson<ConsumerExplainer>(
+      `/products/${slug}/explainer`,
+      headers,
+      `product-${slug}`,
+    );
+    return result.data;
+  },
+);
+
+export const fetchProductPageShell = cache(async (slug: string) => {
+  const [productResult, overview, explainer] = await Promise.all([
+    fetchProductRecord(slug),
+    fetchProductOverviewData(slug),
+    fetchProductExplainerData(slug),
+  ]);
+
+  return {
+    product: productResult.data,
+    overview,
+    explainer,
+  };
+});
+
+/** Shared across layout metadata and page SSR — dedupes product + overview fetches. */
+export const fetchProductForMetadata = cache(
+  async (slug: string): Promise<ProductMetadataFetch> => {
+    const [productResult, overview] = await Promise.all([
+      fetchProductRecord(slug),
+      fetchProductOverviewData(slug),
+    ]);
+
+    if (productResult.status === 404) {
+      return { kind: "not_found" };
+    }
+
+    if (!productResult.data) {
+      if (productResult.status > 0) {
+        console.error(
+          "Product metadata: backend error",
+          productResult.status,
+          slug,
+        );
+      }
+      return { kind: "uncertain", displayName: humanizeSlug(slug) };
+    }
+
+    const product = productResult.data;
+
+    return {
+      kind: "ok",
+      product: {
+        name: product.name,
+        slug: product.slug,
+        company_name: product.company_name,
+        one_line_summary: overview?.one_line_summary,
+        grade: overview?.grade,
+        verdict: overview?.verdict,
+      },
+    };
+  },
+);


### PR DESCRIPTION
## What this PR delivers

Product detail pages (`/products/[slug]`) now render the overview shell faster on first load. SSR waits only for **product**, **overview**, and **explainer** — the content needed for the Overview tab. **Documents** and **topics** (Evidence tab data) load in the background after paint.

Layout metadata and the page share one cached backend fetch path (`product-page-server.ts`), so product and overview are no longer fetched twice per request (layout via internal API routes + page via direct backend).

## Why this matters

**For users:** Initial page load was blocked on five parallel backend calls. The `/topics` endpoint is the slowest (full document hydration) but only powers the Evidence tab. Removing it from the SSR critical path should noticeably reduce time-to-first-byte and time-to-interactive on the Overview tab.

**For maintainers:** Auth header construction and backend fetches are centralized in one React `cache()` module, deduping work between `generateMetadata`, layout structured data, and the page component within a single request.

## How product page behaviour changes

| Path | Change |
|---|---|
| SSR (`page.tsx`) | Fetches product + overview + explainer only; no longer blocks on documents/topics |
| Client (SSR path) | After hydration, fetches documents + topics in a separate effect; Evidence tab shows existing skeletons while loading |
| Client (no SSR fallback) | Unchanged — still fetches all endpoints when SSR data is missing |
| Layout metadata / SEO | Still loads product + overview for OG tags and JSON-LD, but via shared cached backend fetch instead of internal `/api` hop |
| Overview tab | No behavioural change once loaded |
| Evidence tab | Content may appear slightly after the Overview tab on first visit (background fetch) |

## UX changes operators will notice

- Overview tab (verdict, explainer, policy sections) appears sooner on cold load.
- Evidence tab may show skeletons briefly on first visit while documents/topics load; badge count fills in once the fetch completes.
- No change to indexing, limit-reached, or error states.

## Tests

- 9 tests passing in `product-page-client.test.tsx` and `product-page-fetch-state.test.ts`.
- Regression pin: limit-reached and server-error UI tests in `product-page-client.test.tsx`.

### Edge cases to verify in a staging session

1. Open a fully indexed product — Overview tab should render immediately; switch to Evidence tab and confirm documents/topics load (skeleton → content).
2. Hard refresh on Evidence tab URL with hash/query — Overview should still SSR; Evidence data should backfill without breaking the page.
3. Anonymous preview user — confirm page still loads with preview token auth and metadata/OG tags render correctly.
4. Product still indexing (425 on overview) — confirm indexing UI still appears (client fallback path unchanged).

## Notes for reviewers

- `product-page-server.ts` is the single source of truth for server-side product fetches; React `cache()` dedupes calls within one request.
- Evidence deferral is intentional: topics hydration was on the TTFB critical path despite only being used in the Evidence tab.
- Layout no longer round-trips through `/api/products/...` for metadata — direct backend fetch with Clerk/preview auth matches the page approach.