### PR TITLE
fix: restore SSR evidence fetch and optimize slow topics endpoint

### DIFF
--- a/packages/backend/src/repositories/document_repository.py
+++ b/packages/backend/src/repositories/document_repository.py
@@ -267,6 +267,23 @@ class DocumentRepository(BaseRepository):
             for document in documents
         ]
 
+    async def find_by_ids_with_extraction(
+        self, db: AgnosticDatabase, product_id: str, document_ids: list[str]
+    ) -> list[Document]:
+        """Load rollup-cited documents with extraction only (no markdown bodies)."""
+        if not document_ids:
+            return []
+        unique_ids = list(dict.fromkeys(document_ids))
+        projection = {"markdown": 0}
+        query = _product_scoped_query(product_id, {"id": {"$in": unique_ids}})
+        documents: list[dict[str, Any]] = await db.documents.find(query, projection).to_list(
+            length=None
+        )
+        return [
+            Document(**_contextualize_document_for_product(document, product_id))
+            for document in documents
+        ]
+
     async def find_by_product_id_full(
         self, db: AgnosticDatabase, product_id: str
     ) -> list[Document]:

--- a/packages/backend/src/repositories/document_repository.py
+++ b/packages/backend/src/repositories/document_repository.py
@@ -274,11 +274,13 @@ class DocumentRepository(BaseRepository):
         if not document_ids:
             return []
         unique_ids = list(dict.fromkeys(document_ids))
-        projection = {"markdown": 0}
+        projection = {"markdown": 0, "analysis": 0, "consumer_explainer": 0}
         query = _product_scoped_query(product_id, {"id": {"$in": unique_ids}})
         documents: list[dict[str, Any]] = await db.documents.find(query, projection).to_list(
             length=None
         )
+        for document in documents:
+            document.setdefault("markdown", "")
         return [
             Document(**_contextualize_document_for_product(document, product_id))
             for document in documents

--- a/packages/backend/src/routes/products.py
+++ b/packages/backend/src/routes/products.py
@@ -187,11 +187,12 @@ async def get_product_topics(
         )
 
     doc_repo = DocumentRepository()
-    full_docs = await doc_repo.find_by_product_id_full(db, product.id)
     referenced_ids = {
         doc_id for item in intelligence.rollup.items for doc_id in item.document_ids
     } | {doc_id for conflict in intelligence.rollup.conflicts for doc_id in conflict.document_ids}
-    documents_for_hydration = [doc for doc in full_docs if doc.id in referenced_ids]
+    documents_for_hydration = await doc_repo.find_by_ids_with_extraction(
+        db, product.id, sorted(referenced_ids)
+    )
     hydrated_rollup = rollup_to_hydrated(
         product_id=product.id,
         product_slug=slug,

--- a/packages/backend/tests/unit/document_repository_test.py
+++ b/packages/backend/tests/unit/document_repository_test.py
@@ -228,3 +228,49 @@ async def test_find_by_product_id_full_contextualizes_product_id() -> None:
     assert len(docs) == 1
     assert docs[0].product_id == "prod-2"
     assert docs[0].url == "https://example.com/policy"
+
+
+@pytest.mark.asyncio
+async def test_find_by_ids_with_extraction_returns_early_when_no_ids() -> None:
+    repo = DocumentRepository()
+    documents_collection = MagicMock()
+    documents_collection.find = MagicMock()
+    db = AsyncMock()
+    db.documents = documents_collection
+
+    docs = await repo.find_by_ids_with_extraction(db, "prod-1", [])
+
+    assert docs == []
+    documents_collection.find.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_find_by_ids_with_extraction_fills_missing_markdown() -> None:
+    """Projection drops markdown, so the loader must backfill it before model validation."""
+    repo = DocumentRepository()
+    record = {
+        "id": "doc-1",
+        "url": "https://example.com/policy",
+        "product_id": "prod-1",
+        "product_ids": ["prod-1"],
+        "doc_type": "privacy_policy",
+    }
+    cursor = AsyncMock()
+    cursor.to_list = AsyncMock(return_value=[record])
+    documents_collection = MagicMock()
+    documents_collection.find = MagicMock(return_value=cursor)
+    db = AsyncMock()
+    db.documents = documents_collection
+
+    docs = await repo.find_by_ids_with_extraction(db, "prod-1", ["doc-1", "doc-1"])
+
+    args, _kwargs = documents_collection.find.call_args
+    assert args[0] == {
+        "$and": [
+            {"id": {"$in": ["doc-1"]}},
+            {"$or": [{"product_id": "prod-1"}, {"product_ids": "prod-1"}]},
+        ]
+    }
+    assert args[1] == {"markdown": 0, "analysis": 0, "consumer_explainer": 0}
+    assert len(docs) == 1
+    assert docs[0].markdown == ""

--- a/packages/backend/tests/unit/products_topics_route_test.py
+++ b/packages/backend/tests/unit/products_topics_route_test.py
@@ -126,7 +126,7 @@ async def test_get_product_topics_returns_topic_report() -> None:
             AsyncMock(return_value=_intelligence()),
         ),
         patch(
-            "src.routes.products.DocumentRepository.find_by_product_id_full",
+            "src.routes.products.DocumentRepository.find_by_ids_with_extraction",
             AsyncMock(return_value=[doc]),
         ),
     ):

