### PR TITLE
fix(frontend): unify onboarding form background with page background

### DIFF
--- a/packages/frontend/app/(dashboard)/onboarding/page.tsx
+++ b/packages/frontend/app/(dashboard)/onboarding/page.tsx
@@ -9,7 +9,6 @@ import { useEffect, useState } from "react";
 
 import { completeOnboarding, upsertUser } from "@/app/actions/users";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
@@ -203,10 +202,7 @@ export default function OnboardingPage() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.1 }}
         >
-          <Card
-            variant="glass"
-            className="p-8 md:p-10 rounded-3xl border-border/50"
-          >
+          <div className="p-8 md:p-10">
             <form onSubmit={handleSubmit} className="space-y-6">
               {/* Name Fields */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -359,7 +355,7 @@ export default function OnboardingPage() {
                 <span>AI-Powered</span>
               </div>
             </div>
-          </Card>
+          </div>
         </motion.div>
       </div>
     </div>


### PR DESCRIPTION
## What this PR does
Removes the glass `Card` panel wrapping the onboarding form so the form sits directly on the page's `dashboard-bg`, giving the onboarding page a single unified background instead of a panel-on-background look.

## Why
The form was wrapped in a `Card variant="glass"` whose `glass-panel` styling rendered a second, visually distinct surface on top of the page background. That double background was unnecessary; unifying it produces a cleaner onboarding layout.

## How to test
- Visit `/onboarding` (as a user who has not completed onboarding) and confirm the form fields render directly on the page background with no glass panel or border framing the form.
- Confirm spacing/padding around the form is unchanged (the `p-8 md:p-10` padding is preserved).
- Edge case: trigger validation errors (submit with empty email/role/use case) and confirm error styling on inputs still renders correctly without the card.
- Edge case: verify the loading state and the already-onboarded redirect to `/products` still behave as before.