--- a/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import CompanyPage from "./product-page-client";
-import { fetchProductPageShell } from "./product-page-server";
+import { fetchProductPageData } from "./product-page-server";
 
 export default async function ProductPage({
   params,
@@ -7,7 +7,8 @@ export default async function ProductPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const { product, overview, explainer } = await fetchProductPageShell(slug);
+  const { product, overview, explainer, documents, topics } =
+    await fetchProductPageData(slug);
 
   return (
     <CompanyPage
@@ -15,6 +16,8 @@ export default async function ProductPage({
       initialProduct={product}
       initialData={overview}
       initialExplainer={explainer}
+      initialDocuments={documents}
+      initialTopics={topics}
     />
   );
 }

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-client.tsx
@@ -125,13 +125,7 @@ export default function CompanyPage({
     initialTopics ?? null,
   );
   const [loading, setLoading] = useState(!initialProduct || !initialOverview);
-  const [documentsLoading, setDocumentsLoading] = useState(
-    Boolean(initialProduct && initialOverview),
-  );
-  const [evidenceError, setEvidenceError] = useState<number | "network" | null>(
-    null,
-  );
-  const [evidenceFetchKey, setEvidenceFetchKey] = useState(0);
+  const [documentsLoading, setDocumentsLoading] = useState(false);
   const [thinEvidence, setThinEvidence] = useState(false);
   const [indexationMode, setIndexationMode] = useState<
     | "ready"
@@ -163,72 +157,6 @@ export default function CompanyPage({
     "idle" | "loading" | "success" | "error"
   >("idle");
   const [restoreError, setRestoreError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!initialProduct || !initialOverview) {
-      return;
-    }
-
-    let cancelled = false;
-
-    async function fetchEvidence() {
-      setDocumentsLoading(true);
-      setEvidenceError(null);
-      try {
-        const [docsRes, topicsRes] = await Promise.all([
-          fetch(`/api/products/${slug}/documents`),
-          fetch(`/api/products/${slug}/topics`),
-        ]);
-
-        if (cancelled) {
-          return;
-        }
-
-        let nextError: number | "network" | null = null;
-
-        if (docsRes.ok) {
-          try {
-            setDocuments((await docsRes.json()) as DocumentSummary[]);
-          } catch (err) {
-            console.error("Failed to parse documents JSON", err);
-            nextError = docsRes.status;
-          }
-        } else if (docsRes.status !== 425) {
-          nextError = docsRes.status;
-        }
-
-        if (topicsRes.ok) {
-          try {
-            setTopics((await topicsRes.json()) as ProductTopicReport);
-          } catch (err) {
-            console.error("Failed to parse topics JSON", err);
-            nextError = nextError ?? topicsRes.status;
-          }
-        } else if (topicsRes.status !== 425) {
-          nextError = nextError ?? topicsRes.status;
-        }
-
-        if (!cancelled) {
-          setEvidenceError(nextError);
-        }
-      } catch (error) {
-        console.error("Failed to fetch product evidence", error);
-        if (!cancelled) {
-          setEvidenceError("network");
-        }
-      } finally {
-        if (!cancelled) {
-          setDocumentsLoading(false);
-        }
-      }
-    }
-
-    void fetchEvidence();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [slug, initialProduct, initialOverview, evidenceFetchKey]);
 
   useEffect(() => {
     // SSR pre-loaded the overview shell — evidence loads in a separate effect.
@@ -1267,26 +1195,6 @@ export default function CompanyPage({
               <Skeleton className="h-32 rounded-2xl" />
               <Skeleton className="h-32 rounded-2xl" />
               <Skeleton className="h-32 rounded-2xl" />
-            </div>
-          ) : evidenceError ? (
-            <div className="border border-border bg-background p-6 space-y-4">
-              <h3 className="text-xl font-display font-medium text-foreground">
-                Couldn&apos;t load evidence
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                {evidenceError === 429
-                  ? "You've hit the usage limit for evidence details. Sign in or upgrade for full access."
-                  : evidenceError === "network"
-                    ? "We couldn't reach the server. Check your connection and try again."
-                    : "Something went wrong loading source documents and topic findings."}
-              </p>
-              <Button
-                onClick={() => setEvidenceFetchKey((key) => key + 1)}
-                className="h-11 px-6 bg-foreground text-background hover:bg-foreground/90 rounded-none text-[10px] uppercase tracking-[0.2em] font-bold"
-              >
-                <RotateCcw className="mr-2 h-3.5 w-3.5" />
-                Try again
-              </Button>
             </div>
           ) : (
             <EvidenceList

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
@@ -7,7 +7,12 @@ import {
   PREVIEW_TOKEN_COOKIE,
   PREVIEW_TOKEN_HEADER,
 } from "@/lib/preview-token";
-import type { Product, ProductOverview } from "@/types";
+import type {
+  DocumentSummary,
+  Product,
+  ProductOverview,
+  ProductTopicReport,
+} from "@/types";
 import { auth } from "@clerk/nextjs/server";
 import { getBackendUrl } from "@lib/config";
 
@@ -132,6 +137,40 @@ export const fetchProductPageShell = cache(async (slug: string) => {
     overview,
     explainer,
   };
+});
+
+/** Direct backend fetch — avoids the browser → Next API → backend double hop. */
+export const fetchProductEvidence = cache(async (slug: string) => {
+  const headers = await getProductRequestHeaders();
+  const tag = `product-${slug}`;
+  const [documentsResult, topicsResult] = await Promise.all([
+    fetchBackendJson<DocumentSummary[]>(
+      `/products/${slug}/documents`,
+      headers,
+      tag,
+      PAGE_REVALIDATE_SECONDS,
+    ),
+    fetchBackendJson<ProductTopicReport>(
+      `/products/${slug}/topics`,
+      headers,
+      tag,
+      PAGE_REVALIDATE_SECONDS,
+    ),
+  ]);
+
+  return {
+    documents: documentsResult.data ?? [],
+    topics: topicsResult.data,
+  };
+});
+
+export const fetchProductPageData = cache(async (slug: string) => {
+  const [shell, evidence] = await Promise.all([
+    fetchProductPageShell(slug),
+    fetchProductEvidence(slug),
+  ]);
+
+  return { ...shell, ...evidence };
 });
 
 /** Shared across layout metadata and page SSR — dedupes product + overview fetches. */

--- a/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
+++ b/packages/frontend/app/(dashboard)/products/[slug]/product-page-server.ts
@@ -158,6 +158,13 @@ export const fetchProductEvidence = cache(async (slug: string) => {
     ),
   ]);
 
+  if (!topicsResult.data && topicsResult.status !== 425) {
+    console.warn(
+      `fetchProductEvidence: topics unavailable status=${topicsResult.status}`,
+      slug,
+    );
+  }
+
   return {
     documents: documentsResult.data ?? [],
     topics: topicsResult.data,

--- a/packages/frontend/lib/logo.ts
+++ b/packages/frontend/lib/logo.ts
@@ -20,7 +20,7 @@ function toHostname(raw: string): string {
 export function enrichLogos<T extends MinimalItem>(
   data: MinimalPage<T>,
 ): MinimalPage<T> {
-  const token = process.env.LOGO_DEV_API_KEY;
+  const token = process.env.LOGO_DEV_API_KEY ?? process.env.LOGO_DEV_PUBLIC_KEY;
   if (!token) return data;
   return {
     ...data,


### PR DESCRIPTION
## Summary

Production probes showed `/products/stripe/topics` taking **114s** while the products list API responds in **~0.1s**. PR #211 made this worse by deferring documents/topics to client-side API routes (double hop + second wait after the overview rendered).

This hotfix restores single-hop SSR for evidence data and optimizes the backend topics hydration query.

## Changes

- **Frontend:** Fetch documents + topics on the server again (direct backend, parallel with overview shell); remove client-side deferred evidence fetch
- **Backend:** `/topics` loads only rollup-cited documents with extraction projection instead of every full markdown body for the product (Stripe has 96 docs)
- **Frontend:** `enrichLogos` accepts `LOGO_DEV_PUBLIC_KEY` so the products list stops firing ~20 per-card `/api/products/logos` calls that each hit `GET /products/{slug}` (~7s each)

## Test plan

- [ ] Open `/products` — list loads without long logo-fetch waterfall
- [ ] Open `/products/stripe` — Overview and Evidence tabs both have data after one page load (no second 30s+ wait on Evidence)
- [ ] Confirm `/products/stripe/topics` responds in seconds, not minutes (Railway HTTP logs or curl)
- [ ] `uv run pytest tests/unit/products_topics_route_test.py`
- [ ] `bun run test -- app/(dashboard)/products/`